### PR TITLE
Fix Charakter/Setting versenden auf Android

### DIFF
--- a/build_fixes.py
+++ b/build_fixes.py
@@ -114,6 +114,65 @@ def fix_kivy_python3_compatibility():
     return fixed_any
 
 
+def fix_android_manifest_fileprovider():
+    """Fügt FileProvider-Deklaration in AndroidManifest.xml ein (für Datei-Versenden)."""
+    print("P4A Hook: Checking AndroidManifest.xml for FileProvider...")
+
+    platform_dir = Path(".buildozer/android/platform")
+    if not platform_dir.exists():
+        print("P4A Hook: Platform directory not found, skipping FileProvider fix")
+        return False
+
+    # AndroidManifest.xml in allen Build-Verzeichnissen suchen
+    manifest_files = list(platform_dir.glob("build-*/dists/*/src/main/AndroidManifest.xml"))
+    if not manifest_files:
+        # Alternativer Pfad
+        manifest_files = list(platform_dir.glob("build-*/dists/*/AndroidManifest.xml"))
+
+    if not manifest_files:
+        print("P4A Hook: No AndroidManifest.xml found, skipping FileProvider fix")
+        return False
+
+    fileprovider_xml = '''
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>'''
+
+    fixed_any = False
+    for manifest_file in manifest_files:
+        try:
+            with open(manifest_file, 'r') as f:
+                content = f.read()
+
+            if 'FileProvider' in content:
+                print(f"P4A Hook: FileProvider already present in {manifest_file.name}")
+                continue
+
+            # Vor </application> einfügen
+            if '</application>' in content:
+                content = content.replace(
+                    '</application>',
+                    f'{fileprovider_xml}\n    </application>'
+                )
+                with open(manifest_file, 'w') as f:
+                    f.write(content)
+                print(f"P4A Hook: FileProvider added to {manifest_file}")
+                fixed_any = True
+            else:
+                print(f"P4A Hook: </application> not found in {manifest_file}")
+
+        except Exception as e:
+            print(f"P4A Hook: Error fixing manifest {manifest_file}: {e}")
+
+    return fixed_any
+
+
 def fix_pyjnius_python3_compatibility():
     """Fix Python 3+ / Cython 3.x compatibility issues in ALL pyjnius .pxi files"""
     print("P4A Hook: Searching for pyjnius build directories...")
@@ -200,6 +259,7 @@ def before_apk_build(toolchain):
     print("P4A Hook (before_apk_build): Applying build fixes...")
     fix_kivy_python3_compatibility()
     fix_pyjnius_python3_compatibility()
+    fix_android_manifest_fileprovider()
 
 
 if __name__ == "__main__":

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -203,7 +203,8 @@ android.accept_sdk_license = True
 # 3) A directory, here 'legal_resources' must contain one or more directories, 
 # each of a resource kind:  drawable, xml, etc...
 # android.add_resources = legal_resources
-#android.add_resources =
+# FileProvider-Konfiguration fuer Datei-Versenden (Share-Intent)
+android.add_resources = res/xml/file_paths.xml:xml/file_paths.xml
 
 # (list) Gradle dependencies to add
 android.gradle_dependencies = androidx.core:core-ktx:1.15.0, androidx.core:core:1.6.0

--- a/res/xml/file_paths.xml
+++ b/res/xml/file_paths.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- App-internes Dateiverzeichnis (user_data_dir) -->
+    <files-path name="files" path="." />
+    <!-- Externes Dateiverzeichnis -->
+    <external-files-path name="external_files" path="." />
+    <!-- Cache-Verzeichnis -->
+    <cache-path name="cache" path="." />
+    <!-- Externes Cache-Verzeichnis (fuer temporaere Share-Dateien) -->
+    <external-cache-path name="external_cache" path="." />
+</paths>

