### PR TITLE
Add Linux system dependencies documentation for KivyMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,29 @@ source venv/bin/activate  # Linux/Mac
 venv\Scripts\activate     # Windows
 ```
 
-3. **Dependencies installieren:**
+3. **System-Abhängigkeiten installieren (Linux):**
+
+KivyMD benötigt `pycairo`, das C-Erweiterungen kompiliert. Dafür werden System-Pakete benötigt:
+
+```bash
+# Debian/Ubuntu:
+sudo apt-get install python3-dev libcairo2-dev libffi-dev pkg-config libjpeg-dev zlib1g-dev
+
+# Fedora/RHEL/CentOS:
+sudo dnf install python3-devel cairo-devel gcc pkg-config libjpeg-devel zlib-devel
+
+# Arch Linux:
+sudo pacman -S cairo pkgconf
+```
+
+4. **Dependencies installieren:**
 ```bash
 pip install -r requirements.txt
 ```
 
 **Hinweis zu KivyMD:** Die aktuelle KivyMD 2.0.1 Version wird direkt von GitHub installiert, da sie noch nicht offiziell auf PyPI verfügbar ist.
 
-4. **Anwendung starten:**
+5. **Anwendung starten:**
 ```bash
 python main.py
 ```
@@ -136,11 +151,22 @@ pip install kivy>=2.1.0
 pip install https://github.com/kivymd/KivyMD/archive/master.zip
 ```
 
-**Linux: "command 'gcc' failed"**
+**Linux: pycairo / "Python dependency not found" / "command 'gcc' failed"**
+
+KivyMD hängt von `pycairo` ab, das System-Bibliotheken zum Kompilieren benötigt:
+
 ```bash
-sudo apt-get install python3-dev libffi-dev
-sudo apt-get install libjpeg-dev zlib1g-dev  # für Pillow
+# Debian/Ubuntu:
+sudo apt-get install python3-dev libcairo2-dev libffi-dev pkg-config libjpeg-dev zlib1g-dev
+
+# Fedora/RHEL/CentOS:
+sudo dnf install python3-devel cairo-devel gcc pkg-config libjpeg-devel zlib-devel
+
+# Arch Linux:
+sudo pacman -S cairo pkgconf
 ```
+
+Danach erneut `pip install -r requirements.txt` ausführen.
 
 **Windows: "Microsoft Visual C++ 14.0 is required"**
 - Visual Studio Build Tools installieren oder

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,13 @@
 # Savage Worlds Charakter-Generator - Requirements
 # Python 3.8+ erforderlich
-# 
+#
 # Installation: pip install -r requirements.txt
+#
+# LINUX: System-Abhängigkeiten müssen VOR der Installation vorhanden sein!
+#   Debian/Ubuntu: sudo apt-get install python3-dev libcairo2-dev libffi-dev pkg-config
+#   Fedora/RHEL:   sudo dnf install python3-devel cairo-devel gcc pkg-config
+#   Arch Linux:    sudo pacman -S cairo pkgconf
+# Siehe README.md für Details.
 
 # =============================================================================
 # KERN-DEPENDENCIES


### PR DESCRIPTION
## Summary
This PR improves the setup documentation for Linux users by adding explicit instructions for installing system-level dependencies required by KivyMD, particularly `pycairo` and its build requirements.

## Key Changes
- **README.md**: 
  - Added new step 3 documenting required system packages for Linux (Debian/Ubuntu, Fedora/RHEL/CentOS, and Arch Linux)
  - Expanded troubleshooting section with detailed pycairo dependency resolution instructions for multiple Linux distributions
  - Renumbered subsequent setup steps (3→4, 4→5) to accommodate the new system dependencies section

- **requirements.txt**:
  - Added prominent comments at the top warning Linux users about system-level dependencies that must be installed before pip dependencies
  - Included quick reference commands for the three major Linux distribution families
  - Added reference to README.md for detailed information

## Implementation Details
The changes address a common installation issue where users on Linux systems encounter build failures when installing KivyMD because required C development libraries and headers are missing. By making these dependencies explicit and providing distribution-specific installation commands upfront, users can resolve issues before attempting the pip installation rather than debugging cryptic compilation errors afterward.

https://claude.ai/code/session_01BXdNsV5bGhpb15pC3tbgjC