### PR TITLE
Fix: Lösch-Bestätigungs-Dialog bleibt auf Android hängen

### DIFF
--- a/views/fertigkeit_popup.py
+++ b/views/fertigkeit_popup.py
@@ -2,6 +2,7 @@
 from kivy.lang import Builder
 from kivy.logger import Logger
 from kivy.app import App
+from kivy.clock import Clock
 from kivy.metrics import dp
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.dropdownitem import MDDropDownItem, MDDropDownItemText
@@ -291,6 +292,31 @@ class FertigkeitDialogHandler:
         )
         main_content.add_widget(scroll)
 
+        def _dismiss_confirm_popup(*_):
+            """Schließt das Bestätigungs-Popup robust (doppelter Versuch)."""
+            popup = getattr(self, '_delete_confirm_popup', None)
+            if popup is None:
+                return
+            try:
+                popup.dismiss()
+            except Exception as e:
+                Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
+
+        def _on_cancel(x):
+            _dismiss_confirm_popup()
+            # Zweiter Dismiss-Versuch verzögert, falls der erste auf Android
+            # durch Timing-Probleme der Animation nicht gegriffen hat.
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+
+        def _on_confirm_release(x):
+            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
+            # ausführen. Auf Android kann das synchrone Aufrufen von
+            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
+            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),
             MDDialogContentContainer(main_content),
@@ -298,15 +324,12 @@ class FertigkeitDialogHandler:
                 MDButton(
                     MDButtonText(text="Abbrechen"),
                     style="text",
-                    on_release=lambda x: self._delete_confirm_popup.dismiss()
+                    on_release=_on_cancel,
                 ),
                 MDButton(
                     MDButtonText(text="Löschen"),
                     style="filled",
-                    on_release=lambda x: (
-                        self._delete_confirm_popup.dismiss(),
-                        on_confirm()
-                    )
+                    on_release=_on_confirm_release,
                 ),
             ),
             size_hint=(0.85, None),

--- a/views/handicap_popup.py
+++ b/views/handicap_popup.py
@@ -409,6 +409,29 @@ class HandicapDialogHandler:
         )
         main_content.add_widget(scroll)
 
+        def _dismiss_confirm_popup(*_):
+            """Schließt das Bestätigungs-Popup robust (doppelter Versuch)."""
+            popup = getattr(self, '_delete_confirm_popup', None)
+            if popup is None:
+                return
+            try:
+                popup.dismiss()
+            except Exception as e:
+                Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
+
+        def _on_cancel(x):
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+
+        def _on_confirm_release(x):
+            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
+            # ausführen. Auf Android kann das synchrone Aufrufen von
+            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
+            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),
             MDDialogContentContainer(main_content),
@@ -416,15 +439,12 @@ class HandicapDialogHandler:
                 MDButton(
                     MDButtonText(text="Abbrechen"),
                     style="text",
-                    on_release=lambda x: self._delete_confirm_popup.dismiss()
+                    on_release=_on_cancel,
                 ),
                 MDButton(
                     MDButtonText(text="Löschen"),
                     style="filled",
-                    on_release=lambda x: (
-                        self._delete_confirm_popup.dismiss(),
-                        on_confirm()
-                    )
+                    on_release=_on_confirm_release,
                 ),
             ),
             size_hint=(0.85, None),

--- a/views/macht_popup.py
+++ b/views/macht_popup.py
@@ -428,6 +428,29 @@ class MachtDialogHandler:
         )
         main_content.add_widget(scroll)
 
+        def _dismiss_confirm_popup(*_):
+            """Schließt das Bestätigungs-Popup robust (doppelter Versuch)."""
+            popup = getattr(self, '_delete_confirm_popup', None)
+            if popup is None:
+                return
+            try:
+                popup.dismiss()
+            except Exception as e:
+                Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
+
+        def _on_cancel(x):
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+
+        def _on_confirm_release(x):
+            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
+            # ausführen. Auf Android kann das synchrone Aufrufen von
+            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
+            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),
             MDDialogContentContainer(main_content),
@@ -435,15 +458,12 @@ class MachtDialogHandler:
                 MDButton(
                     MDButtonText(text="Abbrechen"),
                     style="text",
-                    on_release=lambda x: self._delete_confirm_popup.dismiss()
+                    on_release=_on_cancel,
                 ),
                 MDButton(
                     MDButtonText(text="Löschen"),
                     style="filled",
-                    on_release=lambda x: (
-                        self._delete_confirm_popup.dismiss(),
-                        on_confirm()
-                    )
+                    on_release=_on_confirm_release,
                 ),
             ),
             size_hint=(0.85, None),

