### PR TITLE
Reduce font sizes in mobile views for improved layout

### DIFF
--- a/views/ausruestung_view_mobile.kv
+++ b/views/ausruestung_view_mobile.kv
@@ -152,7 +152,7 @@
 
         MDLabel:
             text: root.name
-            font_size: dp(13)
+            font_size: dp(11)
             bold: True
             halign: 'left'
             valign: 'middle'
@@ -163,7 +163,7 @@
 
         MDLabel:
             text: f"{root.kategorie.capitalize() if root.kategorie else '?'} | {root.gewicht}kg | {root.kosten}{root.waehrungseinheit} | x{root.menge}"
-            font_size: dp(10)
+            font_size: dp(9)
             theme_text_color: "Secondary"
             halign: 'left'
             valign: 'middle'

--- a/views/handicaps_view_mobile.kv
+++ b/views/handicaps_view_mobile.kv
@@ -107,7 +107,7 @@
     # Name - responsiv mit Obergrenze
     MDLabel:
         text: root.handicap_name
-        font_size: dp(13)
+        font_size: dp(11)
         size_hint_x: None
         width: min(dp(250), self.parent.width - dp(230)) if self.parent else dp(200)
         halign: 'left'
@@ -119,7 +119,7 @@
     # Stufe kompakt
     MDLabel:
         text: root.stufe.capitalize() if root.stufe else "?"
-        font_size: dp(11)
+        font_size: dp(9)
         size_hint_x: None
         width: dp(58)
         halign: 'center'

--- a/views/maechte_view_mobile.kv
+++ b/views/maechte_view_mobile.kv
@@ -111,7 +111,7 @@
     # Name - responsiv mit Obergrenze
     MDLabel:
         text: root.macht_name
-        font_size: dp(13)
+        font_size: dp(11)
         size_hint_x: None
         width: min(dp(260), self.parent.width - dp(220)) if self.parent else dp(200)
         halign: 'left'
@@ -123,7 +123,7 @@
     # Rang kompakt
     MDLabel:
         text: root.rang
-        font_size: dp(11)
+        font_size: dp(9)
         size_hint_x: None
         width: dp(16)
         halign: 'center'

--- a/views/talente_view_mobile.kv
+++ b/views/talente_view_mobile.kv
@@ -146,7 +146,7 @@
     # Name - responsiv mit Obergrenze
     MDLabel:
         text: root.talent_name
-        font_size: dp(13)
+        font_size: dp(11)
         size_hint_x: None
         width: min(dp(260), self.parent.width - dp(220)) if self.parent else dp(200)
         halign: 'left'
@@ -158,7 +158,7 @@
     # Kategorie - breiter im Landscape
     MDLabel:
         text: root.kategorie
-        font_size: dp(11)
+        font_size: dp(9)
         size_hint_x: None
         width: dp(70) if (self.parent and self.parent.width > dp(400)) else dp(44)
         halign: 'left'
@@ -170,7 +170,7 @@
     # Rang kompakt
     MDLabel:
         text: root.rang
-        font_size: dp(11)
+        font_size: dp(9)
         size_hint_x: None
         width: dp(18)
         halign: 'center'


### PR DESCRIPTION
## Summary
This PR reduces font sizes across multiple mobile view components to improve layout density and visual hierarchy on mobile devices.

## Key Changes
- **talente_view_mobile.kv**: Reduced primary label from 13dp to 11dp, secondary labels from 11dp to 9dp
- **ausruestung_view_mobile.kv**: Reduced item name from 13dp to 11dp, item details from 10dp to 9dp
- **handicaps_view_mobile.kv**: Reduced handicap name from 13dp to 11dp, level indicator from 11dp to 9dp
- **maechte_view_mobile.kv**: Reduced power name from 13dp to 11dp, rank indicator from 11dp to 9dp

## Implementation Details
The changes follow a consistent pattern:
- Primary/main content labels: 13dp → 11dp (2dp reduction)
- Secondary/metadata labels: 11dp → 9dp (2dp reduction)
- This creates a clearer visual hierarchy while maintaining readability on mobile screens
- All changes are applied uniformly across talent, equipment, handicap, and power list items

https://claude.ai/code/session_01J21sWomcWym4U4twH952uu