### PR TITLE
Versenden-Funktion für Charaktere und Settings

### DIFF
--- a/utils/share_utils.py
+++ b/utils/share_utils.py
@@ -1,0 +1,173 @@
+# utils/share_utils.py
+"""
+Plattformübergreifende Teilen-Funktionalität für Dateien.
+Unterstützt Android (Share-Intent) und Desktop (xdg-open / open / Explorer).
+"""
+
+import os
+import subprocess
+from pathlib import Path
+from kivy.logger import Logger
+from kivy.utils import platform as kivy_platform
+
+
+def share_file(file_path, mime_type='*/*', title="Datei teilen"):
+    """
+    Teilt eine Datei über die plattformspezifische Teilen-Funktion.
+
+    Args:
+        file_path: Pfad zur Datei
+        mime_type: MIME-Typ der Datei (z.B. 'application/json', 'application/pdf')
+        title: Titel für den Teilen-Dialog
+
+    Returns:
+        bool: True bei Erfolg
+    """
+    file_path = str(file_path)
+    if not os.path.exists(file_path):
+        Logger.error(f"Teilen: Datei nicht gefunden: {file_path}")
+        return False
+
+    try:
+        if kivy_platform == 'android':
+            return _share_on_android(file_path, mime_type, title)
+        else:
+            return _share_on_desktop(file_path)
+    except Exception as e:
+        Logger.error(f"Fehler beim Teilen der Datei: {e}")
+        return False
+
+
+def share_multiple_files(file_paths, mime_type='*/*', title="Dateien teilen"):
+    """
+    Teilt mehrere Dateien über die plattformspezifische Teilen-Funktion.
+
+    Args:
+        file_paths: Liste von Dateipfaden
+        mime_type: MIME-Typ der Dateien
+        title: Titel für den Teilen-Dialog
+
+    Returns:
+        bool: True bei Erfolg
+    """
+    # Nur existierende Dateien
+    existing = [str(p) for p in file_paths if os.path.exists(str(p))]
+    if not existing:
+        Logger.error("Teilen: Keine der angegebenen Dateien existiert")
+        return False
+
+    try:
+        if kivy_platform == 'android':
+            return _share_multiple_on_android(existing, mime_type, title)
+        else:
+            # Auf Desktop: Ordner mit den Dateien öffnen
+            return _share_on_desktop(existing[0])
+    except Exception as e:
+        Logger.error(f"Fehler beim Teilen der Dateien: {e}")
+        return False
+
+
+def get_mime_type(file_path):
+    """Bestimmt den MIME-Typ anhand der Dateiendung."""
+    ext = Path(file_path).suffix.lower()
+    mime_types = {
+        '.json': 'application/json',
+        '.pdf': 'application/pdf',
+        '.html': 'text/html',
+        '.htm': 'text/html',
+        '.txt': 'text/plain',
+    }
+    return mime_types.get(ext, '*/*')
+
+
+def _share_on_android(file_path, mime_type, title):
+    """Teilt eine Datei über Android Share-Intent mit FileProvider."""
+    from jnius import autoclass
+
+    Intent = autoclass('android.content.Intent')
+    File = autoclass('java.io.File')
+    PythonActivity = autoclass('org.kivy.android.PythonActivity')
+
+    context = PythonActivity.mActivity
+    java_file = File(file_path)
+
+    # FileProvider für sichere URI-Erzeugung verwenden
+    try:
+        FileProvider = autoclass('androidx.core.content.FileProvider')
+        authority = context.getPackageName() + '.fileprovider'
+        content_uri = FileProvider.getUriForFile(context, authority, java_file)
+    except Exception:
+        Uri = autoclass('android.net.Uri')
+        content_uri = Uri.fromFile(java_file)
+
+    intent = Intent(Intent.ACTION_SEND)
+    intent.setType(mime_type)
+    intent.putExtra(Intent.EXTRA_STREAM, content_uri)
+    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    chooser = Intent.createChooser(intent, title)
+    chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(chooser)
+    Logger.info(f"Android: Datei geteilt: {os.path.basename(file_path)}")
+    return True
+
+
+def _share_multiple_on_android(file_paths, mime_type, title):
+    """Teilt mehrere Dateien über Android Share-Intent (ACTION_SEND_MULTIPLE)."""
+    from jnius import autoclass
+
+    Intent = autoclass('android.content.Intent')
+    File = autoclass('java.io.File')
+    ArrayList = autoclass('java.util.ArrayList')
+    PythonActivity = autoclass('org.kivy.android.PythonActivity')
+
+    context = PythonActivity.mActivity
+    uris = ArrayList()
+
+    for file_path in file_paths:
+        java_file = File(file_path)
+        try:
+            FileProvider = autoclass('androidx.core.content.FileProvider')
+            authority = context.getPackageName() + '.fileprovider'
+            content_uri = FileProvider.getUriForFile(context, authority, java_file)
+        except Exception:
+            Uri = autoclass('android.net.Uri')
+            content_uri = Uri.fromFile(java_file)
+        uris.add(content_uri)
+
+    intent = Intent(Intent.ACTION_SEND_MULTIPLE)
+    intent.setType(mime_type)
+    intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    chooser = Intent.createChooser(intent, title)
+    chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(chooser)
+    Logger.info(f"Android: {len(file_paths)} Dateien geteilt")
+    return True
+
+
+def _share_on_desktop(file_path):
+    """Öffnet den Dateimanager mit der Datei ausgewählt (Desktop)."""
+    import sys
+
+    file_path = os.path.abspath(file_path)
+    folder = os.path.dirname(file_path)
+
+    try:
+        if sys.platform == 'win32':
+            # Windows: Explorer mit Datei markiert öffnen
+            subprocess.Popen(['explorer', '/select,', file_path])
+        elif sys.platform == 'darwin':
+            # macOS: Finder mit Datei markiert öffnen
+            subprocess.Popen(['open', '-R', file_path])
+        else:
+            # Linux: Dateimanager mit dem Ordner öffnen
+            subprocess.Popen(['xdg-open', folder])
+        Logger.info(f"Desktop: Ordner geöffnet für: {os.path.basename(file_path)}")
+        return True
+    except Exception as e:
+        Logger.warning(f"Desktop: Dateimanager konnte nicht geöffnet werden: {e}")
+        return False

