### PR TITLE
Fix wealth warning logic in equipment purchase dialogs

### DIFF
--- a/views/ausruestung_view.py
+++ b/views/ausruestung_view.py
@@ -419,7 +419,9 @@ class AusruestungItemRow(MDBoxLayout):
                 Logger.debug(f"Cyberware-Kauf fehlgeschlagen: {self.name}")
                 self._refresh_ui()
                 self._zeige_cyberware_kauf_fehler(controller, self.name)
-                self._show_kauf_warnung(1)
+                # Vermögen-Warnung nur bei tatsächlich nicht ausreichendem Vermögen
+                if controller.charakter.vermoegen < effektiver_preis:
+                    self._show_kauf_warnung(1)
         except Exception as e:
             Logger.error(f"Fehler beim konfigurierten Cyberware-Kauf: {e}")
             self.show_error("Ein unerwarteter Fehler ist aufgetreten.")
@@ -497,8 +499,10 @@ class AusruestungItemRow(MDBoxLayout):
                 self._refresh_ui()
                 # Cyberware: Zeige spezifische Fehlermeldung bei Stress-Überschreitung
                 self._zeige_cyberware_kauf_fehler(controller, self.name)
-                # Snackbar-Warnung bei nicht ausreichendem Vermögen
-                self._show_kauf_warnung(anzahl)
+                # Snackbar-Warnung nur bei tatsächlich nicht ausreichendem Vermögen
+                aktueller_preis = preis or self.kosten
+                if controller.charakter.vermoegen < aktueller_preis * anzahl:
+                    self._show_kauf_warnung(anzahl)
 
         except Exception as e:
             Logger.error(f"Fehler beim Verarbeiten des Kaufs: {str(e)}")


### PR DESCRIPTION
## Summary
Fixed the wealth warning display logic in cyberware purchase flows to only show warnings when the character actually has insufficient funds, rather than showing warnings for all failed purchases.

## Key Changes
- **Configured purchase flow**: Added a check to verify `controller.charakter.vermoegen < effektiver_preis` before displaying the wealth warning, ensuring warnings only appear when funds are genuinely insufficient
- **Dialog-based purchase flow**: Added similar validation with `controller.charakter.vermoegen < aktueller_preis * anzahl` to prevent spurious warnings when other purchase failure reasons exist (e.g., stress limit exceeded)

## Implementation Details
The changes distinguish between different failure modes in cyberware purchases:
- Insufficient wealth → show wealth warning
- Other failures (stress limits, configuration errors, etc.) → show specific error message without wealth warning

This prevents confusing users with misleading wealth warnings when the actual purchase failure is due to other game mechanics constraints.

https://claude.ai/code/session_016vFHMio58VD6QRAs3ahSV1