### PR TITLE
fix(android): Mobile-Nav triggert Lazy-Screen-Erzeugung (Schritt-2-Bugfix)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1428,12 +1428,15 @@ class SW_Charakter_GeneratorApp(MDApp):
 
             if 0 <= tab_index < len(self.tab_definitions):
                 tab_text = self.tab_definitions[tab_index][1]
-                clean_name = tab_text.lower().replace(' ', '_').replace('ä', 'ae').replace('ö', 'oe').replace('ü', 'ue').replace('ß', 'ss')
-                screen_name = f"screen_{tab_index}_{clean_name}"
+
+                # Lazy-Instanziierung sicherstellen
+                screen, screen_name = self._instantiate_screen(tab_index, screen_manager)
+                if screen is None or screen_name is None:
+                    Logger.warning(f"Bottom-Nav: Screen für Tab '{tab_text}' konnte nicht erzeugt werden")
+                    return True
 
                 screen_manager.transition = NoTransition()
                 try:
-                    screen_manager.get_screen(screen_name)
                     screen_manager.current = screen_name
                 except Exception:
                     Logger.warning(f"Screen '{screen_name}' nicht gefunden")
@@ -1667,12 +1670,15 @@ class SW_Charakter_GeneratorApp(MDApp):
                 return
 
             tab_text = self.tab_definitions[index][1]
-            clean_name = tab_text.lower().replace(' ', '_').replace('ä', 'ae').replace('ö', 'oe').replace('ü', 'ue').replace('ß', 'ss')
-            screen_name = f"screen_{index}_{clean_name}"
+
+            # Lazy-Instanziierung sicherstellen
+            screen, screen_name = self._instantiate_screen(index, screen_manager)
+            if screen is None or screen_name is None:
+                Logger.warning(f"Popup-Wechsel: Screen für Tab '{tab_text}' konnte nicht erzeugt werden")
+                return
 
             screen_manager.transition = NoTransition()
             try:
-                screen_manager.get_screen(screen_name)
                 screen_manager.current = screen_name
             except Exception:
                 Logger.warning(f"Screen '{screen_name}' nicht gefunden")
@@ -1727,14 +1733,17 @@ class SW_Charakter_GeneratorApp(MDApp):
 
             if 0 <= item_index < len(self.tab_definitions):
                 tab_text = self.tab_definitions[item_index][1]
-                clean_name = tab_text.lower().replace(' ', '_').replace('ä', 'ae').replace('ö', 'oe').replace('ü', 'ue').replace('ß', 'ss')
-                screen_name = f"screen_{item_index}_{clean_name}"
+
+                # Lazy-Instanziierung sicherstellen
+                screen, screen_name = self._instantiate_screen(item_index, screen_manager)
+                if screen is None or screen_name is None:
+                    Logger.warning(f"NavigationRail: Screen für Tab '{tab_text}' konnte nicht erzeugt werden")
+                    return True
 
                 # Transition ohne Animation bei direktem Tap
                 screen_manager.transition = NoTransition()
 
                 try:
-                    screen_manager.get_screen(screen_name)
                     screen_manager.current = screen_name
                 except Exception:
                     Logger.warning(f"Screen '{screen_name}' nicht gefunden")


### PR DESCRIPTION
## Bugfix zu Schritt 2 (Lazy-Screens) — Mobile-Nav

Unter `force_mobile_layout: true` (und auf Android) kamen beim Tab-Wechsel wiederholt diese Warnungen:

```
[WARNING] Screen 'screen_1_einstellungen' nicht gefunden
[WARNING] Screen 'screen_6_talente' nicht gefunden
```

### Ursache

Drei Mobile-Navigations-Handler setzten `screen_manager.current` **direkt** auf den Screen-Namen — **ohne** `_instantiate_screen()` vorher zu rufen. Da in PR #171 nur Tab 0 eager instanziiert wird, existierten die anderen Screens zu dem Zeitpunkt noch nicht im `ScreenManager`, und der Tab-Wechsel scheiterte lautlos.

**Betroffene Methoden:**

| Zeile | Methode | Pfad |
|---|---|---|
| `main.py:1429` | `_on_bottom_nav_touch` | Bottom-Nav-Tap (Mobile-Layout) |
| `main.py:1672` | `_switch_to_tab_from_popup` | „Mehr"-Popup Tab-Auswahl |
| `main.py:1735` | `_on_rail_item_touch` | NavigationRail-Tap |

Die beiden anderen Pfade (`on_tab_switch`, `_switch_to_tab_index`) waren bereits korrekt — hier ist mir das Pattern beim Refactor durchgerutscht.

### Fix

Alle drei Pfade routen jetzt über `_instantiate_screen(tab_index, sm)`, das bei Bedarf den Screen lazy erzeugt, registriert und den Screen-Namen zurückgibt. Dabei:

- Dupliziertes Name-Building (umlaut-replace) fällt weg (kommt aus `_screen_name_for_tab`).
- Der bestehende `screen_manager.get_screen()`-Sanity-Check entfällt — Lazy-Instanziierung garantiert Existenz.
- Fehlerpfad loggt aussagekräftige Warnung (z. B. „Bottom-Nav: Screen für Tab 'Einstellungen' konnte nicht erzeugt werden").

### Test plan

- [x] Syntax-Check: `python -c "import ast; ast.parse(open('main.py').read())"` — OK
- [ ] Lokal: `python main.py` mit `"force_mobile_layout": true` in `config/app_config.json`, durch alle Tabs tappen — kein „Screen nicht gefunden" mehr im Log
- [ ] Android-APK: Bottom-Nav / NavigationRail / „Mehr"-Popup testen

### Abdeckung

`_instantiate_screen` selbst ist durch `test units/test_lazy_screens.py` bereits getestet (Idempotenz, Orphan-Recovery, ungültiger Index). Die drei betroffenen Handler sind integrations-nah und schwer zu unit-testen (erfordern vollständig aufgebauten Kivy-Widget-Tree).

Teil des Plans: [`plans/android_performance_plan.md`](../blob/main/plans/android_performance_plan.md) — **Bugfix** zu Schritt 2.