### PR TITLE
Snackbar-Abstand vom unteren Bildschirmrand erhöht

### DIFF
--- a/services/dialog_service.py
+++ b/services/dialog_service.py
@@ -70,7 +70,7 @@ class DialogService:
         try:
             snackbar = MDSnackbar(
                 MDSnackbarText(text=message),
-                y=dp(24),
+                y=dp(64),
                 pos_hint={"center_x": 0.5},
                 size_hint_x=0.8,
                 duration=duration,


### PR DESCRIPTION
y-Position von dp(24) auf dp(64) erhöht, damit Snackbar-Nachrichten
nicht von der Android-Navigationsleiste verdeckt werden.

https://claude.ai/code/session_01AHckbM4T9UdmTyKMeydd1w