--- a/utils/share_utils.py
+++ b/utils/share_utils.py
@@ -5,6 +5,7 @@ Unterstützt Android (Share-Intent) und Desktop (xdg-open / open / Explorer).
 """
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from kivy.logger import Logger
@@ -80,25 +81,81 @@ def get_mime_type(file_path):
     return mime_types.get(ext, '*/*')
 
 
+def _kopiere_in_share_verzeichnis(context, file_path):
+    """
+    Kopiert eine Datei in das externe Cache-Verzeichnis zum Teilen.
+
+    Dateien im internen App-Speicher sind für andere Apps nicht zugänglich.
+    Durch das Kopieren ins externe Cache-Verzeichnis wird der Zugriff ermöglicht.
+
+    Returns:
+        str: Pfad zur kopierten Datei im Share-Verzeichnis
+    """
+    cache_dir = context.getExternalCacheDir()
+    if cache_dir:
+        share_dir = os.path.join(cache_dir.getAbsolutePath(), 'share')
+    else:
+        # Fallback auf internen Cache
+        share_dir = os.path.join(context.getCacheDir().getAbsolutePath(), 'share')
+
+    os.makedirs(share_dir, exist_ok=True)
+    dest_path = os.path.join(share_dir, os.path.basename(file_path))
+    shutil.copy2(file_path, dest_path)
+    Logger.debug(f"Teilen: Datei kopiert nach {dest_path}")
+    return dest_path
+
+
+def _erzeuge_content_uri(context, file_path):
+    """
+    Erzeugt eine content:// URI für die Datei über FileProvider.
+
+    Falls FileProvider nicht konfiguriert ist (Manifest fehlt), wird als Fallback
+    StrictMode gelockert und eine file:// URI verwendet.
+
+    Returns:
+        Content-URI für die Datei
+    """
+    from jnius import autoclass
+
+    File = autoclass('java.io.File')
+    java_file = File(file_path)
+
+    # Versuch 1: FileProvider (bevorzugt, sicher)
+    try:
+        FileProvider = autoclass('androidx.core.content.FileProvider')
+        authority = context.getPackageName() + '.fileprovider'
+        content_uri = FileProvider.getUriForFile(context, authority, java_file)
+        Logger.debug(f"Teilen: FileProvider URI erzeugt für {os.path.basename(file_path)}")
+        return content_uri
+    except Exception as e:
+        Logger.warning(f"Teilen: FileProvider nicht verfügbar ({e}), verwende Fallback")
+
+    # Versuch 2: StrictMode lockern und file:// URI verwenden
+    # Notwendig auf Android 7+ (API 24+) wenn FileProvider nicht im Manifest konfiguriert ist
+    try:
+        StrictMode = autoclass('android.os.StrictMode')
+        Builder = autoclass('android.os.StrictMode$VmPolicy$Builder')
+        StrictMode.setVmPolicy(Builder().build())
+        Logger.debug("Teilen: StrictMode VmPolicy gelockert für file:// URI")
+    except Exception as e:
+        Logger.warning(f"Teilen: StrictMode konnte nicht angepasst werden: {e}")
+
+    Uri = autoclass('android.net.Uri')
+    return Uri.fromFile(java_file)
+
+
 def _share_on_android(file_path, mime_type, title):
     """Teilt eine Datei über Android Share-Intent mit FileProvider."""
     from jnius import autoclass
 
     Intent = autoclass('android.content.Intent')
-    File = autoclass('java.io.File')
     PythonActivity = autoclass('org.kivy.android.PythonActivity')
 
     context = PythonActivity.mActivity
-    java_file = File(file_path)
 
-    # FileProvider für sichere URI-Erzeugung verwenden
-    try:
-        FileProvider = autoclass('androidx.core.content.FileProvider')
-        authority = context.getPackageName() + '.fileprovider'
-        content_uri = FileProvider.getUriForFile(context, authority, java_file)
-    except Exception:
-        Uri = autoclass('android.net.Uri')
-        content_uri = Uri.fromFile(java_file)
+    # Datei ins teilbare Verzeichnis kopieren
+    share_path = _kopiere_in_share_verzeichnis(context, file_path)
+    content_uri = _erzeuge_content_uri(context, share_path)
 
     intent = Intent(Intent.ACTION_SEND)
     intent.setType(mime_type)
@@ -118,7 +175,6 @@ def _share_multiple_on_android(file_paths, mime_type, title):
     from jnius import autoclass
 
     Intent = autoclass('android.content.Intent')
-    File = autoclass('java.io.File')
     ArrayList = autoclass('java.util.ArrayList')
     PythonActivity = autoclass('org.kivy.android.PythonActivity')
 
@@ -126,14 +182,9 @@ def _share_multiple_on_android(file_paths, mime_type, title):
     uris = ArrayList()
 
     for file_path in file_paths:
-        java_file = File(file_path)
-        try:
-            FileProvider = autoclass('androidx.core.content.FileProvider')
-            authority = context.getPackageName() + '.fileprovider'
-            content_uri = FileProvider.getUriForFile(context, authority, java_file)
-        except Exception:
-            Uri = autoclass('android.net.Uri')
-            content_uri = Uri.fromFile(java_file)
+        # Jede Datei ins teilbare Verzeichnis kopieren
+        share_path = _kopiere_in_share_verzeichnis(context, file_path)
+        content_uri = _erzeuge_content_uri(context, share_path)
         uris.add(content_uri)
 
     intent = Intent(Intent.ACTION_SEND_MULTIPLE)


### PR DESCRIPTION
## Summary

- **Root cause:** On Android 7+ (API 24+), sharing files via `Uri.fromFile()` throws `FileUriExposedException`. The code tried `FileProvider` first but it wasn't declared in the Android manifest, so the fallback to `file://` URI also failed.
- **Fix:** Three-layer approach:
  1. Files are now copied to the external cache directory before sharing (internal app storage is inaccessible to other apps)
  2. `FileProvider` is properly configured: `file_paths.xml` resource + p4a build hook injects the `<provider>` declaration into `AndroidManifest.xml`
  3. `StrictMode` fallback relaxes `VmPolicy` if `FileProvider` is still unavailable (e.g. on older builds without manifest changes)

## Changed files

- `res/xml/file_paths.xml` — new FileProvider path configuration
- `buildozer.spec` — adds `file_paths.xml` as Android resource
- `build_fixes.py` — p4a hook injects FileProvider into AndroidManifest.xml during build
- `utils/share_utils.py` — refactored sharing logic with copy-to-cache + FileProvider + StrictMode fallback

## Test plan

- [ ] Build new APK with `buildozer android debug`
- [ ] Verify "Char versenden" opens Android share dialog with JSON file
- [ ] Verify "Setting versenden" opens Android share dialog with setting JSON
- [ ] Verify sharing multiple files (JSON + PDF) works via "Char versenden"
- [ ] Verify desktop sharing still opens file manager

https://claude.ai/code/session_01V8YzGKmA93pxvZnBwaRsvq