### PR TITLE
Add ScrollView to mobile profile layout and fix keyboard handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,6 +166,12 @@ class SW_Charakter_GeneratorApp(MDApp):
         ]
 
     def build(self):
+        # Auf Android: Fenster automatisch verschieben, damit die Tastatur
+        # das fokussierte Textfeld nicht überdeckt
+        from kivy.utils import platform as _platform
+        if _platform == 'android':
+            Window.softinput_mode = 'below_target'
+
         # KORRIGIERT: Theme aus Config laden (Service Container ist bereits initialisiert)
         self.load_theme_from_config()
         return self.load_main_kv()

--- a/views/profil_view_mobile.kv
+++ b/views/profil_view_mobile.kv
@@ -1,128 +1,135 @@
 # profil_view_mobile.kv - Smartphone-optimiertes Layout
 # Labels als Überschriften ÜBER den TextFields statt daneben
-# Kein ScrollView - verhindert Touch-Probleme mit TextFields auf Android
+# ScrollView ermöglicht Scrollen wenn die Tastatur Felder nach oben verschiebt
+# (softinput_mode='below_target' in main.py sorgt dafür, dass das fokussierte Feld sichtbar bleibt)
 # Gleiche Widget-Klasse und IDs wie Desktop-Version
 
 <ProfilWidget>:
     orientation: 'vertical'
     md_bg_color: self.theme_cls.backgroundColor
 
-    MDBoxLayout:
-        orientation: 'vertical'
-        size_hint: (1, 1)
-        padding: [dp(12), dp(8), dp(12), dp(12)]
-        spacing: dp(6)
+    ScrollView:
+        do_scroll_x: False
+        bar_width: dp(4)
 
-        # Name
         MDBoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: self.minimum_height
-            spacing: dp(2)
+            padding: [dp(12), dp(8), dp(12), dp(12)]
+            spacing: dp(6)
 
-            MDLabel:
-                text: "Name:"
+            # Name
+            MDBoxLayout:
+                orientation: 'vertical'
                 size_hint_y: None
-                height: dp(24)
-                halign: 'left'
-                theme_text_color: "Primary"
-                font_size: dp(13)
+                height: self.minimum_height
+                spacing: dp(2)
 
-            MDTextField:
-                id: name_input
-                hint_text: "Name eingeben"
-                size_hint_x: 1
-                text: root.char_name
-                on_text: root.on_char_name_change(root, self.text)
+                MDLabel:
+                    text: "Name:"
+                    size_hint_y: None
+                    height: dp(24)
+                    halign: 'left'
+                    theme_text_color: "Primary"
+                    font_size: dp(13)
 
-        # Alter
-        MDBoxLayout:
-            orientation: 'vertical'
-            size_hint_y: None
-            height: self.minimum_height
-            spacing: dp(2)
+                MDTextField:
+                    id: name_input
+                    hint_text: "Name eingeben"
+                    size_hint_x: 1
+                    text: root.char_name
+                    on_text: root.on_char_name_change(root, self.text)
 
-            MDLabel:
-                text: "Alter:"
+            # Alter
+            MDBoxLayout:
+                orientation: 'vertical'
                 size_hint_y: None
-                height: dp(24)
-                halign: 'left'
-                theme_text_color: "Primary"
-                font_size: dp(13)
+                height: self.minimum_height
+                spacing: dp(2)
 
-            MDTextField:
-                id: alter_input
-                hint_text: "Alter eingeben"
-                size_hint_x: 1
-                text: root.alter
-                on_text: root.on_alter_change(root, self.text)
+                MDLabel:
+                    text: "Alter:"
+                    size_hint_y: None
+                    height: dp(24)
+                    halign: 'left'
+                    theme_text_color: "Primary"
+                    font_size: dp(13)
 
-        # Geschlecht
-        MDBoxLayout:
-            orientation: 'vertical'
-            size_hint_y: None
-            height: self.minimum_height
-            spacing: dp(2)
+                MDTextField:
+                    id: alter_input
+                    hint_text: "Alter eingeben"
+                    size_hint_x: 1
+                    text: root.alter
+                    on_text: root.on_alter_change(root, self.text)
 
-            MDLabel:
-                text: "Geschlecht:"
+            # Geschlecht
+            MDBoxLayout:
+                orientation: 'vertical'
                 size_hint_y: None
-                height: dp(24)
-                halign: 'left'
-                theme_text_color: "Primary"
-                font_size: dp(13)
+                height: self.minimum_height
+                spacing: dp(2)
 
