### PR TITLE
Ersetze Logger.debug durch Logger.warning bei Fehler-/Fallback-Bedingungen

### DIFF
--- a/functions/cyberware_funktionen.py
+++ b/functions/cyberware_funktionen.py
@@ -460,7 +460,7 @@ def _modifiziere_fertigkeit(charakter, fert_name, bonus):
         nachher = f"W{fert.wuerfel.value}" + (f"{fert.wuerfel.modifier:+d}" if fert.wuerfel.modifier else "")
         Logger.info(f"Cyberware-Effekt: {fert_name} {'+'if bonus > 0 else ''}{bonus} ({vorher} → {nachher})")
     else:
-        Logger.debug(f"Cyberware-Effekt: Fertigkeit '{fert_name}' nicht gefunden")
+        Logger.warning(f"Cyberware-Effekt: Fertigkeit '{fert_name}' nicht gefunden")
 
 
 def _fuege_talent_hinzu(charakter, talent_name):

--- a/functions/volk_funktionen.py
+++ b/functions/volk_funktionen.py
@@ -743,12 +743,12 @@ def get_volk_attribut_optionen(charakter, volk_name):
         if not hasattr(volk, 'effects'):
             if volk_name.lower() in ["halbork", "halborks"]:
                 # Halborks können zwischen Stärke und Konstitution wählen
-                Logger.debug(f"Halbork Attribut-Optionen (Fallback ohne effects): Stärke oder Konstitution")
+                Logger.warning(f"Halbork Attribut-Optionen (Fallback ohne effects): Stärke oder Konstitution")
                 return ["Stärke", "Konstitution"]
             
             elif volk_name.lower() in ["halbelf", "halbelfen"]:
                 # Halbelfen können Geschicklichkeit wählen (als Teil der ENTWEDER/ODER Wahl)
-                Logger.debug(f"Halbelf Attribut-Option (Fallback ohne effects): Geschicklichkeit")
+                Logger.warning(f"Halbelf Attribut-Option (Fallback ohne effects): Geschicklichkeit")
                 return ["Geschicklichkeit"]
         
         # Prüfe ob das Volk generell freie Attribut-Wahlmöglichkeiten hat

--- a/main.py
+++ b/main.py
@@ -1451,7 +1451,7 @@ class SW_Charakter_GeneratorApp(MDApp):
                             child.theme_text_color = "Custom"
                             child.text_color = self.theme_cls.onSurfaceVariantColor
         except Exception as e:
-            Logger.debug(f"Fehler bei Bottom-Nav-Highlighting: {e}")
+            Logger.warning(f"Fehler bei Bottom-Nav-Highlighting: {e}")
 
     def _show_more_screens_popup(self):
         """Zeigt ein Popup mit allen verfügbaren Screens als Grid"""

--- a/models/ruestung.py
+++ b/models/ruestung.py
@@ -54,7 +54,7 @@ class Ruestung(Ausruestung):
         
         # Nur zur Information prüfen, ob die Mindeststärke erfüllt ist
         if not self.kann_angelegt_werden(charakter):
-            Logger.debug(f"Warnung: {self.name} wurde angelegt, obwohl Mindeststärke nicht erfüllt ist.")
+            Logger.warning(f"{self.name} wurde angelegt, obwohl Mindeststärke nicht erfüllt ist.")
         else:
             Logger.debug(f"{self.name} wurde angelegt.")
 

--- a/models/schild.py
+++ b/models/schild.py
@@ -79,7 +79,7 @@ class Schild(Ausruestung):
         
         # Nur zur Information prüfen, ob die Mindeststärke erfüllt ist
         if not self.kann_angelegt_werden(charakter):
-            Logger.debug(f"Warnung: {self.name} wurde angelegt, obwohl Mindeststärke nicht erfüllt ist.")
+            Logger.warning(f"{self.name} wurde angelegt, obwohl Mindeststärke nicht erfüllt ist.")
         else:
             Logger.debug(f"{self.name} wurde angelegt.")
 

--- a/models/waffe.py
+++ b/models/waffe.py
@@ -101,7 +101,7 @@ class Waffe(Ausruestung):
         
         # Nur zur Information prüfen, ob die Mindeststärke erfüllt ist
         if not self.kann_angelegt_werden(charakter):
-            Logger.debug(f"Warnung: {self.name} wurde angelegt, obwohl Mindeststärke nicht erfüllt ist.")
+            Logger.warning(f"{self.name} wurde angelegt, obwohl Mindeststärke nicht erfüllt ist.")
         else:
             Logger.debug(f"{self.name} wurde angelegt.")
 

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -51,7 +51,7 @@ def _get_log_level():
             KivyLogger.debug(f"Log-Level aus Konfiguration gelesen: {level_str}")
             return level
         else:
-            KivyLogger.debug(f"Konfigurationsdatei nicht gefunden, verwende Standard-Log-Level: INFO")
+            KivyLogger.warning(f"Konfigurationsdatei nicht gefunden, verwende Standard-Log-Level: INFO")
             return default_level
             
     except Exception as e:

