### PR TITLE
perf(android): Plan + Schritt 1 (Presplash)

### DIFF
--- a/plans/android_performance_plan.md
+++ b/plans/android_performance_plan.md
@@ -12,7 +12,27 @@ Die App läuft auf Desktop flüssig, fühlt sich auf Android aber träge an. Urs
 
 Ziel: Messbar schnellerer Kaltstart, flüssigere Tab-Wechsel, kein Freeze bei Charakter-Updates, keine Thread-Crashes auf Android. Änderungen sollen Desktop-Verhalten nicht verschlechtern.
 
-**Vorgehen:** Wir arbeiten diesen Plan Schritt für Schritt ab. Jeder Schritt wird einzeln implementiert, getestet und bestätigt, bevor der nächste begonnen wird.
+**Vorgehen:** Wir arbeiten diesen Plan Schritt für Schritt ab. Jeder Schritt wird einzeln implementiert, getestet und bestätigt, bevor der nächste begonnen wird. **Jeder Schritt bekommt einen eigenen PR** und — wo sinnvoll — passendes Logging sowie einen Unit-Test.
+
+---
+
+## Checkliste
+
+- [x] **Schritt 1** — Presplash in `buildozer.spec` aktivieren
+- [ ] **Schritt 2** — Tab-Screens lazy instanziieren (`main.py`)
+- [ ] **Schritt 3** — Nicht-kritische Services lazy (`service_container.py`)
+- [ ] **Schritt 4** — `BackupService` in Hintergrund-Thread
+- [ ] **Schritt 5** — `threading.Thread`-Gebrauch für Android absichern
+- [ ] **Schritt 6** — `Clock.schedule_once`-Ketten konsolidieren
+- [ ] **Schritt 7** — `CharakterbogenWidget` Update-in-Place
+- [ ] **Schritt 8** — Dialog-Wiederverwendung
+- [ ] **Schritt 9** — Binding-Lifecycle prüfen
+- [ ] **Schritt 10** — Theme-Color-Caching
+- [ ] **Schritt 11** — Debug-Build-Profil arm64-only
+- [ ] **Schritt 12** — `no-byte-compile-python` prüfen
+- [ ] **Schritt 13** — Release-Logging-Level reduzieren
+- [ ] **Schritt 14** — Startup-Timing-Logs in `main.py`
+- [ ] **Schritt 15** — On-Device-Profiling
 
 ---
 


### PR DESCRIPTION
## Summary

- **Plan-Dokument** `plans/android_performance_plan.md` mit 15-Schritte-Checkliste (P0/P1/P2) zur Verbesserung der Android-Performance: Startup, UI-Rendering, Thread-Sicherheit, Build-Optimierung.
- **Schritt 1 (Presplash)** in `buildozer.spec` aktiviert:
  - `presplash.filename = %(source.dir)s/assets/icon_512.png`
  - `android.presplash_color = #121212`
  
  Ersetzt den schwarzen Screen beim Android-Start durch das App-Icon auf dunklem Material-Hintergrund. Nur Config-Änderung — Desktop ist nicht betroffen.

## Arbeitsweise

Jeder folgende Schritt des Plans bekommt einen **eigenen PR**. Jeder PR bringt, wo sinnvoll, passendes Logging und einen Unit-Test mit.

## Test plan

- [x] Desktop-Smoke: `python main.py` startet unverändert (Presplash ist Android-only).
- [ ] Android-Build-Check: beim nächsten `buildozer android debug` wird das Icon als Presplash angezeigt.

https://claude.ai/code/session_01RvSB3xi2CLhQAoBdfrFSkz