### PR TITLE
Fix Android App Bar: höhere Touch-Ziele, schnellere Reaktion, Fingerdrift-Toleranz

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -97,7 +97,7 @@ MDScreen:
             id: tabs_container
             orientation: 'vertical'
             size_hint_y: None
-            height: dp(60)  # Höhe der Tabbar
+            height: dp(64)  # Höhe der Tabbar
             padding: [dp(4), 0, 0, 0]
             md_bg_color: app.theme_cls.backgroundColor
             MDTabsPrimary:

--- a/main.py
+++ b/main.py
@@ -1307,7 +1307,9 @@ class SW_Charakter_GeneratorApp(MDApp):
 
                 item.add_widget(icon)
                 item.add_widget(label)
-                item.bind(on_touch_up=self._on_bottom_nav_touch)
+                # on_touch_down statt on_touch_up: Bottom-Bar liegt NICHT in einem
+                # ScrollView, daher ist sofortige Reaktion möglich und zuverlässiger.
+                item.bind(on_touch_down=self._on_bottom_nav_touch)
 
                 bottom_nav_box.add_widget(item)
                 self._bottom_nav_items.append(item)
@@ -1342,7 +1344,7 @@ class SW_Charakter_GeneratorApp(MDApp):
 
             mehr_item.add_widget(mehr_icon)
             mehr_item.add_widget(mehr_label)
-            mehr_item.bind(on_touch_up=self._on_bottom_nav_touch)
+            mehr_item.bind(on_touch_down=self._on_bottom_nav_touch)
 
             bottom_nav_box.add_widget(mehr_item)
             self._bottom_nav_items.append(mehr_item)
@@ -1361,10 +1363,10 @@ class SW_Charakter_GeneratorApp(MDApp):
         if hasattr(touch, 'is_mouse_scrolling') and touch.is_mouse_scrolling:
             return False
 
-        # Debounce
+        # Debounce: 500ms (Android-Standard, verhindert Doppel-Taps)
         import time as _time
         now = _time.time()
-        if now - self._last_rail_touch_time < 0.3:
+        if now - self._last_rail_touch_time < 0.5:
             return True
         self._last_rail_touch_time = now
 