--- a/views/ausruestung_popup.py
+++ b/views/ausruestung_popup.py
@@ -619,7 +619,7 @@ class AusruestungDialogHandler:
                 elif widget and hasattr(widget, 'refresh'):
                     widget.refresh()
         except Exception as e:
-            Logger.debug(f"Ausrüstung-Widget nicht gefunden: {e}")
+            Logger.warning(f"Ausrüstung-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/fertigkeit_popup.py
+++ b/views/fertigkeit_popup.py
@@ -480,7 +480,7 @@ class FertigkeitDialogHandler:
                 elif widget and hasattr(widget, 'refresh_widget'):
                     widget.refresh_widget()
         except Exception as e:
-            Logger.debug(f"Eigenschaften-Widget nicht gefunden: {e}")
+            Logger.warning(f"Eigenschaften-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/handicap_popup.py
+++ b/views/handicap_popup.py
@@ -590,7 +590,7 @@ class HandicapDialogHandler:
                     from kivy.clock import Clock
                     Clock.schedule_once(lambda dt: widget.refresh_widget(), 0)
         except Exception as e:
-            Logger.debug(f"Handicap-Widget nicht gefunden: {e}")
+            Logger.warning(f"Handicap-Widget nicht gefunden: {e}")
 
     def dismiss_dialog(self, *args):
         """Schließt den aktiven Dialog"""

--- a/views/macht_popup.py
+++ b/views/macht_popup.py
@@ -617,7 +617,7 @@ class MachtDialogHandler:
                 elif widget and hasattr(widget, 'refresh'):
                     widget.refresh()
         except Exception as e:
-            Logger.debug(f"Macht-Widget nicht gefunden: {e}")
+            Logger.warning(f"Macht-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/pointbar_view.py
+++ b/views/pointbar_view.py
@@ -513,7 +513,7 @@ class GenerationPointsBar(MDBoxLayout):
             if not robustheit_text:
                 robustheit_wert = getattr(self.charakter, 'robustheit', 2)
                 robustheit_text = str(robustheit_wert)
-                Logger.debug(f"Fallback auf robustheit: {robustheit_text}")
+                Logger.warning(f"Fallback auf robustheit: {robustheit_text}")
             else:
                 Logger.debug(f"Verwende robustheit_mit_ruestung: {robustheit_text}")
 

--- a/views/ruestung_popup.py
+++ b/views/ruestung_popup.py
@@ -670,7 +670,7 @@ class RuestungDialogHandler:
                 elif widget and hasattr(widget, 'refresh_widget'):
                     widget.refresh_widget()
         except Exception as e:
-            Logger.debug(f"Ausrüstung-Widget nicht gefunden: {e}")
+            Logger.warning(f"Ausrüstung-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/schild_popup.py
+++ b/views/schild_popup.py
@@ -617,7 +617,7 @@ class SchildDialogHandler:
                 elif widget and hasattr(widget, 'refresh_widget'):
                     widget.refresh_widget()
         except Exception as e:
-            Logger.debug(f"Ausrüstung-Widget nicht gefunden: {e}")
+            Logger.warning(f"Ausrüstung-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/talent_popup.py
+++ b/views/talent_popup.py
@@ -611,7 +611,7 @@ class TalentDialogHandler:
                 elif widget and hasattr(widget, 'refresh'):
                     widget.refresh()
         except Exception as e:
-            Logger.debug(f"Talente-Widget nicht gefunden: {e}")
+            Logger.warning(f"Talente-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/volk_popup.py
+++ b/views/volk_popup.py
@@ -1756,7 +1756,7 @@ class VolkDialogHandler:
                 elif widget and hasattr(widget, 'refresh_widget'):
                     widget.refresh_widget()
         except Exception as e:
-            Logger.debug(f"Volk-Widget nicht gefunden: {e}")
+            Logger.warning(f"Volk-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""

--- a/views/waffe_popup.py
+++ b/views/waffe_popup.py
@@ -710,7 +710,7 @@ class WaffeDialogHandler:
                 elif widget and hasattr(widget, 'refresh_widget'):
                     widget.refresh_widget()
         except Exception as e:
-            Logger.debug(f"Ausrüstung-Widget nicht gefunden: {e}")
+            Logger.warning(f"Ausrüstung-Widget nicht gefunden: {e}")
 
     def _show_success_snackbar(self, message):
         """Zeigt eine Erfolgs-Snackbar an"""


### PR DESCRIPTION
18 Logger.debug()-Aufrufe wurden zu Logger.warning() hochgestuft,
da sie echte Warn- und Fehlerzustände darstellen (fehlende Widgets,
Mindeststärke nicht erfüllt, Fallback-Pfade, nicht gefundene Ressourcen).

https://claude.ai/code/session_01WwowDniWxh8EEbqF21UV8V