--- a/views/charakter_verwaltung_widget.kv
+++ b/views/charakter_verwaltung_widget.kv
@@ -189,6 +189,32 @@
                             MDButtonText:
                                 text: "Element-Statistiken"
 
+                    MDBoxLayout:
+                        orientation: "horizontal"
+                        spacing: "8dp"
+                        size_hint_y: None
+                        height: "50dp"
+
+                        MDButton:
+                            style: "elevated"
+                            on_release: root.versende_charakter()
+
+                            MDButtonIcon:
+                                icon: "share-variant"
+
+                            MDButtonText:
+                                text: "Charakter versenden"
+
+                        MDButton:
+                            style: "elevated"
+                            on_release: root.versende_setting()
+
+                            MDButtonIcon:
+                                icon: "share"
+
+                            MDButtonText:
+                                text: "Setting versenden"
+
             # ===== Charakter-Einstellungen =====
             MDCard:
                 style: "elevated"

--- a/views/charakter_verwaltung_widget.py
+++ b/views/charakter_verwaltung_widget.py
@@ -1143,6 +1143,228 @@ class CharakterVerwaltungWidget(MDBoxLayout):
         else:
             Logger.warning("DialogService nicht verfügbar - Setting löschen nicht möglich")
 
+    # ==================== TEILEN / VERSENDEN ====================
+
+    def versende_charakter(self):
+        """Zeigt Dialog zum Versenden von Charakter-Dateien (JSON, PDF, HTML)"""
+        try:
+            controller = self.app.controller
+            if not controller or not controller.charakter:
+                self._show_share_warning("Kein Charakter geladen.")
+                return
+
+            char_name = getattr(controller.charakter, 'char_name', 'Charakter')
+            char_file_path = getattr(controller, 'current_character_file_path', None)
+
+            # Verfügbare Dateien sammeln
+            dateien = self._sammle_charakter_dateien(char_file_path, char_name)
+
+            if not dateien:
+                self._show_share_warning(
+                    "Keine Charakter-Dateien zum Versenden gefunden.\n"
+                    "Speichere den Charakter zuerst."
+                )
+                return
+
+            self._zeige_versende_dialog(dateien, f"Charakter versenden: {char_name}")
+        except Exception as e:
+            Logger.error(f"Fehler beim Versenden des Charakters: {e}")
+
+    def _sammle_charakter_dateien(self, char_file_path, char_name):
+        """Sammelt alle vorhandenen Dateien eines Charakters (JSON, PDF, HTML)."""
+        dateien = []
+
+        if char_file_path and os.path.exists(char_file_path):
+            dateien.append({
+                'pfad': char_file_path,
+                'name': os.path.basename(char_file_path),
+                'typ': 'Charakter (JSON)',
+                'icon': 'code-json',
+            })
+
+            # Zugehörige PDF/HTML im gleichen Verzeichnis suchen
+            ordner = os.path.dirname(char_file_path)
+            basis = Path(char_file_path).stem
+
+            pdf_pfad = os.path.join(ordner, f"{basis}.pdf")
+            if os.path.exists(pdf_pfad):
+                dateien.append({
+                    'pfad': pdf_pfad,
+                    'name': os.path.basename(pdf_pfad),
+                    'typ': 'Charakterbogen (PDF)',
+                    'icon': 'file-pdf-box',
+                })
+
+            html_pfad = os.path.join(ordner, f"{basis}.html")
+            if os.path.exists(html_pfad):
+                dateien.append({
+                    'pfad': html_pfad,
+                    'name': os.path.basename(html_pfad),
+                    'typ': 'Charakterbogen (HTML)',
+                    'icon': 'language-html5',
+                })
+        else:
+            # Kein gespeicherter Charakter - in chars/ nach passenden Dateien suchen
+            from utils.path_utils import get_chars_path
+            import glob as glob_mod
+
+            chars_dir = get_chars_path()
+            for ext in ('*.json', '*.pdf', '*.html'):
+                for f in glob_mod.glob(os.path.join(chars_dir, ext)):
+                    if char_name.lower() in os.path.basename(f).lower():
+                        icon = 'code-json' if f.endswith('.json') else (
+                            'file-pdf-box' if f.endswith('.pdf') else 'language-html5'
+                        )
+                        typ = 'JSON' if f.endswith('.json') else (
+                            'PDF' if f.endswith('.pdf') else 'HTML'
+                        )
+                        dateien.append({
+                            'pfad': f,
+                            'name': os.path.basename(f),
+                            'typ': typ,
+                            'icon': icon,
+                        })
+
+        return dateien
+
+    def _zeige_versende_dialog(self, dateien, titel):
+        """Zeigt einen Dialog mit Checkboxen für die zu versendenden Dateien."""
+        from kivymd.uix.selectioncontrol import MDCheckbox
+
+        dialog_content = MDBoxLayout(
+            orientation="vertical",
+            spacing=dp(8),
+            padding=dp(16),
+            size_hint_y=None,
+        )
+        dialog_content.bind(minimum_height=dialog_content.setter('height'))
+
+        dialog_content.add_widget(MDLabel(
+            text="Dateien zum Versenden auswählen:",
+            size_hint_y=None,
+            height=dp(30),
+        ))
+
+        checkboxes = []
+        for datei in dateien:
+            row = MDBoxLayout(
+                orientation='horizontal',
+                spacing=dp(8),
+                size_hint_y=None,
+                height=dp(48),
+            )
+
+            cb = MDCheckbox(
+                active=True,
+                size_hint=(None, None),
+                size=(dp(48), dp(48)),
+                pos_hint={"center_y": .5},
+            )
+            checkboxes.append((cb, datei))
+
+            row.add_widget(cb)
+            row.add_widget(MDListItemLeadingIcon(icon=datei['icon']))
+            row.add_widget(MDLabel(
+                text=f"{datei['name']} ({datei['typ']})",
+                pos_hint={"center_y": .5},
+            ))
+
+            dialog_content.add_widget(row)
+
+        def _on_versenden(x):
+            self._versende_dialog.dismiss()
+            ausgewaehlte = [d['pfad'] for cb, d in checkboxes if cb.active]
+            if ausgewaehlte:
+                self._versende_dateien(ausgewaehlte, titel)
+
+        self._versende_dialog = MDDialog(
+            MDDialogHeadlineText(text=titel),
+            MDDialogContentContainer(dialog_content, orientation="vertical"),
+            MDDialogButtonContainer(
+                MDButton(
+                    MDButtonText(text="Abbrechen"),
+                    style="text",
+                    on_release=lambda x: self._versende_dialog.dismiss(),
+                ),
+                MDButton(
+                    MDButtonText(text="Versenden"),
+                    style="text",
+                    on_release=_on_versenden,
+                ),
+                spacing="8dp",
+            ),
+            size_hint=(0.85, None),
+            auto_dismiss=False,
+        )
+        self._versende_dialog.open()
+
+    def _versende_dateien(self, dateipfade, titel="Dateien versenden"):
+        """Versendet die ausgewählten Dateien über die Plattform-Teilen-Funktion."""
+        from utils.share_utils import share_file, share_multiple_files, get_mime_type
+
+        try:
+            if len(dateipfade) == 1:
+                mime = get_mime_type(dateipfade[0])
+                success = share_file(dateipfade[0], mime, titel)
+            else:
+                success = share_multiple_files(dateipfade, '*/*', titel)
+
+            if not success:
+                dialog_service = service_container.get_dialog_service()
+                if dialog_service:
+                    dialog_service.show_warning_dialog(
+                        "Das Versenden konnte nicht gestartet werden."
+                    )
+        except Exception as e:
+            Logger.error(f"Fehler beim Versenden: {e}")
+
+    def versende_setting(self):
+        """Versendet das aktuell aktive Setting als JSON-Datei."""
+        try:
+            controller = self.app.controller
+            if not controller or not controller.charakter:
+                self._show_share_warning("Kein Charakter geladen.")
+                return
+
+            setting_name = getattr(controller.charakter, 'active_setting_name', None)
+            if not setting_name:
+                self._show_share_warning("Kein aktives Setting vorhanden.")
+                return
+
+            # Setting-Datei finden (zuerst im Benutzer-Verzeichnis, dann nativ)
+            from utils.path_utils import get_settings_path, get_user_settings_path
+
+            setting_file = None
+            user_file = os.path.join(get_user_settings_path(), f"{setting_name}.json")
+            native_file = os.path.join(get_settings_path(), f"{setting_name}.json")
+
+            if os.path.exists(user_file):
+                setting_file = user_file
+            elif os.path.exists(native_file):
+                setting_file = native_file
+
+            if not setting_file:
+                self._show_share_warning(f"Setting-Datei für '{setting_name}' nicht gefunden.")
+                return
+
+            from utils.share_utils import share_file
+            success = share_file(setting_file, 'application/json', f"Setting versenden: {setting_name}")
+
+            if not success:
+                dialog_service = service_container.get_dialog_service()
+                if dialog_service:
+                    dialog_service.show_warning_dialog(
+                        "Das Versenden konnte nicht gestartet werden."
+                    )
+        except Exception as e:
+            Logger.error(f"Fehler beim Versenden des Settings: {e}")
+
+    def _show_share_warning(self, message):
+        """Zeigt eine Warnung beim Versenden."""
+        dialog_service = service_container.get_dialog_service()
+        if dialog_service:
+            dialog_service.show_warning_dialog(message)
+
     # ==================== UI UPDATE METHODEN ====================
 
     def refresh_widget(self):

