### PR TITLE
Add "Arm" to non-duplicable handicaps list

### DIFF
--- a/config/handicap_config.json
+++ b/config/handicap_config.json
@@ -51,6 +51,7 @@
   },
   "nicht_duplizierbare_handicaps": [
     "Alt",
+    "Arm",
     "Jung",
     "Blind",
     "Einarmig",

--- a/functions/handicap_funktionen.py
+++ b/functions/handicap_funktionen.py
@@ -94,7 +94,7 @@ class HandicapManager:
                 "standard_fertigkeitssteigerungen": 12
             },
             "nicht_duplizierbare_handicaps": [
-                "Alt", "Jung", "Blind", "Einarmig", "Einäugig", 
+                "Alt", "Arm", "Jung", "Blind", "Einarmig", "Einäugig",
                 "Stumm", "Analphabet", "Klein", "Fettleibig", "Langsam"
             ]
         }

--- a/views/handicaps_view.py
+++ b/views/handicaps_view.py
@@ -112,7 +112,7 @@ class HandicapItemRow(MDBoxLayout):
     ausgewaehlt = BooleanProperty(False)
 
     NICHT_DUPLIZIERBARE_HANDICAPS = [
-        "Alt", "Jung", "Blind", "Einarmig", "Einäugig", "Stumm", 
+        "Alt", "Arm", "Jung", "Blind", "Einarmig", "Einäugig", "Stumm",
         "Analphabet", "Klein", "Fettleibig", "Langsam"
     ]
 


### PR DESCRIPTION
## Summary
This PR adds "Arm" to the list of handicaps that cannot be duplicated in character creation, ensuring consistent validation across the application.

## Key Changes
- Added "Arm" to the `nicht_duplizierbare_handicaps` list in `functions/handicap_funktionen.py`
- Added "Arm" to the `NICHT_DUPLIZIERBARE_HANDICAPS` constant in `views/handicaps_view.py`
- Added "Arm" to the `nicht_duplizierbare_handicaps` array in `config/handicap_config.json`

## Implementation Details
The "Arm" handicap is now properly registered as a non-duplicable handicap across all three configuration sources, maintaining consistency between the backend logic, UI layer, and configuration file. This prevents players from selecting the "Arm" handicap multiple times during character creation.

https://claude.ai/code/session_01VSakvnaRXZc9eziB6hGdME