### PR TITLE
perf(android): Schritt 3 — Nicht-kritische Services lazy

### DIFF
--- a/plans/android_performance_plan.md
+++ b/plans/android_performance_plan.md
@@ -20,7 +20,7 @@ Ziel: Messbar schnellerer Kaltstart, flüssigere Tab-Wechsel, kein Freeze bei Ch
 
 - [x] **Schritt 1** — Presplash in `buildozer.spec` aktivieren
 - [x] **Schritt 2** — Tab-Screens lazy instanziieren (`main.py`)
-- [ ] **Schritt 3** — Nicht-kritische Services lazy (`service_container.py`)
+- [x] **Schritt 3** — Nicht-kritische Services lazy (`service_container.py`)
 - [ ] **Schritt 4** — `BackupService` in Hintergrund-Thread
 - [ ] **Schritt 5** — `threading.Thread`-Gebrauch für Android absichern
 - [ ] **Schritt 6** — `Clock.schedule_once`-Ketten konsolidieren

--- a/services/service_container.py
+++ b/services/service_container.py
@@ -4,9 +4,10 @@ Service Container für Dependency Injection
 Zentralisiert die Verwaltung aller Services
 """
 
+import time
 from kivy.logger import Logger
 from kivy.app import App
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Callable
 
 # Service Imports
 from services.theme_service import ThemeService
@@ -25,76 +26,132 @@ class ServiceContainer:
     """
     Dependency Injection Container für alle Services
     Implementiert Singleton-Pattern für Service-Instanzen
+
+    Services werden teilweise lazy initialisiert: Nicht-kritische Services
+    (`backup`, `tutorial`, `pdf`, `html`) werden erst beim ersten Zugriff
+    erzeugt — das spart Startup-Zeit auf Android.
     """
-    
+
     _instance = None
     _services: Dict[str, Any] = {}
+    _lazy_factories: Dict[str, Callable[[], Any]] = {}
     _initialized = False
-    
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         if not self._initialized:
             self._initialized = True
             Logger.info("ServiceContainer initialisiert")
-    
+
     def initialize(self, charakter_controller):
         """
-        Initialisiert alle Services mit den erforderlichen Abhängigkeiten
-        
+        Initialisiert alle Services mit den erforderlichen Abhängigkeiten.
+
+        Kernservices werden sofort instanziiert, nicht-kritische Services
+        nur als Factory registriert und beim ersten Zugriff erzeugt.
+
         Args:
             charakter_controller: Der Hauptcontroller für Charakterverwaltung
         """
         try:
             app = App.get_running_app()
             theme_cls = app.theme_cls if app else None
-            
-            # Core Services
+
+            # --- Kernservices (eager) ---
             self._services['config'] = ConfigService()
             self._services['event'] = EventService()
             self._services['theme'] = ThemeService()
-            self._services['backup'] = BackupService(self._services['config'])
-            self._services['tutorial'] = TutorialService(self._services['config'])
             self._services['wizard'] = WizardService()
-            
+
+            # --- Nicht-kritische Services (lazy) ---
+            config_service = self._services['config']
+            self._lazy_factories['backup'] = lambda: BackupService(config_service)
+            self._lazy_factories['tutorial'] = lambda: TutorialService(config_service)
+
             # Controller-abhängige Services
             if charakter_controller:
                 # Controller selbst registrieren
                 self._services['charakter_controller'] = charakter_controller
-                
+
+                # FileManager wird früh gebraucht (Auto-Load) → eager
                 self._services['file_manager'] = FileManagerService(charakter_controller)
-                self._services['pdf'] = PDFService(charakter_controller)
-                self._services['html'] = HTMLService(charakter_controller)
-                
+
+                # PDF/HTML erst bei Export nötig → lazy
+                self._lazy_factories['pdf'] = lambda: PDFService(charakter_controller)
+                self._lazy_factories['html'] = lambda: HTMLService(charakter_controller)
+
                 if theme_cls:
+                    # Dialog wird bei fast jeder Nutzeraktion gebraucht → eager
                     self._services['dialog'] = DialogService(charakter_controller, theme_cls)
-            
-            Logger.info("Alle Services erfolgreich initialisiert")
-            
-            # Event über erfolgreiche Initialisierung senden
+
+            eager = sorted(self._services.keys())
+            lazy = sorted(self._lazy_factories.keys())
+            Logger.info(
+                f"ServiceContainer: {len(eager)} eager Services "
+                f"({', '.join(eager)}), {len(lazy)} lazy Services "
+                f"({', '.join(lazy)})"
+            )
+
+            # Event über erfolgreiche Initialisierung senden (nur eager Services)
             if 'event' in self._services:
-                self._services['event'].publish('services_initialized', self._services.keys())
-                
+                self._services['event'].publish('services_initialized', list(self._services.keys()))
+
         except Exception as e:
             Logger.error(f"Fehler bei Service-Initialisierung: {str(e)}", exc_info=True)
     
     def get_service(self, service_name: str) -> Optional[Any]:
         """
