### PR TITLE
Fix Android: Pointbar in Widget-Hierarchie nach oben verschoben

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -89,6 +89,7 @@
 MDScreen:
     # Wir packen alles in eine einzige vertikale MDBoxLayout-Struktur
     MDBoxLayout:
+        id: outer_box
         orientation: 'vertical'
         md_bg_color: app.theme_cls.backgroundColor
 
@@ -103,6 +104,27 @@ MDScreen:
             MDTabsPrimary:
                 id: tabs_bar
                 # In "on_start" füllen wir hier MDTabsItem rein.
+
+        # ----------------- (1.5) POINTBAR + WIZARD BAR -----------------
+        # Direkt im äußeren Layout für zuverlässiges Touch-Handling
+        # auf Android (kürzerer Touch-Dispatch-Pfad).
+        MDBoxLayout:
+            id: pointbar_container
+            orientation: 'vertical'
+            size_hint_y: None
+            height: self.minimum_height
+            md_bg_color: app.theme_cls.backgroundColor
+
+            GenerationPointsBar:
+                id: generation_points
+                charakter: app.controller.charakter
+
+            # WIZARD BAR (wird bei Bedarf eingeblendet)
+            WizardBar:
+                id: wizard_bar
+                opacity: 0
+                height: 0
+                wizard_service: app.wizard_service
 
         # ----------------- (2) HORIZONTALES LAYOUT: NAV-RAIL + CONTENT -----------------
         MDBoxLayout:
@@ -152,28 +174,10 @@ MDScreen:
                         spacing: dp(4)
                         padding: [0, dp(8), 0, dp(8)]
 
-            # Hauptinhalt (Pointbar + ScreenManager + Logger)
+            # Hauptinhalt (ScreenManager + Logger)
             MDBoxLayout:
                 orientation: 'vertical'
                 id: main_content_area
-
-                # ----------------- POINTBAR -------------------
-                MDBoxLayout:
-                    orientation: 'vertical'
-                    size_hint_y: None
-                    height: self.minimum_height
-                    md_bg_color: app.theme_cls.backgroundColor
-
-                    GenerationPointsBar:
-                        id: generation_points
-                        charakter: app.controller.charakter
-
-                    # ----------------- WIZARD BAR (wird bei Bedarf eingeblendet) -------------------
-                    WizardBar:
-                        id: wizard_bar
-                        opacity: 0
-                        height: 0
-                        wizard_service: app.wizard_service
 
                 # ----------------- TAB-INHALT (CAROUSEL) -------------------
                 MDBoxLayout:

--- a/main.py
+++ b/main.py
@@ -1797,34 +1797,24 @@ class SW_Charakter_GeneratorApp(MDApp):
                 # Content-Padding reduzieren
                 tab_content_box.padding = [dp(4), 0, dp(4), dp(4)]
 
-                # Pointbar auf Smartphone weiter runter (Statusbar/Notch-Abstand)
+                # Android: Top-Padding auf äußerstes Layout für Statusbar/Notch
                 from kivy.utils import platform as _platform
                 if _platform == 'android':
-                    main_content_area = root.ids.get('main_content_area')
-                    if main_content_area:
-                        main_content_area.padding = [0, self._android_top_padding, 0, 0]
+                    outer_box = root.ids.get('outer_box')
+                    if outer_box:
+                        outer_box.padding = [0, self._android_top_padding, 0, 0]
 
                     # Swipe nur auf Android aktivieren
                     if screen_manager and hasattr(screen_manager, 'swipe_enabled'):
                         screen_manager.swipe_enabled = True
 
                 # Orientierung bestimmt ob Rail oder Bottom-Bar
-                # (NACH Padding-Änderungen, damit das Layout korrekt berechnet wird)
                 self._update_mobile_orientation()
 
                 # Aktive Items hervorheben
                 if current_index < len(self.rail_items):
                     self._set_active_rail_item(current_index)
                 self._set_active_bottom_nav_item(current_index)
-
-                # Android: Pointbar-Layout erzwingen — die initiale Layout-Kette
-                # propagiert Widget-Positionen nicht vollständig, weil
-                # is_expanded=True (Default) von _update_mobile_orientation nicht
-                # geändert wird. Durch ein verzögertes Toggle wird die Neuberechnung
-                # aller KV-Bindings (content_box height, minimum_height-Kette)
-                # erzwungen — dasselbe, was bei einer Orientierungsänderung passiert.
-                if _platform == 'android':
-                    Clock.schedule_once(self._force_android_pointbar_layout, 0.3)
 
                 Logger.info("Mobile Navigation aktiviert")
             else:
@@ -1973,31 +1963,6 @@ class SW_Charakter_GeneratorApp(MDApp):
 
         except Exception as e:
             Logger.error(f"Fehler bei Orientierungs-Update: {str(e)}")
-
-    def _force_android_pointbar_layout(self, dt):
-        """Erzwingt ein vollständiges Relayout der Pointbar auf Android.
-
-        Workaround: Beim App-Start ist is_expanded=True (Default) und
-        _update_mobile_orientation setzt es erneut auf True — kein Change-Event,
-        KV-Bindings für content_box.height und die minimum_height-Kette werden
-        nicht neu berechnet.  Durch ein kurzes Toggle (False → True) wird
-        dasselbe Relayout ausgelöst wie bei einer Orientierungsänderung.
-        """
-        try:
-            root = self.root
-            if not root:
-                return
-            pointbar = root.ids.get('generation_points')
-            if not pointbar:
-                return
-
-            # is_expanded kurz auf False setzen → KV-Bindings feuern
-            pointbar.is_expanded = False
-            # Im nächsten Frame zurück auf True → zweites Relayout
-            Clock.schedule_once(lambda dt: setattr(pointbar, 'is_expanded', True), 0)
-            Logger.debug("Android: Pointbar-Layout-Fix angewendet")
-        except Exception as e:
-            Logger.error(f"Fehler beim Pointbar-Layout-Fix: {e}")
 
     def set_screen_orientation(self, orientation='auto', locked=False):
         """Setzt die Bildschirm-Orientierung auf Android.


### PR DESCRIPTION
## Summary

- Pointbar (GenerationPointsBar + WizardBar) aus dem tief verschachtelten `main_content_area` herausgelöst und direkt als Kind des äußeren vertikalen Layouts (`outer_box`) platziert
- Touch-Dispatch-Pfad auf Android deutlich verkürzt (vorher 5+ Ebenen, jetzt 3)
- Android-Statusbar-Padding auf `outer_box` statt `main_content_area` angewendet

## Hintergrund

Die Buttons in der Top-Bar (Undo, Speichern, Laden, Aufklappen) reagierten auf Android erst nach einem Orientierungswechsel (Portrait → Landscape → Portrait). Der erste Fix (PR #152) hat das Problem nicht gelöst. Durch das Verschieben der Pointbar höher in der Widget-Hierarchie wird der Touch-Dispatch-Pfad verkürzt:

**Vorher:** `MDScreen → outer_box → horizontal → main_content_area → wrapper → GenerationPointsBar`
**Nachher:** `MDScreen → outer_box → pointbar_container → GenerationPointsBar`

## Geänderte Dateien

- `main.kv` — Pointbar-Container zwischen `tabs_container` und horizontalem Layout eingefügt, `outer_box` ID hinzugefügt
- `main.py` — Android-Top-Padding auf `outer_box`, `_force_android_pointbar_layout` Workaround entfernt

https://claude.ai/code/session_01A7sC9hhA5y8eQ5LLVjeq7B