### PR TITLE
Fix: Tastatur überdeckt Textfelder auf Android nicht mehr

### DIFF
--- a/views/profil_view_mobile.kv
+++ b/views/profil_view_mobile.kv
@@ -1,135 +1,129 @@
 # profil_view_mobile.kv - Smartphone-optimiertes Layout
 # Labels als Überschriften ÜBER den TextFields statt daneben
-# ScrollView ermöglicht Scrollen wenn die Tastatur Felder nach oben verschiebt
-# (softinput_mode='below_target' in main.py sorgt dafür, dass das fokussierte Feld sichtbar bleibt)
+# Kein ScrollView - verhindert Touch-Probleme mit TextFields auf Android
+# softinput_mode='below_target' in main.py sorgt dafür, dass das fokussierte Feld sichtbar bleibt
 # Gleiche Widget-Klasse und IDs wie Desktop-Version
 
 <ProfilWidget>:
     orientation: 'vertical'
     md_bg_color: self.theme_cls.backgroundColor
 
-    ScrollView:
-        do_scroll_x: False
-        bar_width: dp(4)
+    MDBoxLayout:
+        orientation: 'vertical'
+        size_hint: (1, 1)
+        padding: [dp(12), dp(8), dp(12), dp(12)]
+        spacing: dp(6)
 
+        # Name
         MDBoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: self.minimum_height
-            padding: [dp(12), dp(8), dp(12), dp(12)]
-            spacing: dp(6)
+            spacing: dp(2)
 
-            # Name
-            MDBoxLayout:
-                orientation: 'vertical'
+            MDLabel:
+                text: "Name:"
                 size_hint_y: None
-                height: self.minimum_height
-                spacing: dp(2)
+                height: dp(24)
+                halign: 'left'
+                theme_text_color: "Primary"
+                font_size: dp(13)
 
-                MDLabel:
-                    text: "Name:"
-                    size_hint_y: None
-                    height: dp(24)
-                    halign: 'left'
-                    theme_text_color: "Primary"
-                    font_size: dp(13)
+            MDTextField:
+                id: name_input
+                hint_text: "Name eingeben"
+                size_hint_x: 1
+                text: root.char_name
+                on_text: root.on_char_name_change(root, self.text)
 
-                MDTextField:
-                    id: name_input
-                    hint_text: "Name eingeben"
-                    size_hint_x: 1
-                    text: root.char_name
-                    on_text: root.on_char_name_change(root, self.text)
+        # Alter
+        MDBoxLayout:
+            orientation: 'vertical'
+            size_hint_y: None
+            height: self.minimum_height
+            spacing: dp(2)
 
-            # Alter
-            MDBoxLayout:
-                orientation: 'vertical'
+            MDLabel:
+                text: "Alter:"
                 size_hint_y: None
-                height: self.minimum_height
-                spacing: dp(2)
+                height: dp(24)
+                halign: 'left'
+                theme_text_color: "Primary"
+                font_size: dp(13)
 
-                MDLabel:
-                    text: "Alter:"
-                    size_hint_y: None
-                    height: dp(24)
-                    halign: 'left'
-                    theme_text_color: "Primary"
-                    font_size: dp(13)
+            MDTextField:
+                id: alter_input
+                hint_text: "Alter eingeben"
+                size_hint_x: 1
+                text: root.alter
+                on_text: root.on_alter_change(root, self.text)
 
-                MDTextField:
-                    id: alter_input
-                    hint_text: "Alter eingeben"
-                    size_hint_x: 1
-                    text: root.alter
-                    on_text: root.on_alter_change(root, self.text)
+        # Geschlecht
+        MDBoxLayout:
+            orientation: 'vertical'
+            size_hint_y: None
+            height: self.minimum_height
+            spacing: dp(2)
 
-            # Geschlecht
-            MDBoxLayout:
-                orientation: 'vertical'
+            MDLabel:
+                text: "Geschlecht:"
                 size_hint_y: None
-                height: self.minimum_height
-                spacing: dp(2)
+                height: dp(24)
+                halign: 'left'
+                theme_text_color: "Primary"
+                font_size: dp(13)
 
