### PR TITLE
0.6.4.2

### DIFF
--- a/views/voelker_view.py
+++ b/views/voelker_view.py
@@ -113,7 +113,7 @@ class VoelkerWidget(MDBoxLayout):
         """Zeigt einen Popup-Dialog mit Suchfeld für die Völker-Auswahl."""
         from kivymd.uix.dialog import (
             MDDialog, MDDialogHeadlineText,
-            MDDialogContentContainer
+            MDDialogContentContainer, MDDialogButtonContainer
         )
         from kivymd.uix.textfield import MDTextField, MDTextFieldHintText
         from kivymd.uix.list import MDListItem, MDListItemHeadlineText, MDListItemLeadingIcon
@@ -234,34 +234,11 @@ class VoelkerWidget(MDBoxLayout):
             # Live-Filterung bei Texteingabe
             search_field.bind(text=populate_list)
 
-            # Button-Leiste innerhalb des Content-Bereichs (zuverlässiger auf Android)
-            button_row = MDBoxLayout(
-                orientation='horizontal',
-                size_hint_y=None,
-                height=dp(48),
-                spacing=dp(8),
-                padding=[dp(0), dp(8), dp(0), dp(0)],
-            )
-            button_row.add_widget(MDBoxLayout(size_hint_x=1))  # Spacer
-            btn_cancel = MDButton(
-                MDButtonText(text="Abbrechen"),
-                style="text",
-                on_release=lambda x: self._dismiss_volk_popup(),
-            )
-            btn_confirm = MDButton(
-                MDButtonText(text="Bestätigen"),
-                style="text",
-                on_release=lambda x: self._confirm_volk_popup(),
-            )
-            button_row.add_widget(btn_cancel)
-            button_row.add_widget(btn_confirm)
-
             # Zusammenbauen
             list_container.add_widget(items_list)
             list_container.add_widget(scroll_zone)
             scroll_view.add_widget(list_container)
             dialog_content.add_widget(scroll_view)
-            dialog_content.add_widget(button_row)
 
             # Dialog erstellen - auto_dismiss=False verhindert versehentliches
             # Schließen durch Touch auf den Hintergrund (Android-Problem)
@@ -271,6 +248,19 @@ class VoelkerWidget(MDBoxLayout):
                     dialog_content,
                     orientation="vertical",
                     padding=dp(0),
+                ),
+                MDDialogButtonContainer(
+                    MDButton(
+                        MDButtonText(text="Abbrechen"),
+                        style="text",
+                        on_release=lambda x: self._dismiss_volk_popup(),
+                    ),
+                    MDButton(
+                        MDButtonText(text="Bestätigen"),
+                        style="text",
+                        on_release=lambda x: self._confirm_volk_popup(),
+                    ),
+                    spacing="8dp",
                 ),
                 size_hint=(0.85, None),
                 auto_dismiss=False,
@@ -732,7 +722,7 @@ class VoelkerWidget(MDBoxLayout):
         """Zeigt einen erweiterten Dialog mit Suchfeld für Talent/Attribut/Fertigkeiten-Auswahl."""
         from kivymd.uix.dialog import (
             MDDialog, MDDialogHeadlineText,
-            MDDialogContentContainer
+            MDDialogContentContainer, MDDialogButtonContainer
         )
         from kivymd.uix.textfield import MDTextField, MDTextFieldHintText
         from kivymd.uix.button import MDButton, MDButtonText, MDIconButton
@@ -862,25 +852,9 @@ class VoelkerWidget(MDBoxLayout):
 
                 filter_button.bind(on_release=toggle_filter)
 
-            # Abbrechen-Button innerhalb des Content-Bereichs (zuverlässiger auf Android)
-            button_row = MDBoxLayout(
-                orientation='horizontal',
-                size_hint_y=None,
-                height=dp(48),
-                padding=[dp(0), dp(8), dp(0), dp(0)],
-            )
-            button_row.add_widget(MDBoxLayout(size_hint_x=1))  # Spacer
-            btn_cancel = MDButton(
-                MDButtonText(text="Abbrechen"),
-                style="text",
-                on_release=lambda x: self.search_dialog.dismiss(),
-            )
-            button_row.add_widget(btn_cancel)
-
             # Container zusammenbauen
             dialog_content.add_widget(search_row)
             dialog_content.add_widget(scroll_view)
-            dialog_content.add_widget(button_row)
 
             # Dialog erstellen - auto_dismiss=False für Android-Kompatibilität
             self.search_dialog = MDDialog(
@@ -889,6 +863,14 @@ class VoelkerWidget(MDBoxLayout):
                     dialog_content,
                     orientation="vertical",
                     padding=dp(0),
+                ),
+                MDDialogButtonContainer(
+                    MDButton(
+                        MDButtonText(text="Abbrechen"),
+                        style="text",
+                        on_release=lambda x: self.search_dialog.dismiss(),
+                    ),
+                    spacing="8dp",
                 ),
                 size_hint=(0.85, None),
                 auto_dismiss=False,


### PR DESCRIPTION
Gleicher Bug wie bei den Wizard-Dialogen: Buttons innerhalb von MDDialogContentContainer erhalten auf Android keine Touch-Events. Betrifft _show_volk_search_popup() und _show_search_dialog().

https://claude.ai/code/session_01Gf9wo3HJAcYRPzbfTBzQiz