### PR TITLE
Verbessere Platzierung und Verständlichkeit des Charaktergenerierung-Buttons

### DIFF
--- a/views/charakter_verwaltung_widget.kv
+++ b/views/charakter_verwaltung_widget.kv
@@ -295,33 +295,63 @@
                         MDButtonText:
                             text: 'Erhöhe Startkapital mit Handicap-Punkten'
 
-                    MDGridLayout:
-                        cols: 2
-                        spacing: dp(8)
+                    # Generierungsstatus und Aufstiege
+                    MDBoxLayout:
+                        orientation: 'vertical'
                         size_hint_y: None
-                        height: dp(48)
+                        height: self.minimum_height
+                        spacing: dp(8)
+
+                        MDLabel:
+                            text: "Schließe die Charaktererstellung ab, um Aufstiege und Rang-Fortschritt freizuschalten."
+                            size_hint_y: None
+                            height: dp(36)
+                            font_size: dp(12)
+                            theme_text_color: "Secondary"
+                            opacity: 0 if root.char_gen_completed else 1
+                            size_hint_y: None
+                            height: dp(36) if not root.char_gen_completed else 0
 
                         MDButton:
-                            style: "tonal"
-                            size_hint_x: 1
-                            on_release: root.erhoehe_aufstieg()
+                            id: char_gen_toggle_button
+                            style: "filled" if not root.char_gen_completed else "outlined"
+                            size_hint: None, None
+                            size: dp(300), dp(40)
+                            on_release: root.toggle_char_gen_completed()
 
                             MDButtonIcon:
-                                icon: "plus"
+                                icon: "check-circle" if root.char_gen_completed else "progress-wrench"
 
                             MDButtonText:
-                                text: "Aufstieg"
+                                text: "Erstellung abschließen" if not root.char_gen_completed else "Zurück zur Erstellung"
 
-                        MDButton:
-                            style: "outlined"
-                            size_hint_x: 1
-                            on_release: root.senke_aufstieg()
+                        MDGridLayout:
+                            cols: 2
+                            spacing: dp(8)
+                            size_hint_y: None
+                            height: dp(48)
 
-                            MDButtonIcon:
-                                icon: "minus"
+                            MDButton:
+                                style: "tonal"
+                                size_hint_x: 1
+                                on_release: root.erhoehe_aufstieg()
 
-                            MDButtonText:
-                                text: "Abstieg"
+                                MDButtonIcon:
+                                    icon: "plus"
+
+                                MDButtonText:
+                                    text: "Aufstieg"
+
+                            MDButton:
+                                style: "outlined"
+                                size_hint_x: 1
+                                on_release: root.senke_aufstieg()
+
+                                MDButtonIcon:
+                                    icon: "minus"
+
+                                MDButtonText:
+                                    text: "Abstieg"
 
             # ===== Setting-Verwaltung =====
             MDCard:

--- a/views/charakter_verwaltung_widget.py
+++ b/views/charakter_verwaltung_widget.py
@@ -19,6 +19,7 @@ from kivy.logger import Logger
 from kivy.clock import Clock
 from kivy.metrics import dp
 from kivy.core.window import Window
+from kivy.properties import BooleanProperty
 from pathlib import Path
 
 # Handler imports