-        Gibt einen Service zurück
-        
+        Gibt einen Service zurück. Erzeugt Lazy-Services beim ersten Zugriff.
+
         Args:
             service_name (str): Name des Services
-            
+
         Returns:
             Service-Instanz oder None
         """
         service = self._services.get(service_name)
-        if not service:
-            Logger.warning(f"Service '{service_name}' nicht gefunden oder nicht initialisiert")
-        return service
+        if service is not None:
+            return service
+
+        # Lazy-Factory vorhanden? → jetzt erzeugen
+        factory = self._lazy_factories.get(service_name)
+        if factory is not None:
+            try:
+                start = time.monotonic()
+                service = factory()
+                elapsed_ms = (time.monotonic() - start) * 1000.0
+                self._services[service_name] = service
+                # Factory nur einmal aufrufen
+                del self._lazy_factories[service_name]
+                Logger.info(
+                    f"Lazy-Service: '{service_name}' in {elapsed_ms:.1f} ms instanziiert"
+                )
+
+                # Event senden, falls EventService verfügbar
+                event_service = self._services.get('event')
+                if event_service and service_name != 'event':
+                    try:
+                        event_service.publish(
+                            'service_lazy_initialized',
+                            {'name': service_name, 'elapsed_ms': elapsed_ms}
+                        )
+                    except Exception:
+                        pass  # Event-Fehler darf Service-Nutzung nicht blockieren
+
+                return service
+            except Exception as e:
+                Logger.error(
+                    f"Fehler beim Lazy-Init von Service '{service_name}': {str(e)}",
+                    exc_info=True
+                )
+                return None
+
+        Logger.warning(f"Service '{service_name}' nicht gefunden oder nicht initialisiert")
+        return None
     
     def get_theme_service(self) -> Optional[ThemeService]:
         """Gibt den Theme-Service zurück"""
@@ -172,24 +229,48 @@ class ServiceContainer:
     
     def is_service_available(self, service_name: str) -> bool:
         """
-        Prüft, ob ein Service verfügbar ist
-        
+        Prüft, ob ein Service verfügbar ist (bereits instanziiert oder
+        via Lazy-Factory verfügbar).
+
         Args:
             service_name (str): Service-Name
-            
+
         Returns:
             bool: True wenn verfügbar
         """
+        if service_name in self._services and self._services[service_name] is not None:
+            return True
+        return service_name in self._lazy_factories
+
+    def is_service_loaded(self, service_name: str) -> bool:
+        """
+        Prüft, ob ein Service tatsächlich bereits instanziiert wurde.
+
+        Nützlich für Shutdown-Pfade und Tests, um Lazy-Services nicht
+        unnötig zu materialisieren.
+
+        Args:
+            service_name (str): Service-Name
+
+        Returns:
+            bool: True wenn Service bereits erzeugt wurde
+        """
         return service_name in self._services and self._services[service_name] is not None
-    
+
     def get_service_status(self) -> Dict[str, bool]:
         """
