### PR TITLE
Freies Talent ändern: Overlay-Zustand vor Edit-Modus korrekt setzen

### DIFF
--- a/views/voelker_auswahl_overlay.py
+++ b/views/voelker_auswahl_overlay.py
@@ -671,10 +671,8 @@ class VoelkerAuswahlOverlay(MDBoxLayout):
             from functions.volk_funktionen import _get_halbelf_freies_talent
             current_talent = _get_halbelf_freies_talent(self._charakter)
         elif talent_typ == 'freies_talent':
-            # Für generische freie Talente gibt es keine spezielle Tracking-Variable
-            # Wir könnten prüfen, ob ein Talent ausgewählt ist, das zu diesem Volk gehört
-            # Aber das ist komplex; vorerst keine Vorselektion
-            current_talent = None
+            from functions.volk_funktionen import _get_menschen_freies_talent
+            current_talent = _get_menschen_freies_talent(self._charakter)
         
         if current_talent:
             selected_talent[0] = current_talent

--- a/views/voelker_view.py
+++ b/views/voelker_view.py
@@ -846,11 +846,19 @@ class VoelkerWidget(MDBoxLayout):
         
         self._voelker_overlay._charakter = self.controller.charakter
         self._voelker_overlay._selected_volk = volk_name
+        # Overlay-Zustand für Edit-Modus vorbereiten: _selected_extras zurücksetzen und
+        # _zusatzelemente_info auf nur das bearbeitete Element begrenzen, damit
+        # _all_extras_selected() nach einer Auswahl True zurückgibt.
+        self._voelker_overlay._selected_extras = {}
+        if talent_typ == 'freies_talent':
+            self._voelker_overlay._zusatzelemente_info = {'freie_talente': True}
+        elif talent_typ == 'halbelf_talent':
+            self._voelker_overlay._zusatzelemente_info = {'halbelf_entweder_oder': True}
+        elif talent_typ == 'mensch_talent':
+            self._voelker_overlay._zusatzelemente_info = {'menschen_vielseitig': True}
+        self._voelker_overlay.on_volk_chosen = self._on_overlay_volk_chosen
         # Talentauswahl direkt öffnen
         self._voelker_overlay._show_talent_selection(talent_typ)
-        # Das Overlay wird geöffnet; es sollte den bereits gewählten Talentnamen vorselektieren?
-        # Aktuell nicht implementiert, aber das Overlay zeigt alle Talente an.
-        # Der User kann ein anderes Talent wählen.
 
     def _on_edit_attribut(self, attribut_name):
         """Öffnet einen Dialog zum Bearbeiten des ausgewählten freien Attributs."""


### PR DESCRIPTION
Beim Bearbeiten eines bereits gewählten freien Talents über den Stift-Button
wurde _all_extras_selected() nie True, weil _zusatzelemente_info noch alle
Volk-Extras des letzten open()-Aufrufs enthielt (z.B. freie_talente UND
freie_attribute), _selected_extras beim Edit aber nur den einen bearbeiteten
Typ enthielt. Dadurch wurde der on_volk_chosen-Callback nie ausgelöst.

Fix: Vor dem direkten Aufruf von _show_talent_selection im Edit-Modus werden
_selected_extras zurückgesetzt, _zusatzelemente_info auf den bearbeiteten
Typ begrenzt und on_volk_chosen explizit gesetzt.

Zusätzlich: Vorselektion des aktuellen Talents im Dialog für 'freies_talent'
via _get_menschen_freies_talent (wie bereits für 'mensch_talent').

https://claude.ai/code/session_01C1yNuw2x11wjRzye2NQTjf