### PR TITLE
Fix: Bestätigungs-Dialog schließt sich nach Ausrüstung löschen nicht

### DIFF
--- a/views/ausruestung_popup.py
+++ b/views/ausruestung_popup.py
@@ -442,17 +442,17 @@ class AusruestungDialogHandler:
                 Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
 
         def _on_cancel(x):
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
 
         def _on_confirm_release(x):
-            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
-            # ausführen. Auf Android kann das synchrone Aufrufen von
-            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
-            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
-            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+            # dismiss() darf nicht synchron im on_release-Handler aufgerufen
+            # werden – auf Android blockiert das laufende Touch-Event die
+            # Dismiss-Animation. Daher erst im nächsten Frame schließen und
+            # on_confirm() mit ausreichend Abstand danach ausführen.
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.35)
 
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),

--- a/views/ruestung_popup.py
+++ b/views/ruestung_popup.py
@@ -351,17 +351,17 @@ class RuestungDialogHandler:
                 Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
 
         def _on_cancel(x):
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
 
         def _on_confirm_release(x):
-            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
-            # ausführen. Auf Android kann das synchrone Aufrufen von
-            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
-            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
-            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+            # dismiss() darf nicht synchron im on_release-Handler aufgerufen
+            # werden – auf Android blockiert das laufende Touch-Event die
+            # Dismiss-Animation. Daher erst im nächsten Frame schließen und
+            # on_confirm() mit ausreichend Abstand danach ausführen.
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.35)
 
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),

--- a/views/schild_popup.py
+++ b/views/schild_popup.py
@@ -346,17 +346,17 @@ class SchildDialogHandler:
                 Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
 
         def _on_cancel(x):
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
 
         def _on_confirm_release(x):
-            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
-            # ausführen. Auf Android kann das synchrone Aufrufen von
-            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
-            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
-            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+            # dismiss() darf nicht synchron im on_release-Handler aufgerufen
+            # werden – auf Android blockiert das laufende Touch-Event die
+            # Dismiss-Animation. Daher erst im nächsten Frame schließen und
+            # on_confirm() mit ausreichend Abstand danach ausführen.
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.35)
 
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),

--- a/views/waffe_popup.py
+++ b/views/waffe_popup.py
@@ -376,17 +376,17 @@ class WaffeDialogHandler:
                 Logger.warning(f"Fehler beim Schließen des Lösch-Dialogs: {e}")
 
         def _on_cancel(x):
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
 
         def _on_confirm_release(x):
-            # Dialog zuerst schließen, dann die eigentliche Aktion verzögert
-            # ausführen. Auf Android kann das synchrone Aufrufen von
-            # on_confirm() (mit UI-Refresh) die Dismiss-Animation unterbrechen
-            # und den Dialog in einem inkonsistenten Zustand hinterlassen.
-            _dismiss_confirm_popup()
-            Clock.schedule_once(_dismiss_confirm_popup, 0.15)
-            Clock.schedule_once(lambda dt: on_confirm(), 0.2)
+            # dismiss() darf nicht synchron im on_release-Handler aufgerufen
+            # werden – auf Android blockiert das laufende Touch-Event die
+            # Dismiss-Animation. Daher erst im nächsten Frame schließen und
+            # on_confirm() mit ausreichend Abstand danach ausführen.
+            Clock.schedule_once(lambda dt: _dismiss_confirm_popup(), 0)
+            Clock.schedule_once(_dismiss_confirm_popup, 0.2)
+            Clock.schedule_once(lambda dt: on_confirm(), 0.35)
 
         self._delete_confirm_popup = MDDialog(
             MDDialogHeadlineText(text=f"{item_type} löschen?"),


### PR DESCRIPTION
dismiss() darf auf Android nicht synchron im on_release-Handler
aufgerufen werden – das laufende Touch-Event blockiert die
Dismiss-Animation von MDDialog, sodass der Dialog sichtbar bleibt
obwohl die Lösch-Aktion bereits ausgeführt wurde.

Lösung: dismiss() per Clock.schedule_once(..., 0) auf den nächsten
Frame verschieben und on_confirm() mit 0.35 s Abstand ausführen,
damit die Dismiss-Animation vollständig abgeschlossen ist bevor
der UI-Refresh ausgelöst wird.

Betroffen: waffe_popup.py, ruestung_popup.py, schild_popup.py,
ausruestung_popup.py

https://claude.ai/code/session_01PFnCPATDdBx1FGkGEhzQAP