### PR TITLE
Fix: Settings-Dateimanager Pfad/Button auf Android abgeschnitten

### DIFF
--- a/utils/custom_filemanager.py
+++ b/utils/custom_filemanager.py
@@ -33,8 +33,9 @@ class CustomFileManager(MDFileManager):
                 grid = rv.children[0]  # RecycleGridLayout
                 # Kivy padding: [left, top, right, bottom]
                 # Standard ist "10dp" (alle Seiten gleich)
-                # Bottom auf 80dp setzen (FAB dp(72) + Puffer)
-                grid.padding = [dp(10), dp(10), dp(10), dp(80)]
+                # Top auf 20dp für Pfadanzeige-Abstand, Bottom auf 100dp
+                # (FAB dp(72) + Navigationsleiste + Puffer)
+                grid.padding = [dp(10), dp(20), dp(10), dp(100)]
                 Logger.info("CustomFileManager: Android Bottom-Padding gesetzt")
         except Exception as e:
             Logger.warning(f"CustomFileManager: Bottom-Padding konnte nicht gesetzt werden: {e}")
@@ -48,7 +49,7 @@ class CustomFileManager(MDFileManager):
             # Standard KivyMD setzt y=dp(12), was verdeckt wird
             fab_y = dp(12)
             if platform == 'android':
-                fab_y = dp(72)
+                fab_y = dp(88)
 
             self.selection_button = MDFabButton(
                 on_release=self.select_directory_on_press_button,

--- a/views/setting_popup.py
+++ b/views/setting_popup.py
@@ -28,7 +28,7 @@ from kivymd.uix.dialog import (
     MDDialog, MDDialogHeadlineText, MDDialogContentContainer,
     MDDialogButtonContainer
 )
-from kivymd.uix.filemanager import MDFileManager
+from utils.custom_filemanager import CustomFileManager
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.label import MDLabel
 from kivymd.uix.button import MDButton, MDButtonText
@@ -184,7 +184,7 @@ class BaseFileManagerMixin:
     file_manager = None
 
     def open_file_manager(self, settings_dir, select_callback):
-        self.file_manager = MDFileManager(
+        self.file_manager = CustomFileManager(
             exit_manager=self.close_file_manager,
             select_path=select_callback,
             ext=[".json"],


### PR DESCRIPTION
## Summary

- **Settings-Dateimanager nutzt jetzt `CustomFileManager`** statt den Standard `MDFileManager` — damit greifen die Android-spezifischen Padding- und FAB-Anpassungen auch beim Laden/Speichern/Löschen von Settings
- **Bottom-Padding erhöht** (`dp(80)` → `dp(100)`), damit die letzten Listeneinträge nicht hinter dem FAB und der Android-Navigationsleiste verschwinden
- **Top-Padding erhöht** (`dp(10)` → `dp(20)`) für bessere Sichtbarkeit der Pfadanzeige
- **FAB-Button höher positioniert** (`dp(72)` → `dp(88)`) für mehr Abstand zur Navigationsleiste

## Ursache

`BaseFileManagerMixin` in `setting_popup.py` erstellte einen einfachen `MDFileManager`, der keine Android-Anpassungen hat. Der `CustomFileManager` (bereits in `file_manager_service.py` für Charakter-Dateien verwendet) enthält diese Fixes bereits — wurde aber für Settings nicht genutzt.

## Test plan

- [ ] App auf Android starten, Settings laden → Pfadanzeige oben vollständig sichtbar
- [ ] Bestätigungs-Button (Häkchen) nicht von Navigationsleiste verdeckt
- [ ] Letzte Einträge in der Dateiliste sichtbar und nicht hinter FAB versteckt
- [ ] Desktop-Verhalten unverändert (FAB bleibt bei `dp(12)`)

https://claude.ai/code/session_01U7HEnLKZnm3gtZR4ovESV2