### PR TITLE
Fix: Neuer-Charakter-Wizard Buttons reagieren nicht auf Android

### DIFF
--- a/views/charakter_verwaltung_widget.py
+++ b/views/charakter_verwaltung_widget.py
@@ -249,12 +249,12 @@ class CharakterVerwaltungWidget(MDBoxLayout):
                 MDButton(
                     MDButtonText(text="Abbrechen"),
                     style="text",
-                    on_release=lambda x: self._wizard_setting_dialog.dismiss(),
+                    on_release=lambda x: self._defocus_and_call(self._wizard_setting_dialog.dismiss),
                 ),
                 MDButton(
                     MDButtonText(text="Weiter"),
                     style="text",
-                    on_release=lambda x: self._on_setting_selected(),
+                    on_release=lambda x: self._defocus_and_call(self._on_setting_selected),
                 ),
                 spacing="8dp",
             ),


### PR DESCRIPTION
Setting-Auswahl-Dialog (Schritt 1 des Wizards) verwendet jetzt
_defocus_and_call() für Abbrechen- und Weiter-Button, analog zum
bereits gefixten Konfig-Dialog (Schritt 2). Behebt das Android-Problem,
bei dem ein fokussiertes MDTextField die Touch-Events der Buttons schluckt.

https://claude.ai/code/session_01SDfbfRnT731vYY3HHn5SvU