-        Gibt den Status aller Services zurück
-        
+        Gibt den Status aller Services zurück.
+
+        Lazy-Services, die noch nicht instanziiert wurden, erscheinen mit
+        `False`.
+
         Returns:
-            dict: Service-Name -> Verfügbarkeit
+            dict: Service-Name -> bereits instanziiert
         """
-        return {name: service is not None for name, service in self._services.items()}
+        status = {name: service is not None for name, service in self._services.items()}
+        for lazy_name in self._lazy_factories:
+            status.setdefault(lazy_name, False)
+        return status
     
     def shutdown(self):
         """Beendet alle Services ordnungsgemäß"""
@@ -210,6 +291,7 @@ class ServiceContainer:
         
         # Services entfernen
         self._services.clear()
+        self._lazy_factories.clear()
         Logger.info("ServiceContainer heruntergefahren")
 
 

--- a/test units/run_all_tests.py
+++ b/test units/run_all_tests.py
@@ -55,6 +55,7 @@ TEST_MODULE = [
     'test_setting_draft',
     'test_setting_merge',
     'test_lazy_screens',
+    'test_lazy_services',
 ]
 
 # Doppelte entfernen

--- a/test units/test_lazy_services.py
+++ b/test units/test_lazy_services.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Unit Tests für Lazy-Service-Initialisierung (services/service_container.py).
+
+Tests zu Plan-Schritt 3 der Android-Performance-Optimierung:
+- Kern-Services sind nach initialize() sofort verfügbar.
+- Nicht-kritische Services sind nach initialize() NICHT instanziiert.
+- Erster Zugriff auf Lazy-Service erzeugt Instanz via Factory.
+- Zweiter Zugriff liefert dieselbe Instanz (Idempotenz).
+- is_service_loaded unterscheidet eager/lazy korrekt.
+- Factory-Fehler blockieren ServiceContainer nicht.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+try:  # pragma: no cover
+    import kivy  # noqa: F401
+    _KIVY_AVAILABLE = True
+except Exception:
+    _KIVY_AVAILABLE = False
+
+
+@unittest.skipUnless(_KIVY_AVAILABLE, "Kivy nicht verfügbar")
+class TestLazyServices(unittest.TestCase):
+    """Testet die Lazy-Service-Erzeugung im ServiceContainer."""
+
+    def setUp(self):
+        # Singleton-State zwischen Tests zurücksetzen
+        from services.service_container import ServiceContainer
+        ServiceContainer._services = {}
+        ServiceContainer._lazy_factories = {}
+        self.container = ServiceContainer()
+
+    def tearDown(self):
+        from services.service_container import ServiceContainer
+        ServiceContainer._services = {}
+        ServiceContainer._lazy_factories = {}
+
+    def _init_container(self, with_controller=True):
+        """Initialisiert den Container mit gemockten Service-Klassen."""
+        controller = MagicMock() if with_controller else None
+        # App.get_running_app() gibt None zurück → kein Dialog-Service
+        with patch('services.service_container.App') as mock_app:
+            mock_app.get_running_app.return_value = None
+            self.container.initialize(controller)
+
+    # ---------- Eager Services ----------
+
+    def test_core_services_are_eager(self):
+        """ConfigService, EventService, ThemeService, WizardService sofort verfügbar."""
+        self._init_container()
+        for name in ('config', 'event', 'theme', 'wizard'):
+            self.assertTrue(
+                self.container.is_service_loaded(name),
+                f"Kernservice '{name}' sollte eager sein"
+            )
+
+    def test_file_manager_eager_with_controller(self):
+        """FileManagerService wird eager erzeugt, wenn Controller vorhanden."""
+        self._init_container(with_controller=True)
+        self.assertTrue(self.container.is_service_loaded('file_manager'))
+        self.assertTrue(self.container.is_service_loaded('charakter_controller'))
+
+    # ---------- Lazy Services ----------
+
+    def test_lazy_services_not_loaded_after_init(self):
+        """backup, tutorial, pdf, html sind nach init NICHT instanziiert."""
+        self._init_container()
+        for name in ('backup', 'tutorial', 'pdf', 'html'):
+            self.assertFalse(
+                self.container.is_service_loaded(name),
+                f"Lazy-Service '{name}' darf nach init nicht geladen sein"
+            )
+            self.assertTrue(
+                self.container.is_service_available(name),
+                f"Lazy-Service '{name}' sollte verfügbar (via Factory) sein"
+            )
+
+    def test_lazy_service_is_created_on_first_access(self):
+        """Erster Zugriff erzeugt Lazy-Service."""
+        self._init_container()
+        service = self.container.get_service('backup')
+        self.assertIsNotNone(service)
+        self.assertTrue(self.container.is_service_loaded('backup'))
+
+    def test_lazy_service_is_idempotent(self):
+        """Zweiter Zugriff liefert dieselbe Instanz (Factory nur 1x)."""
+        self._init_container()
+        first = self.container.get_service('tutorial')
+        second = self.container.get_service('tutorial')
+        self.assertIs(first, second)
+
+    def test_lazy_factory_removed_after_first_call(self):
+        """Nach erstem Zugriff ist die Factory weg (kein doppeltes Erzeugen möglich)."""
+        self._init_container()
+        _ = self.container.get_service('pdf')
+        self.assertNotIn('pdf', self.container._lazy_factories)
+        self.assertIn('pdf', self.container._services)
+
+    def test_get_backup_service_triggers_lazy_init(self):
+        """Convenience-Getter erzeugt Lazy-Service korrekt."""
+        self._init_container()
+        self.assertFalse(self.container.is_service_loaded('backup'))
+        service = self.container.get_backup_service()
+        self.assertIsNotNone(service)
+        self.assertTrue(self.container.is_service_loaded('backup'))
+
+    # ---------- Fehlerbehandlung ----------
+
+    def test_factory_error_returns_none_and_does_not_crash(self):
+        """Wenn eine Factory eine Exception wirft, bekommt der Caller None zurück."""
+        self._init_container()
+        self.container._lazy_factories['broken'] = lambda: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        result = self.container.get_service('broken')
+        self.assertIsNone(result)
+        # Weitere Services dürfen weiterhin funktionieren
+        self.assertIsNotNone(self.container.get_service('config'))
+
+    def test_unknown_service_returns_none(self):
+        """Unbekannter Service-Name liefert None ohne Crash."""
+        self._init_container()
+        self.assertIsNone(self.container.get_service('does_not_exist'))
+
+    # ---------- Status & Available ----------
+
+    def test_get_service_status_includes_lazy(self):
+        """get_service_status zeigt Lazy-Services als False, Eager als True."""
+        self._init_container()
+        status = self.container.get_service_status()
+        self.assertTrue(status.get('config'))
+        self.assertFalse(status.get('backup'))
+        self.assertFalse(status.get('tutorial'))
+        self.assertFalse(status.get('pdf'))
+        self.assertFalse(status.get('html'))
+
+    def test_is_service_available_true_for_lazy(self):
+        """is_service_available gibt True auch für nicht-instanziierte Lazy-Services."""
+        self._init_container()
+        self.assertTrue(self.container.is_service_available('backup'))
+        self.assertTrue(self.container.is_service_available('tutorial'))
+        self.assertTrue(self.container.is_service_available('pdf'))
+        self.assertTrue(self.container.is_service_available('html'))
+
+    def test_is_service_available_false_for_unknown(self):
+        """is_service_available gibt False für unbekannte Services."""
+        self._init_container()
+        self.assertFalse(self.container.is_service_available('unknown_svc'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Schritt 3 des Android-Performance-Plans

Services `backup`, `tutorial`, `pdf`, `html` werden nicht mehr im `ServiceContainer.initialize()` instanziiert, sondern erst beim ersten Zugriff über eine registrierte Factory erzeugt. Das spart Startup-Zeit auf Android — insbesondere der `BackupService` (ZIP + Hash-Check) blockt nicht mehr den Startup-Pfad.

### Änderungen

- **`services/service_container.py`**
  - Neue Klassenvariable `_lazy_factories: Dict[str, Callable]`
  - `initialize()` spaltet in eager (`config`, `event`, `theme`, `wizard`, `dialog`, `file_manager`, `charakter_controller`) und lazy (`backup`, `tutorial`, `pdf`, `html`)
  - `get_service()` fällt bei fehlendem Service auf Factory zurück, misst Init-Zeit, loggt `"Lazy-Service: '<name>' in X.X ms instanziiert"`, feuert Event `service_lazy_initialized`
  - Neuer Helfer `is_service_loaded()` unterscheidet "bereits erzeugt" von "verfügbar via Factory"
  - `get_service_status()` zeigt Lazy-Services als `False` bis zur Instanziierung
  - `shutdown()` räumt `_lazy_factories` mit auf
  - Factory-Fehler werden gefangen → Caller bekommt `None`, Container crasht nicht

### Logging

```
[INFO] ServiceContainer: 7 eager Services (charakter_controller, config, dialog, event, file_manager, theme, wizard),
                        4 lazy Services (backup, html, pdf, tutorial)
[INFO] Lazy-Service: 'backup' in 12.3 ms instanziiert   ← beim ersten Zugriff
```

### Test-Unit

`test units/test_lazy_services.py` — 12 Tests mit `@unittest.skipUnless(_KIVY_AVAILABLE, ...)`-Guard:
- `test_core_services_are_eager` — config/event/theme/wizard sofort da
- `test_file_manager_eager_with_controller` — file_manager + controller eager
- `test_lazy_services_not_loaded_after_init` — backup/tutorial/pdf/html nicht instanziiert
- `test_lazy_service_is_created_on_first_access` — erster Zugriff erzeugt
- `test_lazy_service_is_idempotent` — zweiter Zugriff liefert dieselbe Instanz
- `test_lazy_factory_removed_after_first_call` — Factory verschwindet nach Erstellung
- `test_get_backup_service_triggers_lazy_init` — Convenience-Getter funktioniert
- `test_factory_error_returns_none_and_does_not_crash` — robustes Error-Handling
- `test_unknown_service_returns_none` — unbekannter Name → None
- `test_get_service_status_includes_lazy` — Status-Dict korrekt
- `test_is_service_available_true_for_lazy` — Lazy gilt als verfügbar
- `test_is_service_available_false_for_unknown` — unbekannt gilt als nicht verfügbar

### Kompatibilität

Alle bestehenden Aufrufstellen (`get_backup_service()`, `get_tutorial_service()`, `get_pdf_service()`, `get_html_service()` in main.py, pdf_manager.py, html_manager.py, file_manager_service.py) funktionieren unverändert — die Lazy-Erzeugung ist für den Caller transparent.

### Test plan

- [x] Syntax-Check: `python -c "import ast; ast.parse(...)"`
- [x] Logik-Smoketest mit Kivy-Stubs: alle Asserts grün
- [x] `test units/run_all_tests.py test_lazy_services`: 12 skipped (CI ohne Kivy — erwartet), 0 Fehler
- [ ] Desktop-Smoketest: `python main.py` — Startup-Log zeigt eager/lazy-Split, erste PDF/HTML-Export-Aktion triggert Lazy-Init
- [ ] Android-Build: Startup sollte messbar schneller sein

Teil des Plans: [`plans/android_performance_plan.md`](../blob/main/plans/android_performance_plan.md) — Schritt 3 abgehakt.