### PR TITLE
Desktop-Skalierung für HiDPI-Displays verbessern

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -172,7 +172,7 @@ MDScreen:
                 MDBoxLayout:
                     orientation: 'vertical'
                     id: tab_content_box
-                    padding: [30, 0, 30, 30]
+                    padding: [dp(30), 0, dp(30), dp(30)]
                     size_hint_y: 1  # Füllt den restlichen Platz
                     md_bg_color: app.theme_cls.backgroundColor
 

--- a/main.py
+++ b/main.py
@@ -10,6 +10,11 @@ from functools import partial
 import re
 import webbrowser
 
+# Desktop-Skalierung MUSS vor allen Kivy-Imports gesetzt werden!
+# Setzt KIVY_METRICS_DENSITY für korrekte dp()-Skalierung auf HiDPI-Displays.
+from utils.desktop_scaling import apply_desktop_scaling
+_applied_density = apply_desktop_scaling()
+
 # Logging-Setup als erstes importieren und initialisieren
 from utils.logging_setup import setup_file_logging, cleanup_old_logs, log_system_info
 

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -59,6 +59,9 @@ class AppConfig:
 
     # Mobile-Layout-Override (für Desktop-Tests)
     force_mobile_layout: bool = False
+
+    # Desktop-Skalierung: "auto" für automatische Erkennung, oder float (z.B. 1.5)
+    desktop_scale_factor: str = "auto"
     
     # Version und Metadaten
     config_version: str = "1.0"