--- a/views/talent_popup.py
+++ b/views/talent_popup.py
@@ -428,6 +428,29 @@ class TalentDialogHandler:
         )
         main_content.add_widget(scroll)
 
+        def _dismiss_confirm_popup(*_):
+            """Schließt das Bestätigungs-Popup robust (doppelter Versuch)."""
+            popup = getattr(self, '_delete_confirm_popup', None)
+            if popup is None:
+                return
+            try:
+                popup.dismiss()
+            except Exception as e:
+                Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
+
+        def _on_cancel(x):
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+
+        def _on_confirm_release(x):
+            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
+            # ausführen. Auf Android kann das synchrone Aufrufen von
+            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
+            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),
             MDDialogContentContainer(main_content),
@@ -435,15 +458,12 @@ class TalentDialogHandler:
                 MDButton(
                     MDButtonText(text="Abbrechen"),
                     style="text",
-                    on_release=lambda x: self._delete_confirm_popup.dismiss()
+                    on_release=_on_cancel,
                 ),
                 MDButton(
                     MDButtonText(text="Löschen"),
                     style="filled",
-                    on_release=lambda x: (
-                        self._delete_confirm_popup.dismiss(),
-                        on_confirm()
-                    )
+                    on_release=_on_confirm_release,
                 ),
             ),
             size_hint=(0.85, None),

--- a/views/volk_popup.py
+++ b/views/volk_popup.py
@@ -1463,6 +1463,29 @@ class VolkDialogHandler:
         )
         main_content.add_widget(scroll)
 
+        def _dismiss_confirm_popup(*_):
+            """Schließt das Bestätigungs-Popup robust (doppelter Versuch)."""
+            popup = getattr(self, '_delete_confirm_popup', None)
+            if popup is None:
+                return
+            try:
+                popup.dismiss()
+            except Exception as e:
+                Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
+
+        def _on_cancel(x):
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+
+        def _on_confirm_release(x):
+            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
+            # ausführen. Auf Android kann das synchrone Aufrufen von
+            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
+            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
+            _dismiss_confirm_popup()
+            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),
             MDDialogContentContainer(main_content),
@@ -1470,15 +1493,12 @@ class VolkDialogHandler:
                 MDButton(
                     MDButtonText(text="Abbrechen"),
                     style="text",
-                    on_release=lambda x: self._delete_confirm_popup.dismiss()
+                    on_release=_on_cancel,
                 ),
                 MDButton(
                     MDButtonText(text="Löschen"),
                     style="filled",
-                    on_release=lambda x: (
-                        self._delete_confirm_popup.dismiss(),
-                        on_confirm()
-                    )
+                    on_release=_on_confirm_release,
                 ),
             ),
             size_hint=(0.85, None),


### PR DESCRIPTION
Nach dem Klick auf "Löschen" im Bestätigungs-Popup wurde das Löschen zwar
korrekt ausgeführt, der Dialog blieb aber sichtbar und reagierte weder auf
"Löschen" noch auf "Abbrechen". Ursache: dismiss() und on_confirm() liefen
synchron in einer Tupel-Lambda. Die anschließenden UI-Rebuilds
(aktualisiere_ui, _refresh_*_view) unterbrachen die Dismiss-Animation und
hinterließen den Dialog in einem inkonsistenten Zustand.

Fix analog zum HTML-Dialog-Fix (commit b75042e):
- on_confirm() wird verzögert via Clock.schedule_once(0.2s) ausgeführt,
  damit die Dismiss-Animation zuerst abgeschlossen werden kann
- Zweiter Dismiss-Versuch verzögert (0.15s) als Fallback, falls der erste
  durch Timing-Probleme nicht gegriffen hat
- Gleiche Absicherung für den Abbrechen-Button

Betrifft alle Two-Phase Delete-Dialoge:
- views/fertigkeit_popup.py
- views/handicap_popup.py
- views/macht_popup.py
- views/talent_popup.py
- views/volk_popup.py

https://claude.ai/code/session_01H8wu9QFuwyYTsq7K8tamGx