@@ -58,6 +59,8 @@ class CharakterVerwaltungWidget(MDBoxLayout):
     Fokussiert auf: Charakter-CRUD, PDF-Export, Statblock,
                     Charakter-Einstellungen, Setting-Verwaltung
     """
+
+    char_gen_completed = BooleanProperty(False)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -107,6 +110,9 @@ class CharakterVerwaltungWidget(MDBoxLayout):
                 # Character-Events
                 event_service.subscribe(EventTypes.CHARACTER_CREATED, self.character_handler.on_character_created)
                 event_service.subscribe(EventTypes.CHARACTER_LOADED, self.character_handler.on_character_loaded)
+                # Generierungsstatus bei Laden/Erstellen synchronisieren
+                event_service.subscribe(EventTypes.CHARACTER_CREATED, lambda data: self._sync_char_gen_status())
+                event_service.subscribe(EventTypes.CHARACTER_LOADED, lambda data: self._sync_char_gen_status())
 
                 Logger.debug("Event-Handler für CharakterVerwaltung registriert")
         except Exception as e:
@@ -118,6 +124,9 @@ class CharakterVerwaltungWidget(MDBoxLayout):
             # Statistiken aktualisieren
             if self.statistics_manager:
                 self.statistics_manager.update_element_statistics_ui()
+
+            # Generierungsstatus synchronisieren
+            self._sync_char_gen_status()
 
             Logger.info("CharakterVerwaltung Post-Initialisierung erfolgreich abgeschlossen")
         except Exception as e:
@@ -724,6 +733,27 @@ class CharakterVerwaltungWidget(MDBoxLayout):
             Logger.info("Startkapital mit Handicap-Punkten erhöht")
         except Exception as e:
             Logger.error(f"Fehler beim Erhöhen des Startkapitals: {e}")
+
+    def toggle_char_gen_completed(self):
+        """Umschaltet den Charakter-Generierungsstatus"""
+        try:
+            if not (self.app.controller and self.app.controller.charakter):
+                return
+            char = self.app.controller.charakter
+            new_value = not char.char_gen_completed
+            char.char_gen_completed = new_value
+            self.char_gen_completed = new_value
+            Logger.info(f"Charakter-Generierungsstatus über Einstellungen geändert: {new_value}")
+        except Exception as e:
+            Logger.error(f"Fehler beim Umschalten des Generierungsstatus: {e}")
+
+    def _sync_char_gen_status(self):
+        """Synchronisiert den lokalen char_gen_completed-Status mit dem Charakter-Modell"""
+        try:
+            if self.app.controller and self.app.controller.charakter:
+                self.char_gen_completed = self.app.controller.charakter.char_gen_completed
+        except Exception as e:
+            Logger.error(f"Fehler beim Synchronisieren des Generierungsstatus: {e}")
 
     def erhoehe_aufstieg(self):
         """Erhöht die Aufstiege"""

--- a/views/charakter_verwaltung_widget_mobile.kv
+++ b/views/charakter_verwaltung_widget_mobile.kv
@@ -244,6 +244,26 @@
                     MDButtonText:
                         text: 'Startkapital + Handicap-Pkt.'
 
+                MDLabel:
+                    text: "Schließe die Erstellung ab, um Aufstiege freizuschalten."
+                    size_hint_y: None
+                    height: dp(28) if not root.char_gen_completed else 0
+                    font_size: dp(11)
+                    theme_text_color: "Secondary"
+                    opacity: 0 if root.char_gen_completed else 1
+
+                MDButton:
+                    id: char_gen_toggle_button
+                    style: "filled" if not root.char_gen_completed else "outlined"
+                    size_hint_x: 1
+                    on_release: root.toggle_char_gen_completed()
+
+                    MDButtonIcon:
+                        icon: "check-circle" if root.char_gen_completed else "progress-wrench"
+
+                    MDButtonText:
+                        text: "Erstellung abschließen" if not root.char_gen_completed else "Zurück zur Erstellung"
+
                 MDGridLayout:
                     cols: 2
                     spacing: dp(8)

--- a/views/eigenschaften_view.kv
+++ b/views/eigenschaften_view.kv
@@ -17,28 +17,6 @@
             padding: "20dp"
             spacing: "10dp"
 
-            # Hinzugefügte Checkbox für die manuelle Steuerung des char_gen_completed-Status
-            # MDBoxLayout für die feste Positionierung
-            MDBoxLayout:
-                orientation: 'horizontal'
-                size_hint_y: None
-                height: dp(48)
-                spacing: dp(10)
-                size_hint_x: None
-                width: dp(300)  # Feste Breite statt dynamischer Berechnung
-
-                # Button für "Charaktergenerierung abgeschlossen" (Android Checkbox Workaround)
-                MDButton:
-                    id: char_gen_button
-                    size_hint_x: 1
-                    on_release: root.toggle_char_gen_completed()
-                    pos_hint: {"center_y": .5}
-                    
-                    MDButtonText:
-                        text: "Charaktergenerierung abschließen" if not root.char_gen_completed else "Charaktergenerierung aktivieren"
-                        theme_text_color: "Primary" if not root.char_gen_completed else "Custom"
-                        text_color: self.theme_cls.primaryColor if root.char_gen_completed else self.theme_cls.onSurfaceColor
-
             MDLabel:
                 text: 'Attribute'
                 size_hint: (1, None)

--- a/views/eigenschaften_view_mobile.kv
+++ b/views/eigenschaften_view_mobile.kv
@@ -23,17 +23,6 @@
             padding: [dp(8), dp(6), dp(8), dp(6)]
             spacing: dp(4)
 
-            # Charaktergenerierung abschließen Button
-            MDButton:
-                id: char_gen_button
-                size_hint_x: 1
-                on_release: root.toggle_char_gen_completed()
-
-                MDButtonText:
-                    text: "Generierung abschließen" if not root.char_gen_completed else "Generierung aktivieren"
-                    theme_text_color: "Primary" if not root.char_gen_completed else "Custom"
-                    text_color: self.theme_cls.primaryColor if root.char_gen_completed else self.theme_cls.onSurfaceColor
-
             MDLabel:
                 text: 'Attribute'
                 size_hint: (1, None)

--- a/views/pointbar_view.kv
+++ b/views/pointbar_view.kv
@@ -67,6 +67,22 @@
             text_size: self.size
             size_hint_x: 1
 
+        # Status-Button: Charaktergenerierung abschließen / Aufstiege aktiv
+        MDButton:
+            id: char_gen_status_button
+            style: "tonal" if not root.char_gen_completed else "filled"
+            size_hint: None, None
+            size: dp(220), dp(36)
+            pos_hint: {'center_y': 0.5}
+            on_release: root.toggle_char_gen_completed()
+
+            MDButtonIcon:
+                icon: "check-circle" if root.char_gen_completed else "progress-wrench"
+
+            MDButtonText:
+                text: "Aufstiege freigeschaltet" if root.char_gen_completed else "Erstellung abschließen"
+                font_size: dp(11)
+
         # Chevron-Button
         MDIconButton:
             id: chevron_icon

--- a/views/pointbar_view.py
+++ b/views/pointbar_view.py
@@ -99,6 +99,7 @@ class GenerationPointsBar(MDBoxLayout):
     superkraft_punkte_text = StringProperty("")
     machtstufe_text = StringProperty("")
     header_summary_text = StringProperty("")
+    char_gen_completed = BooleanProperty(False)
     is_expanded = BooleanProperty(True)
 
     def __init__(self, **kwargs):
@@ -151,6 +152,7 @@ class GenerationPointsBar(MDBoxLayout):
             self.charakter.unbind(robustheit=self.update_parade_robustheit_text)
             # KORREKTUR: Auch auf robustheit_mit_ruestung binden
             self.charakter.unbind(robustheit_mit_ruestung=self.update_parade_robustheit_text)
+            self.charakter.unbind(char_gen_completed=self._update_char_gen_status)
             Logger.debug("Charakter-Bindings erfolgreich entfernt")
         except Exception as e:
             Logger.error(f"Fehler beim Entfernen der Charakter-Bindings: {str(e)}")
@@ -204,6 +206,9 @@ class GenerationPointsBar(MDBoxLayout):
             self.charakter.bind(parade=self.update_parade_robustheit_text)
             self.charakter.bind(robustheit=self.update_parade_robustheit_text)
             self.charakter.bind(robustheit_mit_ruestung=self.update_parade_robustheit_text)
+
+            # Generierungsstatus
+            self.charakter.bind(char_gen_completed=self._update_char_gen_status)
             
             Logger.info("GenerationPointsBar erfolgreich mit Charakter-Properties verbunden")
         except Exception as e:
@@ -232,8 +237,9 @@ class GenerationPointsBar(MDBoxLayout):
             self.update_rang_text(None, None)
             self.update_parade_robustheit_text(None, None)
             self.update_superkraft_punkte_text(None, None)
-            self.update_machtstufe_text(None, None)     
-            
+            self.update_machtstufe_text(None, None)
+            self._update_char_gen_status(None, None)
+
             self.update_header_summary()
 
             Logger.debug("Alle Texte erfolgreich aktualisiert")
@@ -427,6 +433,19 @@ class GenerationPointsBar(MDBoxLayout):
     def get_logo_path(self):
         """Gibt den korrekten Pfad zum Logo zurück (PyInstaller-kompatibel)"""
         return get_assets_path("Savage-Worlds-Fanprodukt-Logo.png")
+
+    def toggle_char_gen_completed(self):
+        """Umschaltet den Charakter-Generierungsstatus über die Pointbar"""
+        if self.charakter:
+            new_value = not self.charakter.char_gen_completed
+            self.charakter.char_gen_completed = new_value
+            self.char_gen_completed = new_value
+            Logger.info(f"Charakter-Generierungsstatus über Pointbar geändert: {new_value}")
+
+    def _update_char_gen_status(self, instance, value):
+        """Aktualisiert den lokalen char_gen_completed-Status aus dem Charakter-Modell"""
+        if self.charakter:
+            self.char_gen_completed = self.charakter.char_gen_completed
 
     def cleanup(self):
         """Bereinigt die Pointbar beim Herunterfahren"""

--- a/views/pointbar_view_mobile.kv
+++ b/views/pointbar_view_mobile.kv
@@ -171,3 +171,27 @@
                 key_text: "Vermögen:"
                 value_text: root.vermoegen_text
                 key_width_ratio: 0.50
+
+            # Trennlinie vor Status-Button
+            MDDivider:
+                size_hint_y: None
+                height: dp(1)
+
+            # Status-Button: Charaktergenerierung abschließen
+            MDBoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: None
+                height: dp(40)
+                padding: [dp(16), dp(4), dp(8), dp(4)]
+
+                MDButton:
+                    id: char_gen_status_button
+                    style: "tonal" if not root.char_gen_completed else "filled"
+                    size_hint_x: 1
+                    on_release: root.toggle_char_gen_completed()
+
+                    MDButtonIcon:
+                        icon: "check-circle" if root.char_gen_completed else "progress-wrench"
+
+                    MDButtonText:
+                        text: "Aufstiege freigeschaltet" if root.char_gen_completed else "Erstellung abschließen"


### PR DESCRIPTION
Der Button "Charaktergenerierung abschließen" war bisher im Eigenschaften-Tab
versteckt, wo sein Nutzen unklar war. Jetzt ist er an zwei sinnvollen Stellen:

1. **Pointbar** (permanent sichtbar): Kompakter Status-Button im Header zeigt
   den aktuellen Generierungsstatus mit Icon und wechselt zwischen
   "Erstellung abschließen" und "Aufstiege freigeschaltet"

2. **Einstellungen-Tab** (neben Aufstieg-Buttons): Button mit erklärendem
   Hilfetext direkt über den Aufstieg/Abstieg-Buttons, sodass der Zusammenhang
   zwischen Generierungsabschluss und Aufstiegs-Freischaltung klar wird

Änderungen im Detail:
- Button aus Eigenschaften-Tab entfernt (Desktop + Mobile KV)
- Status-Button in Pointbar Header integriert (Desktop + Mobile KV)
- Toggle-Button + Hilfetext im Einstellungen-Tab vor Aufstieg-Buttons (Desktop + Mobile KV)
- BooleanProperty + Binding-Logik in GenerationPointsBar und CharakterVerwaltungWidget
- Status-Synchronisation bei Charakter-Laden/Erstellen via Event-Service

https://claude.ai/code/session_013QvGYT2wHUZa3UHT2i5K7h