--- a/utils/desktop_scaling.py
+++ b/utils/desktop_scaling.py
@@ -1,0 +1,204 @@
+"""
+Desktop-Skalierung für HiDPI-Displays.
+
+WICHTIG: Dieses Modul darf KEINE Kivy-Imports enthalten!
+Es muss VOR allen Kivy-Imports aufgerufen werden, da KIVY_METRICS_DENSITY
+als Environment-Variable gesetzt werden muss, bevor Kivy initialisiert wird.
+
+Setzt KIVY_METRICS_DENSITY basierend auf:
+1. Manuellem desktop_scale_factor aus app_config.json
+2. Automatischer Erkennung der Bildschirmauflösung (Fallback)
+"""
+
+import json
+import os
+import sys
+import subprocess
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Standard-Density auf Desktop: 1.0 (= 160 DPI Baseline)
+DEFAULT_DENSITY = 1.0
+
+# Auto-Detection Schwellwerte (Bildschirmbreite in Pixeln)
+_RESOLUTION_THRESHOLDS = [
+    (3840, 2.0),   # 4K → Density 2.0
+    (2560, 1.5),   # QHD/WQHD → Density 1.5
+    (1920, 1.0),   # Full HD → Density 1.0
+]
+
+
+def _get_app_root():
+    """Ermittelt das App-Stammverzeichnis (ohne Kivy-Import)."""
+    if getattr(sys, 'frozen', False):
+        return Path(sys.executable).parent
+    return Path(__file__).parent.parent
+
+
+def _read_scale_factor_from_config():
+    """
+    Liest desktop_scale_factor aus app_config.json.
+
+    Returns:
+        float oder str: Skalierungsfaktor (z.B. 1.5) oder "auto" für automatische Erkennung.
+        None falls nicht gesetzt oder Fehler.
+    """
+    try:
+        config_path = _get_app_root() / "config" / "app_config.json"
+        if config_path.exists():
+            with open(config_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            value = data.get('desktop_scale_factor', 'auto')
+            if isinstance(value, (int, float)) and value > 0:
+                return float(value)
+            if value == 'auto':
+                return 'auto'
+    except Exception as e:
+        logger.debug(f"desktop_scaling: Config-Lesen fehlgeschlagen: {e}")
+    return 'auto'
+
+
+def _detect_screen_width_linux():
+    """
+    Erkennt die Bildschirmbreite unter Linux via xrandr.
+
+    Returns:
+        int: Bildschirmbreite in Pixeln oder 0 bei Fehler.
+    """
+    try:
+        output = subprocess.check_output(
+            ['xrandr', '--current'],
+            stderr=subprocess.DEVNULL,
+            timeout=3
+        ).decode('utf-8', errors='replace')
+
+        # Suche nach aktiven Ausgängen: z.B. "3840x2160+0+0"
+        # Format: "HDMI-1 connected primary 3840x2160+0+0 ..."
+        import re
+        # Finde die höchste Auflösung eines verbundenen Monitors
+        max_width = 0
+        for line in output.splitlines():
+            if ' connected' in line:
+                match = re.search(r'(\d{3,5})x(\d{3,5})\+', line)
+                if match:
+                    width = int(match.group(1))
+                    if width > max_width:
+                        max_width = width
+        return max_width
+    except Exception:
+        return 0
+
+
+def _detect_screen_width_windows():
+    """
+    Erkennt die Bildschirmbreite unter Windows via ctypes.
+
+    Returns:
+        int: Bildschirmbreite in Pixeln oder 0 bei Fehler.
+    """
+    try:
+        import ctypes
+        # SM_CXSCREEN = 0, gibt die Breite des primären Monitors zurück
+        user32 = ctypes.windll.user32
+        # DPI-Awareness setzen für korrekte Auflösung
+        try:
+            user32.SetProcessDPIAware()
+        except Exception:
+            pass
+        return user32.GetSystemMetrics(0)
+    except Exception:
+        return 0
+
+
+def _detect_screen_width_macos():
+    """
+    Erkennt die Bildschirmbreite unter macOS via system_profiler.
+
+    Returns:
+        int: Bildschirmbreite in Pixeln oder 0 bei Fehler.
+    """
+    try:
+        output = subprocess.check_output(
+            ['system_profiler', 'SPDisplaysDataType'],
+            stderr=subprocess.DEVNULL,
+            timeout=5
+        ).decode('utf-8', errors='replace')
+
+        import re
+        # Suche nach "Resolution: 3840 x 2160" oder ähnlich
+        match = re.search(r'Resolution:\s*(\d{3,5})\s*x\s*\d{3,5}', output)
+        if match:
+            return int(match.group(1))
+    except Exception:
+        pass
+    return 0
+
+
+def _detect_screen_width():
+    """Erkennt die Bildschirmbreite plattformübergreifend."""
+    if sys.platform.startswith('linux'):
+        return _detect_screen_width_linux()
+    elif sys.platform == 'win32':
+        return _detect_screen_width_windows()
+    elif sys.platform == 'darwin':
+        return _detect_screen_width_macos()
+    return 0
+
+
+def _auto_detect_density():
+    """
+    Erkennt automatisch eine passende Density basierend auf der Bildschirmauflösung.
+
+    Returns:
+        float: Empfohlene Density (1.0, 1.5 oder 2.0)
+    """
+    width = _detect_screen_width()
+    if width > 0:
+        for threshold, density in _RESOLUTION_THRESHOLDS:
+            if width >= threshold:
+                logger.info(
+                    f"desktop_scaling: Bildschirmbreite {width}px erkannt → Density {density}"
+                )
+                return density
+
+    # Fallback: Standard-Density
+    return DEFAULT_DENSITY
+
+
+def apply_desktop_scaling():
+    """
+    Setzt KIVY_METRICS_DENSITY basierend auf Konfiguration oder Auto-Erkennung.
+
+    MUSS vor allen Kivy-Imports aufgerufen werden!
+
+    Returns:
+        float: Die angewandte Density.
+    """
+    # Auf Android/iOS nicht eingreifen - Kivy erkennt mobile DPI korrekt
+    if hasattr(sys, '_ANDROID_API') or 'ANDROID_ARGUMENT' in os.environ:
+        return DEFAULT_DENSITY
+
+    # Wenn bereits gesetzt (z.B. durch Benutzer-Env), nicht überschreiben
+    if 'KIVY_METRICS_DENSITY' in os.environ:
+        try:
+            existing = float(os.environ['KIVY_METRICS_DENSITY'])
+            logger.info(f"desktop_scaling: KIVY_METRICS_DENSITY bereits gesetzt: {existing}")
+            return existing
+        except ValueError:
+            pass
+
+    scale_factor = _read_scale_factor_from_config()
+
+    if scale_factor == 'auto' or scale_factor is None:
+        density = _auto_detect_density()
+    else:
+        density = float(scale_factor)
+        # Sicherheitsgrenzen
+        density = max(0.5, min(3.0, density))
+
+    os.environ['KIVY_METRICS_DENSITY'] = str(density)
+    logger.info(f"desktop_scaling: KIVY_METRICS_DENSITY gesetzt auf {density}")
+
+    return density

--- a/views/einstellungen_widget.kv
+++ b/views/einstellungen_widget.kv
@@ -115,6 +115,62 @@
                         pos_hint: {"center_y": .5}
                         on_active: root.toggle_logger(self.active)
 
+                # Desktop-Skalierung
+                MDBoxLayout:
+                    orientation: 'horizontal'
+                    size_hint_y: None
+                    height: dp(48)
+                    spacing: dp(16)
+
+                    MDLabel:
+                        text: 'UI-Skalierung:'
+                        size_hint: None, None
+                        size: dp(250), dp(40)
+                        pos_hint: {"center_y": .5}
+
+                    Slider:
+                        id: scale_slider
+                        min: 0.8
+                        max: 2.5
+                        step: 0.1
+                        value: 1.0
+                        size_hint_x: 0.5
+                        pos_hint: {"center_y": .5}
+                        on_value: root.on_scale_slider_changed(self.value)
+
+                    MDLabel:
+                        id: scale_label
+                        text: 'Auto'
+                        size_hint: None, None
+                        size: dp(60), dp(40)
+                        pos_hint: {"center_y": .5}
+
+                MDBoxLayout:
+                    orientation: 'horizontal'
+                    size_hint_y: None
+                    height: dp(36)
+                    spacing: dp(8)
+
+                    Widget:
+                        size_hint_x: None
+                        width: dp(250)
+
+                    MDButton:
+                        style: "outlined"
+                        size_hint: None, None
+                        size: dp(120), dp(36)
+                        on_release: root.reset_scale_to_auto()
+
+                        MDButtonText:
+                            text: "Auto"
+
+                    MDLabel:
+                        text: "(Neustart erforderlich)"
+                        theme_text_color: "Secondary"
+                        size_hint_y: None
+                        height: dp(36)
+                        pos_hint: {"center_y": .5}
+
             MDDivider:
 
             # ===== Spielelemente =====

--- a/views/einstellungen_widget.py
+++ b/views/einstellungen_widget.py
@@ -141,8 +141,83 @@ class EinstellungenWidget(MDBoxLayout):
                 logger_switch.unbind(on_active=None)
                 logger_switch.active = show_logger
                 Logger.debug(f"Logger Switch initialisiert: {show_logger}")
+
+            # Desktop-Skalierung Slider initialisieren
+            self._init_scale_slider(config_service)
         except Exception as e:
             Logger.error(f"Fehler beim Initialisieren der UI-Switches: {e}")
+
+    def _init_scale_slider(self, config_service):
+        """Initialisiert den Skalierungs-Slider aus der Config"""
+        try:
+            scale_factor = config_service.get('desktop_scale_factor', 'auto')
+            slider = self.ids.get('scale_slider')
+            label = self.ids.get('scale_label')
+            if not slider or not label:
+                return
+
+            self._scale_slider_programmatic = True
+            if scale_factor == 'auto' or scale_factor is None:
+                # Aktuellen Wert aus Environment anzeigen
+                import os
+                current = float(os.environ.get('KIVY_METRICS_DENSITY', '1.0'))
+                slider.value = current
+                label.text = f'Auto ({current}x)'
+                self._scale_is_auto = True
+            else:
+                try:
+                    val = float(scale_factor)
+                    slider.value = val
+                    label.text = f'{val}x'
+                    self._scale_is_auto = False
+                except (ValueError, TypeError):
+                    slider.value = 1.0
+                    label.text = 'Auto'
+                    self._scale_is_auto = True
+            self._scale_slider_programmatic = False
+        except Exception as e:
+            Logger.error(f"Fehler beim Initialisieren des Skalierungs-Sliders: {e}")
+
+    def on_scale_slider_changed(self, value):
+        """Callback wenn der Skalierungs-Slider verändert wird"""
+        if getattr(self, '_scale_slider_programmatic', False):
+            return
+        try:
+            value = round(value, 1)
+            label = self.ids.get('scale_label')
+            if label:
+                label.text = f'{value}x'
+
+            config_service = service_container.get_config_service()
+            if config_service:
+                config_service.set('desktop_scale_factor', value)
+            self._scale_is_auto = False
+            Logger.info(f"UI-Skalierung auf {value}x gesetzt (Neustart erforderlich)")
+        except Exception as e:
+            Logger.error(f"Fehler beim Setzen der Skalierung: {e}")
+
+    def reset_scale_to_auto(self):
+        """Setzt die Skalierung auf automatische Erkennung zurück"""
+        try:
+            config_service = service_container.get_config_service()
+            if config_service:
+                config_service.set('desktop_scale_factor', 'auto')
+
+            import os
+            current = float(os.environ.get('KIVY_METRICS_DENSITY', '1.0'))
+
+            self._scale_slider_programmatic = True
+            slider = self.ids.get('scale_slider')
+            label = self.ids.get('scale_label')
+            if slider:
+                slider.value = current
+            if label:
+                label.text = f'Auto ({current}x)'
+            self._scale_is_auto = True
+            self._scale_slider_programmatic = False
+            Logger.info("UI-Skalierung auf Auto zurückgesetzt (Neustart erforderlich)")
+        except Exception as e:
+            Logger.error(f"Fehler beim Zurücksetzen der Skalierung: {e}")
 
     def toggle_logger(self, active):
         """Wechselt die Logger-Leiste Sichtbarkeit und speichert die Einstellung"""


### PR DESCRIPTION
Automatische Erkennung der Bildschirmauflösung und Anpassung der
UI-Skalierung über KIVY_METRICS_DENSITY. Auf 4K-Displays wird
Density 2.0, auf QHD 1.5 gesetzt. Manueller Override über Slider
in den Einstellungen möglich (Neustart erforderlich).

- Neues Modul utils/desktop_scaling.py für Pre-Kivy DPI-Setup
- desktop_scale_factor Config-Option (auto/manuell)
- UI-Slider in Einstellungen mit Auto-Reset
- Raw-Pixel-Padding in main.kv durch dp() ersetzt

https://claude.ai/code/session_01BSmauTzEkgpbqbAmr1dWxW