### PR TITLE
Fix Android-Import (Share Intent) und File-Logging

### DIFF
--- a/utils/intent_handler.py
+++ b/utils/intent_handler.py
@@ -363,8 +363,10 @@ def _detect_json_type(data):
     """
     Erkennt ob die JSON-Daten ein Charakter oder ein Setting sind.
 
-    Charakter-Dateien enthalten typischerweise: char_name, setting, rang, etc.
-    Setting-Dateien enthalten typischerweise: Talente, Handicaps, Völker, etc.
+    Charakter-Dateien (Top-Level-Keys): profil_daten, selected_talente,
+    selected_handicaps, selected_maechte, active_setting_name, voelker_selected.
+    Setting-Dateien (Top-Level-Keys): name, description, fertigkeiten_daten,
+    voelker, talente, handicaps, maechte, startgeld.
 
     Returns:
         str: 'charakter', 'setting' oder 'unbekannt'
@@ -372,18 +374,46 @@ def _detect_json_type(data):
     if not isinstance(data, dict):
         return 'unbekannt'
 
-    # Charakter-Schlüssel
-    charakter_keys = {'char_name', 'setting', 'rang', 'erfahrungspunkte', 'attribute'}
-    # Setting-Schlüssel
-    setting_keys = {'Talente', 'Handicaps', 'Völker', 'Fertigkeiten', 'Mächte'}
+    keys = data.keys()
 
-    char_matches = len(charakter_keys.intersection(data.keys()))
-    setting_matches = len(setting_keys.intersection(data.keys()))
+    # Charakter-spezifische Top-Level-Keys (wie sie vom Charakter-Model gespeichert werden)
+    charakter_keys = {
+        'profil_daten',
+        'selected_talente',
+        'selected_handicaps',
+        'selected_maechte',
+        'selected_waffen',
+        'selected_ruestungen',
+        'active_setting_name',
+        'voelker_selected',
+        'aufstiege_gesamt',
+        'erschoepfung',
+    }
+    # Setting-spezifische Top-Level-Keys (klein, wie in den Setting-JSON-Dateien)
+    setting_keys = {
+        'fertigkeiten_daten',  # sehr unterscheidend - nur Settings haben das
+        'voelker',             # Settings haben 'voelker', Charaktere 'voelker_selected'
+        'talente',             # Settings haben 'talente', Charaktere 'selected_talente'
+        'handicaps',           # Settings haben 'handicaps', Charaktere 'selected_handicaps'
+        'maechte',             # Settings haben 'maechte', Charaktere 'selected_maechte'
+        'startgeld',
+    }
 
-    if char_matches >= 2:
-        return 'charakter'
-    elif setting_matches >= 2:
+    char_matches = len(charakter_keys.intersection(keys))
+    setting_matches = len(setting_keys.intersection(keys))
+
+    # Settings haben oft mehrere distinktive Keys - wenn fertigkeiten_daten vorhanden ist,
+    # ist es definitiv ein Setting (Charaktere haben 'fertigkeiten' ohne _daten)
+    if 'fertigkeiten_daten' in keys:
         return 'setting'
+    # profil_daten ist sehr charakteristisch für Charaktere
+    if 'profil_daten' in keys:
+        return 'charakter'
+
+    if setting_matches >= 2:
+        return 'setting'
+    elif char_matches >= 2:
+        return 'charakter'
     else:
         return 'unbekannt'
 

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -10,69 +10,99 @@ from pathlib import Path
 from kivy.logger import Logger as KivyLogger
 from kivy.utils import platform
 
+# Diagnose-Informationen für das Logging-Setup
+# Wird gespeichert damit die UI die Fehlerursache anzeigen kann
+_setup_error_details = []
+
+
+def get_last_setup_errors():
+    """Gibt die Fehlerdetails aus dem letzten setup_file_logging-Aufruf zurück."""
+    return list(_setup_error_details)
+
+
+def _test_writable(app_dir):
+    """Prüft ob das Verzeichnis tatsächlich beschreibbar ist (inkl. Log-Unterverzeichnis)."""
+    logs_dir = os.path.join(app_dir, "logs")
+    os.makedirs(logs_dir, exist_ok=True)
+    # Echter Schreibtest im finalen logs-Unterverzeichnis
+    test_file = os.path.join(logs_dir, ".write_test.tmp")
+    with open(test_file, 'w') as f:
+        f.write("test")
+    os.remove(test_file)
+    return True
+
+
 def get_app_data_dir():
     """
     Gibt das App-Datenverzeichnis zurück, plattformspezifisch.
