### PR TITLE
fix(services): Lazy-Factories vor eager Konstruktion + Tests mocken Services

### DIFF
--- a/services/service_container.py
+++ b/services/service_container.py
@@ -67,26 +67,35 @@ class ServiceContainer:
             self._services['theme'] = ThemeService()
             self._services['wizard'] = WizardService()
 
-            # --- Nicht-kritische Services (lazy) ---
+            # --- Nicht-kritische Services als Lazy-Factories registrieren ---
+            # WICHTIG: Erst alle Factories registrieren, dann erst eager construieren.
+            # So bleiben Factories registriert, auch wenn ein eager-Service-Constructor
+            # später scheitert.
             config_service = self._services['config']
             self._lazy_factories['backup'] = lambda: BackupService(config_service)
             self._lazy_factories['tutorial'] = lambda: TutorialService(config_service)
 
-            # Controller-abhängige Services
+            if charakter_controller:
+                self._lazy_factories['pdf'] = lambda: PDFService(charakter_controller)
+                self._lazy_factories['html'] = lambda: HTMLService(charakter_controller)
+
+            # --- Controller-abhängige eager Services ---
             if charakter_controller:
                 # Controller selbst registrieren
                 self._services['charakter_controller'] = charakter_controller
 
                 # FileManager wird früh gebraucht (Auto-Load) → eager
-                self._services['file_manager'] = FileManagerService(charakter_controller)
-
-                # PDF/HTML erst bei Export nötig → lazy
-                self._lazy_factories['pdf'] = lambda: PDFService(charakter_controller)
-                self._lazy_factories['html'] = lambda: HTMLService(charakter_controller)
+                try:
+                    self._services['file_manager'] = FileManagerService(charakter_controller)
+                except Exception as e:
+                    Logger.error(f"FileManagerService-Init fehlgeschlagen: {e}", exc_info=True)
 
                 if theme_cls:
                     # Dialog wird bei fast jeder Nutzeraktion gebraucht → eager
-                    self._services['dialog'] = DialogService(charakter_controller, theme_cls)
+                    try:
+                        self._services['dialog'] = DialogService(charakter_controller, theme_cls)
+                    except Exception as e:
+                        Logger.error(f"DialogService-Init fehlgeschlagen: {e}", exc_info=True)
 
             eager = sorted(self._services.keys())
             lazy = sorted(self._lazy_factories.keys())

--- a/test units/test_lazy_services.py
+++ b/test units/test_lazy_services.py
@@ -38,7 +38,26 @@ class TestLazyServices(unittest.TestCase):
         ServiceContainer._lazy_factories = {}
         self.container = ServiceContainer()
 
+        # Alle Service-Klassen durch MagicMock ersetzen — Tests prüfen die
+        # ServiceContainer-Logik, nicht echte Service-Implementierungen.
+        self._patches = [
+            patch('services.service_container.ConfigService', MagicMock()),
+            patch('services.service_container.EventService', MagicMock()),
+            patch('services.service_container.ThemeService', MagicMock()),
+            patch('services.service_container.WizardService', MagicMock()),
+            patch('services.service_container.BackupService', MagicMock()),
+            patch('services.service_container.TutorialService', MagicMock()),
+            patch('services.service_container.FileManagerService', MagicMock()),
+            patch('services.service_container.PDFService', MagicMock()),
+            patch('services.service_container.HTMLService', MagicMock()),
+            patch('services.service_container.DialogService', MagicMock()),
+        ]
+        for p in self._patches:
+            p.start()
+
     def tearDown(self):
+        for p in self._patches:
+            p.stop()
         from services.service_container import ServiceContainer
         ServiceContainer._services = {}
         ServiceContainer._lazy_factories = {}


### PR DESCRIPTION
## Follow-up zu PR #172

Zwei Probleme, die beim ersten Test-Durchlauf in der echten Kivy-Umgebung aufgefallen sind. **Zielbranch ist `claude/android-perf-step-3-lazy-services`** (Grund-PR #172), weil die geänderten Dateien erst dort existieren.

### Problem 1 — Fragile Init-Reihenfolge

Die Lazy-Factories für `pdf` und `html` wurden **nach** dem eager `FileManagerService(controller)`-Aufruf registriert. Wenn der — z. B. mit unvollständigen Test-Inputs oder in Edge-Cases — eine Exception wirft, fängt das umschließende `try/except` sie. **Dabei gehen die noch nicht registrierten Lazy-Factories verloren**, weil der Control-Flow nie dort ankommt.

**Fix:** Reihenfolge umgedreht — erst alle Lazy-Factories registrieren, dann eager konstruieren. Zusätzlich eigenes `try/except` pro eager controller-abhängigem Service (`file_manager`, `dialog`), damit ein Einzelfehler nicht den gesamten Init sprengt.

```python
# Vorher: Lazy-Factories NACH eager → FileManager-Crash killt pdf/html
self._services['file_manager'] = FileManagerService(controller)  # crasht → Rest übersprungen
self._lazy_factories['pdf'] = lambda: PDFService(controller)     # nie erreicht
self._lazy_factories['html'] = lambda: HTMLService(controller)

# Nachher: Lazy-Factories ZUERST → FileManager-Crash egal
self._lazy_factories['pdf'] = lambda: PDFService(controller)
self._lazy_factories['html'] = lambda: HTMLService(controller)
try:
    self._services['file_manager'] = FileManagerService(controller)
except Exception as e:
    Logger.error(...)
```

### Problem 2 — Tests waren von echten Service-Implementierungen abhängig

`test units/test_lazy_services.py` übergab `MagicMock()` als Controller. In der echten Kivy-Umgebung konnte `FileManagerService(MagicMock())` scheitern (strikte Typ-Checks oder I/O im Constructor). Dadurch sind 4 Tests fehlgeschlagen.

**Fix:** `setUp()` patcht alle 10 Service-Klassen (`ConfigService`, `EventService`, `BackupService`, `FileManagerService`, …) durch `MagicMock`. Die Tests prüfen jetzt ausschließlich die Container-Logik — nicht die Service-Implementierungen.

### Test plan

- [x] Smoke-Test mit simuliertem FileManager-Crash: lazy Factories bleiben registriert
- [x] Smoke-Test Normalfall: eager/lazy-Split korrekt
- [x] Syntax-Check: `python -c "import ast; ast.parse(...)"`
- [ ] CI auf dieser Branch (nach Merge von PR #172 wird der Test-Run sauber)

### Zusammenhang

| PR | Inhalt | Basis |
|---|---|---|
| #172 | Schritt 3: Lazy-Services-Grundfunktionalität | `main` |
| Dieser PR | Resilience-Fix + Test-Mocking | PR #172 |

Nach Merge von #172 kann dieser PR gegen `main` rebased werden, falls gewünscht.