-                MDLabel:
-                    text: "Geschlecht:"
-                    size_hint_y: None
-                    height: dp(24)
-                    halign: 'left'
-                    theme_text_color: "Primary"
-                    font_size: dp(13)
+            MDTextField:
+                id: geschlecht_input
+                hint_text: "Geschlecht eingeben"
+                size_hint_x: 1
+                text: root.geschlecht
+                on_text: root.on_geschlecht_change(root, self.text)
 
-                MDTextField:
-                    id: geschlecht_input
-                    hint_text: "Geschlecht eingeben"
-                    size_hint_x: 1
-                    text: root.geschlecht
-                    on_text: root.on_geschlecht_change(root, self.text)
+        # Konzept
+        MDBoxLayout:
+            orientation: 'vertical'
+            size_hint_y: None
+            height: self.minimum_height
+            spacing: dp(2)
 
-            # Konzept
-            MDBoxLayout:
-                orientation: 'vertical'
+            MDLabel:
+                text: "Konzept:"
                 size_hint_y: None
-                height: self.minimum_height
-                spacing: dp(2)
+                height: dp(24)
+                halign: 'left'
+                theme_text_color: "Primary"
+                font_size: dp(13)
 
-                MDLabel:
-                    text: "Konzept:"
-                    size_hint_y: None
-                    height: dp(24)
-                    halign: 'left'
-                    theme_text_color: "Primary"
-                    font_size: dp(13)
+            MDTextField:
+                id: konzept_input
+                hint_text: "Konzept eingeben"
+                size_hint_x: 1
+                text: root.konzept
+                on_text: root.on_konzept_change(root, self.text)
 
-                MDTextField:
-                    id: konzept_input
-                    hint_text: "Konzept eingeben"
-                    size_hint_x: 1
-                    text: root.konzept
-                    on_text: root.on_konzept_change(root, self.text)
+        # Sprachen
+        MDBoxLayout:
+            orientation: 'vertical'
+            size_hint_y: None
+            height: self.minimum_height
+            spacing: dp(2)
 
-            # Sprachen
-            MDBoxLayout:
-                orientation: 'vertical'
+            MDLabel:
+                text: "Sprachen:"
                 size_hint_y: None
-                height: self.minimum_height
-                spacing: dp(2)
+                height: dp(24)
+                halign: 'left'
+                theme_text_color: "Primary"
+                font_size: dp(13)
 
-                MDLabel:
-                    text: "Sprachen:"
-                    size_hint_y: None
-                    height: dp(24)
-                    halign: 'left'
-                    theme_text_color: "Primary"
-                    font_size: dp(13)
+            MDTextField:
+                id: sprachen_input
+                hint_text: "Sprachen eingeben"
+                size_hint_x: 1
+                text: root.sprachen
+                on_text: root.on_sprachen_change(root, self.text)
 
-                MDTextField:
-                    id: sprachen_input
-                    hint_text: "Sprachen eingeben"
-                    size_hint_x: 1
-                    text: root.sprachen
-                    on_text: root.on_sprachen_change(root, self.text)
-
-            # Spacer - Mindesthöhe damit ScrollView korrekt funktioniert
-            Widget:
-                size_hint_y: None
-                height: dp(20)
+        # Spacer - drückt alle Felder nach oben
+        Widget:
+            size_hint_y: 1


### PR DESCRIPTION
## Summary

- Setzt `Window.softinput_mode = 'below_target'` in `build()` auf Android, damit das Fenster automatisch verschoben wird und das fokussierte Textfeld über der Tastatur sichtbar bleibt
- Betrifft alle Textfelder in der App: Popup-Dialoge (z.B. "Neues Volk hinzufügen") und Views (z.B. Profilansicht)

## Test plan

- [ ] Android-Build erstellen und auf einem Gerät testen
- [ ] Profil-Tab: Alle Textfelder (Name, Alter, Geschlecht, Konzept, Sprachen) antippen und prüfen, dass die Tastatur das Feld nicht überdeckt
- [ ] Popup-Dialoge mit Textfeldern öffnen (z.B. "Neues Volk hinzufügen") und prüfen, dass Felder bei Fokus sichtbar bleiben
- [ ] Sicherstellen, dass der Textfokus auf Android weiterhin korrekt funktioniert (kein ScrollView-Problem)

https://claude.ai/code/session_01VRyjFYPpQyASRSGQnEusu3