### PR TITLE
Doppelte Handicaps aus Settings-Dateien entfernt

### DIFF
--- a/settings/50 Fathoms.json
+++ b/settings/50 Fathoms.json
@@ -868,24 +868,6 @@
             "aktiv": true,
             "custom": false
         },
-        "Angetrieben": {
-            "name": "Angetrieben",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder einer Überzeugung angetrieben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Angewohnheit": {
-            "name": "Angewohnheit",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Abhängig von etwas, erleidet Erschöpfung bei Entzug.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Arm": {
             "name": "Arm",
             "stufe": "leicht",
@@ -985,15 +967,6 @@
             "aktiv": true,
             "custom": false
         },
-        "Feind": {
-            "name": "Feind",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Geheimnis": {
             "name": "Geheimnis",
             "stufe": "leicht",
@@ -1008,24 +981,6 @@
             "stufe": "schwer",
             "punkte": 2,
             "beschreibung": "Der Held hat ein dunkles Geheimnis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gesucht": {
-            "name": "Gesucht",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gierig": {
-            "name": "Gierig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false
@@ -1075,47 +1030,11 @@
             "aktiv": true,
             "custom": false
         },
-        "Langsam": {
-            "name": "Langsam",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Bewegungsweite –1, verringere den Sprintwürfel um eine Stufe.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Pazifist": {
-            "name": "Pazifist",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Kämpft nur in Selbstverteidigung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Pech": {
             "name": "Pech",
             "stufe": "schwer",
             "punkte": 2,
             "beschreibung": "Der Charakter beginnt jede Spielsitzung mit einem Benny weniger.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Phobie": {
-            "name": "Phobie",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat Angst vor etwas und zieht –1 von Eigenschaftsproben in dessen Gegenwart ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rachsüchtig": {
-            "name": "Rachsüchtig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false
@@ -1138,29 +1057,11 @@
             "aktiv": true,
             "custom": false
         },
-        "Schwerhörig": {
-            "name": "Schwerhörig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–4 auf Wahrnehmung bei Geräuschen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Schwerzüngig": {
             "name": "Schwerzüngig",
             "stufe": "schwer",
             "punkte": 2,
             "beschreibung": "–1 auf Einschüchtern, Überreden und Provozieren.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwur": {
-            "name": "Schwur",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false

--- a/settings/Deadlands.json
+++ b/settings/Deadlands.json
@@ -3748,24 +3748,6 @@
             "beschreibung": "–1 auf Proben mit Allgemeinwissen und Wahrnehmung.",
             "ausgewaehlt": false,
             "aktiv": true
-        },
-        "Klein": {
-            "name": "Klein",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Dieser Abenteurer ist ziemlich dürr, klein oder beides. Seine Größe (siehe Seite 103) wird um –1 verringert, wodurch auch seine Robustheit sinkt. Die Größe kann nicht unter –1 sinken, doch der Abzug auf Robustheit ist kumulativ. Ein kleiner Halbling hat beispielsweise Größe –1, verliert aber einen zusätzlichen Punkt Robustheit.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Kränklich": {
-            "name": "Kränklich",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Kränkliche Charaktere sind besonders anfällig gegenüber Krankheiten, Infektionen, Umwelteffekten und Erschöpfung. Sie ziehen –2 von Konstitutionsproben ab, um Erschöpfung zu widerstehen (siehe Gefahren, beginnend auf Seite 101).",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
         }
     },
     "maechte": {

--- a/settings/Fantasy Kompendium.json
+++ b/settings/Fantasy Kompendium.json
@@ -4794,24 +4794,6 @@
             "aktiv": true,
             "custom": false
         },
-        "Angetrieben": {
-            "name": "Angetrieben",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder einer Überzeugung angetrieben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Angewohnheit": {
-            "name": "Angewohnheit",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Abhängig von etwas, erleidet Erschöpfung bei Entzug.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Arm": {
             "name": "Arm",
             "stufe": "leicht",
@@ -4911,15 +4893,6 @@
             "aktiv": true,
             "custom": false
         },
-        "Feind": {
-            "name": "Feind",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Geheimnis": {
             "name": "Geheimnis",
             "stufe": "leicht",
@@ -4934,24 +4907,6 @@
             "stufe": "schwer",
             "punkte": 2,
             "beschreibung": "Der Held hat ein dunkles Geheimnis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gesucht": {
-            "name": "Gesucht",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gierig": {
-            "name": "Gierig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false
@@ -5001,47 +4956,11 @@
             "aktiv": true,
             "custom": false
         },
-        "Langsam": {
-            "name": "Langsam",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Bewegungsweite –1, verringere den Sprintwürfel um eine Stufe.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Pazifist": {
-            "name": "Pazifist",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Kämpft nur in Selbstverteidigung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Pech": {
             "name": "Pech",
             "stufe": "schwer",
             "punkte": 2,
             "beschreibung": "Der Charakter beginnt jede Spielsitzung mit einem Benny weniger.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Phobie": {
-            "name": "Phobie",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat Angst vor etwas und zieht –1 von Eigenschaftsproben in dessen Gegenwart ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rachsüchtig": {
-            "name": "Rachsüchtig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false
@@ -5064,29 +4983,11 @@
             "aktiv": true,
             "custom": false
         },
-        "Schwerhörig": {
-            "name": "Schwerhörig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–4 auf Wahrnehmung bei Geräuschen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Schwerzüngig": {
             "name": "Schwerzüngig",
             "stufe": "schwer",
             "punkte": 2,
             "beschreibung": "–1 auf Einschüchtern, Überreden und Provozieren.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwur": {
-            "name": "Schwur",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false

--- a/settings/Rippers.json
+++ b/settings/Rippers.json
@@ -3557,15 +3557,6 @@
             "aktiv": true,
             "custom": false
         },
-        "Schreihals": {
-            "name": "Schreihals",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Furcht und Schrecken entlocken dem Helden einen ohrenbetäubenden Schrei. Jedes Mal, wenn er eine Furchtprobe nicht besteht, schreit er automatisch. Jeder Charakter im Bereich einer großen Schablone erleidet –1 auf das Ergebnis seiner eigenen Furchtprobe.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Überempfindlich": {
             "name": "Überempfindlich",
             "stufe": "schwer",
@@ -3580,15 +3571,6 @@
             "stufe": "leicht",
             "punkte": 1,
             "beschreibung": "Der Held hat eine Schwäche gegenüber einem bestimmten Material (Kaltes Eisen, Holz, Silber, Sonnenlicht, Salz oder Feuer). Er kann dieses Material nicht verwenden und dessen Berührung nicht ertragen. Waffen aus diesem Material verursachen +4 Schaden. Kann mehrfach gewählt werden (jedes Mal andere Schwäche).",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verflucht": {
-            "name": "Verflucht",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Held hat eine dunkle Macht übers Ohr gehauen und ist auf immer mit deren dunklem Mal gezeichnet. Der Charakter kann niemals nützliche Segnungen erhalten, wie sie der Arkane Hintergrund (Wunder) gewährt.",
             "ausgewaehlt": false,
             "aktiv": true,
             "custom": false

--- a/settings/Sundered Skies.json
+++ b/settings/Sundered Skies.json
@@ -4296,15 +4296,6 @@
             "aktiv": true,
             "custom": false
         },
-        "Blutrünstig FK": {
-            "name": "Blutrünstig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Nimmt niemals Gefangene.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
         "Dünnhäutig": {
             "name": "Dünnhäutig",
             "stufe": "leicht",


### PR DESCRIPTION
Mehrere Settings-Dateien enthielten Handicaps mit zwei verschiedenen
Schlüsseln aber identischem Inhalt (z.B. "Gesucht_leicht" und "Gesucht"
für dasselbe Handicap). Dies führte zu doppelten Einträgen in der
Handicap-Liste.

Betroffene Settings:
- Fantasy Kompendium: 11 Duplikate entfernt
- 50 Fathoms: 11 Duplikate entfernt
- Deadlands: 2 Duplikate entfernt
- Rippers: 2 Duplikate entfernt
- Sundered Skies: 1 Duplikat entfernt

https://claude.ai/code/session_01Uom5v7pgiMXTZogQqiujVN