--- a/views/charakter_verwaltung_widget_mobile.kv
+++ b/views/charakter_verwaltung_widget_mobile.kv
@@ -158,6 +158,30 @@
                     MDButtonText:
                         text: "Element-Statistiken"
 
+                MDGridLayout:
+                    cols: 2
+                    spacing: dp(6)
+                    size_hint_y: None
+                    height: dp(48)
+
+                    MDButton:
+                        style: "elevated"
+                        size_hint_x: 1
+                        on_release: root.versende_charakter()
+                        MDButtonIcon:
+                            icon: "share-variant"
+                        MDButtonText:
+                            text: "Char versenden"
+
+                    MDButton:
+                        style: "elevated"
+                        size_hint_x: 1
+                        on_release: root.versende_setting()
+                        MDButtonIcon:
+                            icon: "share"
+                        MDButtonText:
+                            text: "Setting versenden"
+
             MDDivider:
 
             # ===== Charakter-Einstellungen =====


### PR DESCRIPTION
Neue Möglichkeit, Charakter-Dateien (JSON, PDF, HTML) und Settings per Teilen-Funktion zu versenden:

- utils/share_utils.py: Plattformübergreifendes Teilen
  - Android: Share-Intent mit FileProvider (einzeln und mehrere Dateien)
  - Desktop: Dateimanager mit markierter Datei öffnen
- Charakter versenden: Dialog mit Checkbox-Auswahl der verfügbaren Dateien (JSON-Charakter + zugehörige PDF/HTML-Bögen)
- Setting versenden: Aktives Setting als JSON-Datei teilen
- Buttons in Desktop- und Mobile-Layout (Export & Anzeige Bereich)

https://claude.ai/code/session_017NTCfuxwZp7mPCmkghCYYK