### PR TITLE
Fix: Abbrechen-Button im HTML-Dialog reagiert nicht

### DIFF
--- a/manager/html_manager.py
+++ b/manager/html_manager.py
@@ -59,11 +59,14 @@ class HTMLManager:
 
     def _create_html_options_content(self, exists, existing_name, existing_path):
         """Erstellt den Inhalt für den HTML-Options-Dialog"""
+        # Höhe anpassen: mit existierender HTML brauchen wir mehr Platz
+        # für Info-Label und Überschreiben-Button
+        content_height = dp(260) if exists else dp(200)
         content = MDBoxLayout(
             orientation='vertical',
             spacing=dp(16),
             size_hint_y=None,
-            height=dp(200),
+            height=content_height,
             padding=dp(16)
         )
 
@@ -90,12 +93,13 @@ class HTMLManager:
 
         content.add_widget(checkbox_container)
 
-        # Buttons
+        # Buttons - bei zwei Buttons mehr Höhe benötigt
+        buttons_height = dp(100) if exists else dp(52)
         buttons_container = MDBoxLayout(
             orientation='vertical',
             spacing=dp(12),
             size_hint_y=None,
-            height=dp(100)
+            height=buttons_height
         )
 
         if exists:


### PR DESCRIPTION
## Summary

- **Bug:** Wenn eine bestehende HTML-Datei erkannt wurde, überdeckte der überlaufende Dialog-Content den "Abbrechen"-Button, sodass Touch-Events blockiert wurden
- **Ursache:** Die Content-Höhe war fix auf `dp(200)` gesetzt, aber bei `exists=True` kamen Info-Label + Überschreiben-Button hinzu (benötigt ~`dp(242)`)
- **Fix:** Content-Höhe dynamisch anpassen (`dp(260)` bei existierender HTML, `dp(200)` sonst) und Buttons-Container-Höhe passend zur Anzahl der Buttons setzen

## Test plan

- [ ] HTML-Charakterbogen erstellen, wenn bereits eine HTML-Datei existiert → Dialog mit "Bestehende HTML überschreiben" und "Als neue HTML speichern..." erscheint
- [ ] "Abbrechen"-Button klicken → Dialog schließt sich korrekt
- [ ] Auf Android testen: Abbrechen-Button ist sichtbar und reagiert auf Touch

https://claude.ai/code/session_01RzkpMTctpceUHJYvPpfwYm