-    """
-    if platform == 'android':
-        try:
-            # DIREKTER Zugriff auf externen Speicher - umgeht Android-Storage-API
-            external_path = "/sdcard"
-            app_dir = os.path.join(external_path, "SavageWorldsCharGen")
-            
-            # Versuche Ordner zu erstellen
-            try:
-                os.makedirs(app_dir, exist_ok=True)
-                # Test-Schreibzugriff
-                test_file = os.path.join(app_dir, "test_write.tmp")
-                with open(test_file, 'w') as f:
-                    f.write("test")
-                os.remove(test_file)
-                KivyLogger.info(f"FileLogging: Direkter /sdcard Zugriff erfolgreich: {app_dir}")
-                return app_dir
-            except Exception as e:
-                KivyLogger.warning(f"FileLogging: /sdcard nicht beschreibbar: {e}")
-                
-            # Fallback 1: Android Storage API
-            try:
-                from android.storage import primary_external_storage_path
-                external_path = primary_external_storage_path()
-                app_dir = os.path.join(external_path, "SavageWorldsCharGen")
-                os.makedirs(app_dir, exist_ok=True)
-                KivyLogger.info(f"FileLogging: Android Storage API erfolgreich: {app_dir}")
-                return app_dir
-            except Exception as e:
-                KivyLogger.warning(f"FileLogging: Android Storage API fehlgeschlagen: {e}")
-                
-            # Fallback 2: App-interner Speicher (python-for-android API)
-            try:
-                from android.storage import app_storage_path
-                app_dir = app_storage_path()
-                KivyLogger.warning(f"FileLogging: Fallback auf App-internen Speicher: {app_dir}")
-                return app_dir
-            except Exception as e:
-                KivyLogger.warning(f"FileLogging: app_storage_path fehlgeschlagen: {e}")
 
-            # Fallback 3: getFilesDir() über Java API (zuverlässigste Methode)
-            try:
-                from jnius import autoclass
-                PythonActivity = autoclass('org.kivy.android.PythonActivity')
-                context = PythonActivity.mActivity
-                files_dir = context.getFilesDir().getAbsolutePath()
-                app_dir = os.path.join(files_dir, "SavageWorldsCharGen")
-                os.makedirs(app_dir, exist_ok=True)
-                KivyLogger.warning(f"FileLogging: Fallback auf getFilesDir: {app_dir}")
-                return app_dir
-            except Exception as e:
-                KivyLogger.error(f"FileLogging: Alle Android-Speicher-Optionen fehlgeschlagen: {e}")
-                return "/data/data/com.github.thallion.savageworlds/files"
-                
-        except ImportError:
-            # Fallback wenn Android-Module nicht verfügbar
-            return "/sdcard/SavageWorldsCharGen"
-    else:
+    Auf Android wird zuerst der interne App-Speicher verwendet (zuverlässig,
+    keine Berechtigungen nötig, funktioniert auch mit Scoped Storage).
+    Externer Speicher wird nur als zusätzliche Option versucht.
+    """
+    if platform != 'android':
         # Desktop: Verwende aktuelles Arbeitsverzeichnis
         return os.getcwd()