@@ -1667,7 +1669,9 @@ class SW_Charakter_GeneratorApp(MDApp):
         Scroll-Gesten verarbeiten kann (Android-Kompatibilität).
         """
         if not item.collide_point(*touch.pos):
-            return False
+            # Lenienter Fallback: Startposition prüfen (Android-Fingerdrift beim Loslassen)
+            if not item.collide_point(*touch.opos):
+                return False
 
         # Scroll-Gesten ignorieren (nur Taps verarbeiten)
         if hasattr(touch, 'is_mouse_scrolling') and touch.is_mouse_scrolling:
@@ -1675,10 +1679,10 @@ class SW_Charakter_GeneratorApp(MDApp):
         if touch.grab_current is not None and touch.grab_current is not item:
             return False
 
-        # Debounce: Doppelte Touch-Events innerhalb 300ms ignorieren
+        # Debounce: Doppelte Touch-Events innerhalb 500ms ignorieren
         import time as _time
         now = _time.time()
-        if now - self._last_rail_touch_time < 0.3:
+        if now - self._last_rail_touch_time < 0.5:
             return True
         self._last_rail_touch_time = now
 
@@ -1830,7 +1834,7 @@ class SW_Charakter_GeneratorApp(MDApp):
                     bottom_bar.opacity = 0
 
                 # Tabs zeigen
-                tabs_container.height = dp(60)
+                tabs_container.height = dp(64)
                 tabs_container.opacity = 1
 
                 # Content-Padding wiederherstellen
@@ -1932,8 +1936,9 @@ class SW_Charakter_GeneratorApp(MDApp):
                 nav_rail_container.opacity = 0
                 self._nav_rail_visible = False
                 if bottom_bar:
-                    # Höhe = Inhalt (56dp) + Platz für System-Navigationsleiste
-                    bottom_bar.height = dp(56) + self._android_bottom_padding
+                    # Höhe = Inhalt (64dp) + Platz für System-Navigationsleiste
+                    # 64dp statt 56dp für bessere Touch-Zielfläche auf Android
+                    bottom_bar.height = dp(64) + self._android_bottom_padding
                     bottom_bar.padding = [0, dp(4), 0, self._android_bottom_padding]
                     bottom_bar.opacity = 1
                 if pointbar:

--- a/views/pointbar_view.kv
+++ b/views/pointbar_view.kv
@@ -39,8 +39,8 @@
         id: toolbar
         orientation: 'horizontal'
         size_hint_y: None
-        height: dp(40)
-        padding: [dp(4), dp(2), dp(4), dp(2)]
+        height: dp(48)
+        padding: [dp(4), dp(4), dp(4), dp(4)]
         spacing: dp(2)
         md_bg_color: app.theme_cls.surfaceContainerColor
 
@@ -49,7 +49,7 @@
             icon: "chevron-down" if root.is_expanded else "chevron-right"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(40), dp(40)]
             pos_hint: {'center_y': 0.5}
             on_release: root.toggle_panel()
 
@@ -71,7 +71,7 @@
             icon: "undo"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(40), dp(40)]
             pos_hint: {'center_y': 0.5}
             disabled: not root.kann_undo
             opacity: 1 if root.kann_undo else 0.3
@@ -82,7 +82,7 @@
             icon: "content-save"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(40), dp(40)]
             pos_hint: {'center_y': 0.5}
             on_release: root.on_schnellspeichern()
 
@@ -91,7 +91,7 @@
             icon: "folder-open"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(40), dp(40)]
             pos_hint: {'center_y': 0.5}
             on_release: root.on_laden()
 
@@ -100,7 +100,7 @@
             icon: "check-circle" if root.char_gen_completed else "progress-wrench"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(40), dp(40)]
             pos_hint: {'center_y': 0.5}
             on_release: root.toggle_char_gen_completed()
 

--- a/views/pointbar_view_mobile.kv
+++ b/views/pointbar_view_mobile.kv
@@ -40,13 +40,15 @@
     md_bg_color: app.theme_cls.backgroundColor
 
     # ───── Toolbar (immer sichtbar) ─────
+    # Höhe dp(52): erfüllt Android-Mindestanforderung von 48dp Touch-Ziel
+    # mit je dp(4) Puffer oben/unten für zuverlässige Treffsicherheit
     MDBoxLayout:
         id: toolbar
         orientation: 'horizontal'
         size_hint_y: None
-        height: dp(40)
-        padding: [dp(4), dp(2), dp(4), dp(2)]
-        spacing: dp(2)
+        height: dp(52)
+        padding: [dp(4), dp(4), dp(4), dp(4)]
+        spacing: dp(4)
         md_bg_color: app.theme_cls.surfaceContainerColor
 
         # Chevron — klappt Detail-Bereich auf/zu
@@ -54,7 +56,7 @@
             icon: "chevron-down" if root.is_expanded else "chevron-right"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(44), dp(44)]
             pos_hint: {'center_y': 0.5}
             on_release: root.toggle_panel()
 
@@ -76,7 +78,7 @@
             icon: "undo"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(44), dp(44)]
             pos_hint: {'center_y': 0.5}
             disabled: not root.kann_undo
             opacity: 1 if root.kann_undo else 0.3
@@ -87,7 +89,7 @@
             icon: "content-save"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(44), dp(44)]
             pos_hint: {'center_y': 0.5}
             on_release: root.on_schnellspeichern()
 
@@ -96,7 +98,7 @@
             icon: "folder-open"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(44), dp(44)]
             pos_hint: {'center_y': 0.5}
             on_release: root.on_laden()
 
@@ -105,7 +107,7 @@
             icon: "check-circle" if root.char_gen_completed else "progress-wrench"
             style: "standard"
             size_hint: None, None
-            size: [dp(36), dp(36)]
+            size: [dp(44), dp(44)]
             pos_hint: {'center_y': 0.5}
             on_release: root.toggle_char_gen_completed()
 


### PR DESCRIPTION
- Bottom-Nav: on_touch_up → on_touch_down (kein ScrollView-Konflikt, sofortige Reaktion)
- Debounce in beiden Touch-Handlern von 300ms auf 500ms erhöht (Android-Standard)
- Rail-Touch: Fallback auf touch.opos bei Kollisionscheck (toliert Fingerdrift beim Loslassen)
- Bottom-Bar-Höhe von dp(56) auf dp(64) erhöht (größere Touch-Zielfläche)
- Tabs-Container-Höhe von dp(60) auf dp(64) erhöht (Desktop/Tablet)

https://claude.ai/code/session_01HnK4rPKhoNSRGZ7WXGFLsi