-            MDTextField:
-                id: geschlecht_input
-                hint_text: "Geschlecht eingeben"
-                size_hint_x: 1
-                text: root.geschlecht
-                on_text: root.on_geschlecht_change(root, self.text)
+                MDLabel:
+                    text: "Geschlecht:"
+                    size_hint_y: None
+                    height: dp(24)
+                    halign: 'left'
+                    theme_text_color: "Primary"
+                    font_size: dp(13)
 
-        # Konzept
-        MDBoxLayout:
-            orientation: 'vertical'
-            size_hint_y: None
-            height: self.minimum_height
-            spacing: dp(2)
+                MDTextField:
+                    id: geschlecht_input
+                    hint_text: "Geschlecht eingeben"
+                    size_hint_x: 1
+                    text: root.geschlecht
+                    on_text: root.on_geschlecht_change(root, self.text)
 
-            MDLabel:
-                text: "Konzept:"
+            # Konzept
+            MDBoxLayout:
+                orientation: 'vertical'
                 size_hint_y: None
-                height: dp(24)
-                halign: 'left'
-                theme_text_color: "Primary"
-                font_size: dp(13)
+                height: self.minimum_height
+                spacing: dp(2)
 
-            MDTextField:
-                id: konzept_input
-                hint_text: "Konzept eingeben"
-                size_hint_x: 1
-                text: root.konzept
-                on_text: root.on_konzept_change(root, self.text)
+                MDLabel:
+                    text: "Konzept:"
+                    size_hint_y: None
+                    height: dp(24)
+                    halign: 'left'
+                    theme_text_color: "Primary"
+                    font_size: dp(13)
 
-        # Sprachen
-        MDBoxLayout:
-            orientation: 'vertical'
-            size_hint_y: None
-            height: self.minimum_height
-            spacing: dp(2)
+                MDTextField:
+                    id: konzept_input
+                    hint_text: "Konzept eingeben"
+                    size_hint_x: 1
+                    text: root.konzept
+                    on_text: root.on_konzept_change(root, self.text)
 
-            MDLabel:
-                text: "Sprachen:"
+            # Sprachen
+            MDBoxLayout:
+                orientation: 'vertical'
                 size_hint_y: None
-                height: dp(24)
-                halign: 'left'
-                theme_text_color: "Primary"
-                font_size: dp(13)
+                height: self.minimum_height
+                spacing: dp(2)
 
-            MDTextField:
-                id: sprachen_input
-                hint_text: "Sprachen eingeben"
-                size_hint_x: 1
-                text: root.sprachen
-                on_text: root.on_sprachen_change(root, self.text)
+                MDLabel:
+                    text: "Sprachen:"
+                    size_hint_y: None
+                    height: dp(24)
+                    halign: 'left'
+                    theme_text_color: "Primary"
+                    font_size: dp(13)
 
-        # Spacer - drückt alle Felder nach oben
-        Widget:
-            size_hint_y: 1
+                MDTextField:
+                    id: sprachen_input
+                    hint_text: "Sprachen eingeben"
+                    size_hint_x: 1
+                    text: root.sprachen
+                    on_text: root.on_sprachen_change(root, self.text)
+
+            # Spacer - Mindesthöhe damit ScrollView korrekt funktioniert
+            Widget:
+                size_hint_y: None
+                height: dp(20)


### PR DESCRIPTION
## Summary
Improved mobile profile view usability by adding a ScrollView to handle content overflow when the soft keyboard appears, and configured Android to automatically adjust the window position to keep focused text fields visible.

## Key Changes
- **Mobile Layout Enhancement**: Wrapped the profile form fields in a ScrollView to enable scrolling when the soft keyboard pushes content upward
- **Android Keyboard Handling**: Added `Window.softinput_mode = 'below_target'` configuration in `main.py` to automatically shift the window so the focused text field remains visible above the keyboard
- **Layout Restructuring**: Adjusted the spacing and widget hierarchy in `profil_view_mobile.kv` to work properly with the ScrollView
- **Spacer Adjustment**: Changed the bottom spacer from flexible sizing (`size_hint_y: 1`) to fixed height (`dp(20)`) to work correctly with ScrollView's minimum_height calculation

## Implementation Details
- The ScrollView is configured with `do_scroll_x: False` to only allow vertical scrolling
- The `softinput_mode = 'below_target'` setting is applied only on Android platform to avoid affecting other platforms
- Updated comments in the KV file to reflect the new ScrollView-based approach and explain the keyboard handling strategy
- All widget IDs and structure remain consistent with the desktop version for code reusability

https://claude.ai/code/session_01VRyjFYPpQyASRSGQnEusu3