+
+    _setup_error_details.clear()
+
+    # Priorität 1: python-for-android app_storage_path (interner Speicher)
+    # Dieser Pfad ist IMMER beschreibbar für die App - ohne Berechtigungen
+    try:
+        from android.storage import app_storage_path
+        app_dir = app_storage_path()
+        if app_dir:
+            _test_writable(app_dir)
+            KivyLogger.info(f"FileLogging: App-interner Speicher (app_storage_path): {app_dir}")
+            return app_dir
+    except Exception as e:
+        msg = f"app_storage_path: {e}"
+        KivyLogger.warning(f"FileLogging: {msg}")
+        _setup_error_details.append(msg)
+
+    # Priorität 2: getFilesDir() via Java API (ebenfalls interner Speicher)
+    try:
+        from jnius import autoclass
+        PythonActivity = autoclass('org.kivy.android.PythonActivity')
+        context = PythonActivity.mActivity
+        files_dir = context.getFilesDir().getAbsolutePath()
+        if files_dir:
+            _test_writable(files_dir)
+            KivyLogger.info(f"FileLogging: App-interner Speicher (getFilesDir): {files_dir}")
+            return files_dir
+    except Exception as e:
+        msg = f"getFilesDir: {e}"
+        KivyLogger.warning(f"FileLogging: {msg}")
+        _setup_error_details.append(msg)
+
+    # Priorität 3: Externer Speicher (/sdcard) - für Benutzer-Sichtbarkeit im Dateimanager
+    # Nur wenn interner Speicher nicht funktioniert
+    try:
+        from android.storage import primary_external_storage_path
+        external_path = primary_external_storage_path()
+        app_dir = os.path.join(external_path, "SavageWorldsCharGen")
+        _test_writable(app_dir)
+        KivyLogger.info(f"FileLogging: Externer Speicher: {app_dir}")
+        return app_dir
+    except Exception as e:
+        msg = f"primary_external_storage_path: {e}"
+        KivyLogger.warning(f"FileLogging: {msg}")
+        _setup_error_details.append(msg)
+
+    # Letzter Fallback: Hardcodierter /sdcard-Pfad
+    try:
+        app_dir = "/sdcard/SavageWorldsCharGen"
+        _test_writable(app_dir)
+        KivyLogger.warning(f"FileLogging: /sdcard-Fallback: {app_dir}")
+        return app_dir
+    except Exception as e:
+        msg = f"/sdcard: {e}"
+        KivyLogger.error(f"FileLogging: {msg}")
+        _setup_error_details.append(msg)
+
+    # Nichts hat funktioniert - gib den wahrscheinlichsten Pfad zurück,
+    # damit setup_file_logging noch eine Chance hat
+    return "/data/user/0/com.github.thallion.savageworlds/files"
 
 def setup_file_logging(app_name="SavageWorldsGenerator"):
     """
@@ -153,8 +183,10 @@ def setup_file_logging(app_name="SavageWorldsGenerator"):
         return log_filepath
         
     except Exception as e:
-        # Fallback wenn File Logging fehlschlägt
-        KivyLogger.error(f"FileLogging: Konnte Log-Datei nicht erstellen: {str(e)}")
+        # Fallback wenn File Logging fehlschlägt - Fehler für Diagnose speichern
+        error_msg = f"setup_file_logging: {type(e).__name__}: {e}"
+        KivyLogger.error(f"FileLogging: Konnte Log-Datei nicht erstellen: {error_msg}")
+        _setup_error_details.append(error_msg)
         return None
 
 def cleanup_old_logs(max_age_days=7, max_files=20):

--- a/views/einstellungen_widget.py
+++ b/views/einstellungen_widget.py
@@ -403,11 +403,27 @@ class EinstellungenWidget(MDBoxLayout):
             if not hasattr(self.app, 'log_filepath') or not self.app.log_filepath:
                 Logger.warning("Keine Log-Datei verfügbar")
                 from services.service_container import service_container
+
+                # Konkrete Fehlerdetails aus dem Setup abrufen
+                try:
+                    from utils.logging_setup import get_last_setup_errors
+                    setup_errors = get_last_setup_errors()
+                except Exception:
+                    setup_errors = []
+
+                detail = "\n\nDetails:\n" + "\n".join(setup_errors) if setup_errors else ""
+                message = (
+                    "Keine Log-Datei verfügbar.\n"
+                    "Das File-Logging konnte nicht initialisiert werden." + detail
+                )
+
                 dialog_service = service_container.get_dialog_service()
                 if dialog_service:
-                    dialog_service.show_warning_dialog(
-                        "Keine Log-Datei verfügbar.\nDas File-Logging konnte nicht initialisiert werden."
-                    )
+                    # Bei langen Details lieber Error-Dialog verwenden (Snackbar wird abgeschnitten)
+                    if setup_errors:
+                        dialog_service.show_error_dialog(message)
+                    else:
+                        dialog_service.show_warning_dialog(message)
                 return
 
             log_filepath = self.app.log_filepath


### PR DESCRIPTION
## Summary

Behebt zwei Android-spezifische Bugs:

- **Import via "Teilen" schlug fehl** mit generischem Fehler. Ursache: `intent.getParcelableExtra()` liefert ein `android.os.Parcelable`, `ContentResolver`-Methoden erwarten aber `android.net.Uri`. Fix: `cast(Uri, uri)` via pyjnius. Zusätzlich wurde `_read_content_from_uri` mit FileDescriptor-Primary + BufferedReader-Fallback robuster gemacht und Fehlermeldungen werden jetzt detailliert an den User durchgereicht.
- **Setting-Dateien wurden als Charakter erkannt** ("Charakter empfangen" statt "Setting empfangen"). `_detect_json_type` hat die falschen Schlüsselnamen geprüft. Fix: Erkennung anhand der tatsächlichen Top-Level-Keys (`profil_daten` für Charaktere, `fertigkeiten_daten`/`voelker`/`talente` für Settings).
- **"Log kopieren" zeigte "Keine Log-Datei verfügbar"** obwohl das On-Screen-Logging funktionierte. Ursache: `get_app_data_dir()` hat den `/sdcard`-Schreibtest (nur leere Datei) bestanden, danach scheiterte aber das Erstellen der eigentlichen Log-Datei. Fix:
  - Reihenfolge umgestellt: interner Speicher (`app_storage_path` / `getFilesDir`) zuerst, externer Speicher (`/sdcard`) nur als Fallback.
  - `_test_writable()` legt jetzt das `logs/`-Unterverzeichnis an und testet Schreibzugriff dort.
  - Setup-Fehler werden in `_setup_error_details` gespeichert und im "Log kopieren"-Dialog angezeigt, damit die Ursache sichtbar ist, falls es doch noch fehlschlägt.

## Test plan

- [ ] Android: JSON-Charakterdatei per "Teilen" → App öffnen → "Charakter empfangen"-Dialog erscheint und Import gelingt
- [ ] Android: JSON-Setting-Datei per "Teilen" → App öffnen → "Setting empfangen"-Dialog erscheint (nicht "Charakter empfangen")
- [ ] Android: Einstellungen → "Log kopieren" funktioniert und kopiert die aktuelle Session-Log-Datei
- [ ] Falls Logging fehlschlägt: Dialog zeigt konkrete Fehlermeldung aus `_setup_error_details`
- [ ] Desktop (Linux/Windows): keine Regressionen beim Logging oder Laden von Charakteren/Settings

https://claude.ai/code/session_01LZorFjmGPCxrhaBghQnDyz