### PR TITLE
Fix overlapping dialog text on Android

### DIFF
--- a/views/einstellungen_widget.py
+++ b/views/einstellungen_widget.py
@@ -537,45 +537,36 @@ class EinstellungenWidget(MDBoxLayout):
     def _show_simple_dialog(self, title, message):
         """Zeigt einen einfachen Dialog"""
         try:
-            from kivymd.uix.dialog import MDDialog
+            from kivymd.uix.dialog import (
+                MDDialog, MDDialogHeadlineText, MDDialogContentContainer,
+                MDDialogButtonContainer
+            )
             from kivymd.uix.label import MDLabel
             from kivymd.uix.button import MDButton, MDButtonText
-            from kivymd.uix.boxlayout import MDBoxLayout
-            
-            # Content mit MDBoxLayout umhüllen
-            content = MDBoxLayout(
-                orientation="vertical",
-                adaptive_height=True,
-                padding="12dp"
+
+            dialog = MDDialog(
+                MDDialogHeadlineText(text=title),
+                MDDialogContentContainer(
+                    MDLabel(
+                        text=message,
+                        theme_text_color="Primary",
+                        halign="left",
+                    ),
+                    orientation="vertical",
+                ),
+                MDDialogButtonContainer(
+                    MDButton(
+                        MDButtonText(text="OK"),
+                        style="text",
+                        on_release=lambda x: dialog.dismiss(),
+                    ),
+                    spacing="8dp",
+                ),
+                size_hint=(0.85, None),
+                auto_dismiss=True,
             )
-            
-            label = MDLabel(
-                text=message,
-                theme_text_color="Primary",
-                halign="left",
-                valign="top",
-                text_size=(None, None)
-            )
-            label.bind(texture_size=label.setter('size'))
-            content.add_widget(label)
-            
-            # Einfacher Dialog ohne veraltete Parameter
-            dialog = MDDialog()
-            dialog.title = title
-            dialog.content_cls = content
-            dialog.size_hint = (0.85, None)
-            dialog.height = "200dp"
-            
-            # Button hinzufügen
-            from kivymd.uix.button import MDButton, MDButtonText
-            ok_button = MDButton(
-                MDButtonText(text="OK"),
-                on_release=lambda x: dialog.dismiss()
-            )
-            dialog.add_widget(ok_button)
-            
             dialog.open()
-            
+
         except Exception as e:
             # Fallback: Nur Logger verwenden
             Logger.info(f"Dialog-Fallback - {title}: {message}")

--- a/views/setting_popup.py
+++ b/views/setting_popup.py
@@ -229,17 +229,19 @@ class AddSettingPopup(MDBoxLayout, BaseFileManagerMixin):
             self.close_file_manager()
 
     def show_error(self, message):
-        error_dialog = MDDialog(auto_dismiss=True)
-        error_dialog.size_hint = (0.85, None)
-        error_container = MDBoxLayout(orientation="vertical", padding="12dp", spacing="12dp")
-        label = MDLabel(text=message, halign="center")
-        error_container.add_widget(label)
-        btn_container = MDBoxLayout(orientation="horizontal", spacing="12dp",
-                                    size_hint_y=None, height="40dp")
-        btn_cancel = create_text_button("Schließen", lambda x: error_dialog.dismiss())
-        btn_container.add_widget(btn_cancel)
-        error_container.add_widget(btn_container)
-        error_dialog.add_widget(error_container)
+        error_dialog = MDDialog(
+            MDDialogHeadlineText(text="Fehler"),
+            MDDialogContentContainer(
+                MDLabel(text=message, halign="center"),
+                orientation="vertical",
+            ),
+            MDDialogButtonContainer(
+                create_text_button("Schließen", lambda x: error_dialog.dismiss()),
+                spacing="8dp",
+            ),
+            size_hint=(0.85, None),
+            auto_dismiss=True,
+        )
         error_dialog.open()
 
 class LoadSettingPopup(MDBoxLayout, BaseFileManagerMixin):
@@ -271,17 +273,19 @@ class LoadSettingPopup(MDBoxLayout, BaseFileManagerMixin):
                 self.popup.dismiss()
 
     def show_error(self, message, title="Fehler"):
-        error_dialog = MDDialog(auto_dismiss=True)
-        error_dialog.size_hint = (0.85, None)
-        error_container = MDBoxLayout(orientation="vertical", padding="12dp", spacing="12dp")
-        label = MDLabel(text=message, halign="center")
-        error_container.add_widget(label)
-        btn_container = MDBoxLayout(orientation="horizontal", spacing="12dp",
-                                    size_hint_y=None, height="40dp")
-        btn_cancel = create_text_button("Schließen", lambda x: error_dialog.dismiss())
-        btn_container.add_widget(btn_cancel)
-        error_container.add_widget(btn_container)
-        error_dialog.add_widget(error_container)
+        error_dialog = MDDialog(
+            MDDialogHeadlineText(text=title),
+            MDDialogContentContainer(
+                MDLabel(text=message, halign="center"),
+                orientation="vertical",
+            ),
+            MDDialogButtonContainer(
+                create_text_button("Schließen", lambda x: error_dialog.dismiss()),
+                spacing="8dp",
+            ),
+            size_hint=(0.85, None),
+            auto_dismiss=True,
+        )
         error_dialog.open()
 
 class DeleteSettingPopup(MDBoxLayout, BaseFileManagerMixin):
@@ -308,17 +312,19 @@ class DeleteSettingPopup(MDBoxLayout, BaseFileManagerMixin):
                 self.popup.dismiss()
 
     def show_error(self, message, title="Fehler"):
-        error_dialog = MDDialog(auto_dismiss=True)
-        error_dialog.size_hint = (0.85, None)
-        error_container = MDBoxLayout(orientation="vertical", padding="12dp", spacing="12dp")
-        label = MDLabel(text=message, halign="center")
-        error_container.add_widget(label)
-        btn_container = MDBoxLayout(orientation="horizontal", spacing="12dp",
-                                    size_hint_y=None, height="40dp")
-        btn_cancel = create_text_button("Schließen", lambda x: error_dialog.dismiss())
-        btn_container.add_widget(btn_cancel)
-        error_container.add_widget(btn_container)
-        error_dialog.add_widget(error_container)
+        error_dialog = MDDialog(
+            MDDialogHeadlineText(text=title),
+            MDDialogContentContainer(
+                MDLabel(text=message, halign="center"),
+                orientation="vertical",
+            ),
+            MDDialogButtonContainer(
+                create_text_button("Schließen", lambda x: error_dialog.dismiss()),
+                spacing="8dp",
+            ),
+            size_hint=(0.85, None),
+            auto_dismiss=True,
+        )
         error_dialog.open()
 
 # Controller: Verknüpft die Dialoge (Views) mit dem Domain-Repository
@@ -352,38 +358,40 @@ class SettingDialogHandler:
     def open_load_setting_popup(self):
         popup_content = LoadSettingPopup(controller=self.controller)
         popup_content.repository = self.repository
-        container = MDBoxLayout(orientation="vertical", spacing="12dp", padding="12dp")
-        title_label = MDLabel(text="Setting laden", halign="center",
-                              font_style="Title", size_hint_y=None, height="40dp")
-        container.add_widget(title_label)
-        container.add_widget(popup_content)
-        btn_container = MDBoxLayout(orientation="horizontal", spacing="12dp",
-                                    size_hint_y=None, height="40dp")
-        btn_cancel = create_text_button("Abbrechen", lambda x: self.dialog.dismiss())
-        btn_container.add_widget(btn_cancel)
-        container.add_widget(btn_container)
-        self.dialog = MDDialog(auto_dismiss=False)
-        self.dialog.size_hint = (0.85, None)
-        self.dialog.add_widget(container)
+
+        self.dialog = MDDialog(
+            MDDialogHeadlineText(text="Setting laden"),
+            MDDialogContentContainer(
+                popup_content,
+                orientation="vertical",
+            ),
+            MDDialogButtonContainer(
+                create_text_button("Abbrechen", lambda x: self.dialog.dismiss()),
+                spacing="8dp",
+            ),
+            size_hint=(0.85, None),
+            auto_dismiss=False,
+        )
         popup_content.popup = self.dialog
         self.dialog.open()
 
     def open_delete_setting_popup(self):
         popup_content = DeleteSettingPopup(controller=self.controller)
         popup_content.repository = self.repository
-        container = MDBoxLayout(orientation="vertical", spacing="12dp", padding="12dp")
-        title_label = MDLabel(text="Setting löschen", halign="center",
-                              font_style="Title", size_hint_y=None, height="40dp")
-        container.add_widget(title_label)
-        container.add_widget(popup_content)
-        btn_container = MDBoxLayout(orientation="horizontal", spacing="12dp",
-                                    size_hint_y=None, height="40dp")
-        btn_cancel = create_text_button("Abbrechen", lambda x: self.dialog.dismiss())
-        btn_container.add_widget(btn_cancel)
-        container.add_widget(btn_container)
-        self.dialog = MDDialog(auto_dismiss=False)
-        self.dialog.size_hint = (0.85, None)
-        self.dialog.add_widget(container)
+
+        self.dialog = MDDialog(
+            MDDialogHeadlineText(text="Setting löschen"),
+            MDDialogContentContainer(
+                popup_content,
+                orientation="vertical",
+            ),
+            MDDialogButtonContainer(
+                create_text_button("Abbrechen", lambda x: self.dialog.dismiss()),
+                spacing="8dp",
+            ),
+            size_hint=(0.85, None),
+            auto_dismiss=False,
+        )
         popup_content.popup = self.dialog
         popup_content.show_file_manager_popup()  # Direktstart der Dateiauswahl
         self.dialog.open()


### PR DESCRIPTION
## Summary

- **Fix**: "Setting löschen" and "Setting laden" dialogs had overlapping title/content text on Android (as shown in the issue screenshot)
- **Root cause**: These dialogs used the old `MDDialog()` + `add_widget(container)` pattern, which doesn't integrate with KivyMD 2.0.1's internal layout system
- **Fix**: Refactored to use the proper KivyMD 2.0.1 API (`MDDialogHeadlineText`, `MDDialogContentContainer`, `MDDialogButtonContainer`), matching the pattern already used in `open_add_setting_popup`
- Also fixed the same issue in all `show_error()` methods in the setting popups and `_show_simple_dialog()` in `einstellungen_widget.py`

## Test plan

- [ ] Open "Setting löschen" dialog on Android — verify title and content text no longer overlap
- [ ] Open "Setting laden" dialog on Android — verify same
- [ ] Trigger an error in setting save/load/delete — verify error dialog displays correctly
- [ ] Verify dialogs still work correctly on desktop

https://claude.ai/code/session_01DpbARrnCrWBETtxXm1CSih