### PR TITLE
Fix: Import-Fehler und Log-Datei nicht verfügbar auf Android

### DIFF
--- a/utils/intent_handler.py
+++ b/utils/intent_handler.py
@@ -185,10 +185,19 @@ def _import_from_uri(app, uri):
         uri: Android Uri-Objekt
     """
     try:
-        from jnius import autoclass
+        from jnius import autoclass, cast
 
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
         context = PythonActivity.mActivity
+
+        # URI zu android.net.Uri casten. getParcelableExtra() liefert Parcelable,
+        # aber openFileDescriptor/openInputStream erwarten android.net.Uri.
+        # Ohne Cast: "Invalid instance of 'android/os/Parcelable' passed for a 'android/net/Uri'"
+        try:
+            Uri = autoclass('android.net.Uri')
+            uri = cast(Uri, uri)
+        except Exception as e:
+            Logger.warning(f"IntentHandler: URI-Cast fehlgeschlagen: {e}")
 
         # Dateiname aus URI ermitteln
         filename = _get_filename_from_uri(context, uri)


### PR DESCRIPTION
## Summary

Behebt zwei zusammenhängende Bugs auf Android:

1. **Import von JSON-Dateien per "Teilen" schlug fehl** mit der generischen Meldung "Die Datei konnte nicht gelesen werden."
2. **"Log kopieren"-Button funktionierte nicht** — "Keine Log-Datei verfügbar", obwohl das Logging an sich lief.

## Root Causes

### Import-Fehler
`intent.getParcelableExtra()` liefert ein generisches `Parcelable`-Objekt. pyjnius erkennt nicht automatisch, dass es sich um ein `android.net.Uri` handelt. Bei der Weitergabe an `openFileDescriptor()` / `openInputStream()` schlug die Typprüfung fehl:

```
Invalid instance of 'android/os/Parcelable' passed for a 'android/net/Uri'
```

Zusätzlich hat `_read_content_from_uri` Exceptions intern verschluckt und nur `None` zurückgegeben, sodass die tatsächliche Fehlerursache weder dem Benutzer noch im Log sichtbar war.

### Log-Datei nicht verfügbar
`get_app_data_dir()` probierte auf Android mehrere Speicherpfade (`/sdcard`, `primary_external_storage_path`, `app_storage_path`), die aber auf Android 10+ mit Scoped Storage alle fehlschlagen können. Der letzte Fallback war ein hardcodierter Pfad, der u.U. nicht existiert oder nicht beschreibbar ist.

## Changes

### `utils/intent_handler.py`
- **Cast des URI** zu `android.net.Uri` via `jnius.cast()` in `_import_from_uri`, um den Parcelable/Uri-Typkonflikt zu beheben.
- **Neue FileDescriptor-basierte Lesemethode** (`openFileDescriptor` + `os.fdopen`) als primäre Methode — Python-native I/O umgeht mögliche pyjnius-Konstruktor-Probleme bei Java-IO.
- **Java BufferedReader** als Fallback, ohne expliziten Charset-Parameter (Android-Default ist UTF-8), um pyjnius-Konstruktor-Auflösungsprobleme zu vermeiden.
- **Fehler werden an den Benutzer weitergereicht** statt verschluckt zu werden — der Import-Dialog zeigt jetzt die tatsächliche Fehlermeldung (inkl. beider Fehlermethoden-Details), was die Diagnose erst möglich gemacht hat.

### `utils/logging_setup.py`
- **Neuer Fallback 3** in `get_app_data_dir()`: `context.getFilesDir()` via Java API. Diese Methode ist auf Android *immer* beschreibbar ohne spezielle Berechtigungen und funktioniert auch mit Scoped Storage auf Android 10+.

### `views/einstellungen_widget.py`
- `open_log_file()` zeigt jetzt einen **Snackbar-Warning-Dialog**, wenn die Log-Datei nicht verfügbar oder nicht gefunden ist, statt nur eine leicht übersehbare Zeile in die Log-Konsole zu schreiben.

## Test plan

- [x] Änderungen kompilieren ohne Syntaxfehler
- [ ] Auf Android 10+ Gerät: JSON-Datei via "Teilen" an die App schicken → Import sollte erfolgreich sein
- [ ] Auf Android 10+ Gerät: "Log kopieren" drücken → Log-Datei sollte vorhanden sein und teilbar (via `getFilesDir()`-Fallback)
- [ ] Falls ein Fehler auftritt: Dialog zeigt jetzt konkrete Fehlermeldung statt generischer Nachricht

## Hintergrund zur Diagnose

Der erste Fix-Versuch (ohne Cast) zeigte die bessere Fehlerberichterstattung, die den eigentlichen Root Cause erst sichtbar machte:

```
FileDescriptor: Invalid instance of 'android/os/Parcelable' passed for a 'android/net/Uri'
InputStream: Invalid instance of 'android/os/Parcelable' passed for a 'android/net/Uri'
```

Der zweite Commit fügte dann den notwendigen `cast()`-Aufruf hinzu.

https://claude.ai/code/session_01LZorFjmGPCxrhaBghQnDyz