### PR TITLE
fix(android): PDF/HTML-Export unter Scoped Storage reparieren

### DIFF
--- a/manager/html_manager.py
+++ b/manager/html_manager.py
@@ -486,23 +486,17 @@ class HTMLManager:
         import os
         from kivy.utils import platform as kivy_platform
 
-        # Android: HTTP-Server-Threads vermeiden (JVM-Crash-Risiko)
+        # Android: HTTP-Server-Threads vermeiden (JVM-Crash-Risiko).
+        # Wir werfen eine Exception, damit der Aufrufer (_open_file_on_android)
+        # auf die nächste Strategie fällt (FileProvider/Share-Intent).
+        # `webbrowser.open("file://...")` löst auf Android ≥ 7 eine
+        # FileUriExposedException aus und funktioniert nicht.
         if kivy_platform == 'android':
             Logger.warning(
                 "HTMLManager: HTTP-Server auf Android deaktiviert (Thread-Safety). "
-                "Nutzen Sie stattdessen den PDF-Export über android_print_utils.py"
+                "Fallback auf FileProvider/Share-Intent über android_print_utils.py"
             )
-
-            # Alternative: Datei per FileProvider öffnen (fallback)
-            try:
-                import webbrowser
-                abs_path = os.path.abspath(file_path)
-                Logger.info(f"Android: Versuche HTML-Datei über FileProvider zu öffnen: {abs_path}")
-                webbrowser.open(f"file://{abs_path}")
-            except Exception as e:
-                Logger.error(f"Android: Fallback HTML-Öffnung fehlgeschlagen: {e}")
-
-            return
+            raise RuntimeError("HTTP-Server auf Android deaktiviert")
 
         # Desktop: HTTP-Server wie bisher (thread-sicher)
         import threading

--- a/test units/run_all_tests.py
+++ b/test units/run_all_tests.py
@@ -56,6 +56,7 @@ TEST_MODULE = [
     'test_setting_merge',
     'test_lazy_screens',
     'test_lazy_services',
+    'test_android_scoped_storage',
 ]
 
 # Doppelte entfernen

--- a/test units/test_android_scoped_storage.py
+++ b/test units/test_android_scoped_storage.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Unit Tests für den Android Scoped-Storage-Fix in `utils/android_print_utils.py`
+und die Android-Fallback-Logik in `manager/html_manager.py::_open_via_localhost`.
+
+Hintergrund: Unter Scoped Storage (targetSdk ≥ 29) ist
+`/storage/emulated/0/Download/` für normale Apps nicht mehr beschreibbar —
+`open(..., 'w')` scheitert mit PermissionError. Der Fix bevorzugt die
+app-private externe Ablage (`getExternalFilesDir(DOWNLOADS)`), die ohne
+Runtime-Permission immer beschreibbar ist.
+
+Zusätzlich: Auf Android muss `_open_via_localhost` eine Exception werfen,
+damit `_open_file_on_android` auf FileProvider (Strategie 2) fällt — der
+bisherige `webbrowser.open("file://...")`-Fallback löst eine
+FileUriExposedException aus.
+"""
+
+import inspect
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+try:  # pragma: no cover
+    import kivy  # noqa: F401
+    _KIVY_AVAILABLE = True
+except Exception:
+    _KIVY_AVAILABLE = False
+
+
+@unittest.skipUnless(_KIVY_AVAILABLE, "Kivy nicht verfügbar")
+class TestGetDownloadsPath(unittest.TestCase):
+    """Testet `get_downloads_path()` unter verschiedenen Android-Pfadverfügbarkeiten."""
+
+    def setUp(self):
+        # Fake `jnius.autoclass` — nur Environment/PythonActivity werden gebraucht.
+        self._env = MagicMock(name='Environment')
+        self._env.DIRECTORY_DOWNLOADS = 'Download'
+
+        self._context = MagicMock(name='mActivity')
+        python_activity = MagicMock(name='PythonActivity')
+        python_activity.mActivity = self._context
+
+        def _autoclass(name):
+            if name == 'android.os.Environment':
+                return self._env
+            if name == 'org.kivy.android.PythonActivity':
+                return python_activity
+            raise AssertionError(f"Unerwarteter autoclass-Aufruf: {name}")
+
+        self._fake_jnius = MagicMock()
+        self._fake_jnius.autoclass.side_effect = _autoclass
+
+        self._patches = [
+            patch.dict('sys.modules', {'jnius': self._fake_jnius}),
+            patch('utils.android_print_utils.is_android', return_value=True),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def _make_dir(self, path, exists=True):
+        d = MagicMock()
+        d.exists.return_value = exists
+        d.getAbsolutePath.return_value = path
+        return d
+
+    def test_prefers_app_private_external_dir(self):
+        """App-private externer Downloads-Ordner wird bevorzugt."""
+        from utils import android_print_utils
+
+        app_private = self._make_dir('/data/user/0/app/files/Download', exists=True)
+        self._context.getExternalFilesDir.return_value = app_private
+        self._context.getFilesDir.return_value = self._make_dir('/data/user/0/app/files')
+
+        result = android_print_utils.get_downloads_path()
+
+        self.assertEqual(result, '/data/user/0/app/files/Download')
+        self._context.getExternalFilesDir.assert_called_once_with('Download')
+        # Öffentlicher Scoped-Storage-Pfad darf NICHT verwendet werden
+        self._env.getExternalStoragePublicDirectory.assert_not_called()
+
+    def test_creates_app_private_dir_if_missing(self):
+        """Wenn externes Verzeichnis noch nicht existiert, wird mkdirs() aufgerufen."""
+        from utils import android_print_utils
+
+        app_private = MagicMock()
+        app_private.exists.side_effect = [False, True]
+        app_private.getAbsolutePath.return_value = '/data/user/0/app/files/Download'
+        self._context.getExternalFilesDir.return_value = app_private
+
+        result = android_print_utils.get_downloads_path()
+
+        app_private.mkdirs.assert_called_once()
+        self.assertEqual(result, '/data/user/0/app/files/Download')
+
+    def test_falls_back_to_internal_when_external_unavailable(self):
+        """Ohne externe Ablage → Rückgriff auf internes app-Verzeichnis."""
+        from utils import android_print_utils
+
+        self._context.getExternalFilesDir.return_value = None
+        self._context.getFilesDir.return_value = self._make_dir('/data/user/0/app/files')
+
+        result = android_print_utils.get_downloads_path()
+
+        self.assertEqual(result, '/data/user/0/app/files')
+
+    def test_falls_back_to_internal_when_external_raises(self):
+        """Exception aus getExternalFilesDir → Fallback auf internes Verzeichnis, kein Crash."""
+        from utils import android_print_utils
+
+        self._context.getExternalFilesDir.side_effect = RuntimeError("boom")
+        self._context.getFilesDir.return_value = self._make_dir('/data/user/0/app/files')
+
+        result = android_print_utils.get_downloads_path()
+
+        self.assertEqual(result, '/data/user/0/app/files')
+
+    def test_returns_none_on_desktop(self):
+        """Auf Nicht-Android liefert die Funktion None."""
+        for p in self._patches:
+            p.stop()
+        self._patches = []
+        with patch('utils.android_print_utils.is_android', return_value=False):
+            from utils import android_print_utils
+            self.assertIsNone(android_print_utils.get_downloads_path())
+
+
+@unittest.skipUnless(_KIVY_AVAILABLE, "Kivy nicht verfügbar")
+class TestOpenViaLocalhostAndroidFallback(unittest.TestCase):
+    """Stellt sicher, dass `_open_via_localhost` auf Android eine Exception wirft,
+    damit `_open_file_on_android` auf FileProvider weiterfällt."""
+
+    def test_android_path_raises_so_caller_can_fall_through(self):
+        from manager.html_manager import HTMLManager
+
+        with patch('manager.html_manager.Logger'):
+            # kivy.utils.platform wird lokal importiert → per patch.dict stubben
+            with patch.dict('sys.modules', {'kivy.utils': MagicMock(platform='android')}):
+                with self.assertRaises(RuntimeError):
+                    HTMLManager._open_via_localhost('/tmp/irrelevant.html')
+
+    def test_source_does_not_use_file_uri_webbrowser_on_android(self):
+        """Regression: der alte `webbrowser.open('file://...')`-Fallback ist entfernt."""
+        from manager.html_manager import HTMLManager
+
+        source = inspect.getsource(HTMLManager._open_via_localhost)
+        android_block_start = source.find("kivy_platform == 'android'")
+        self.assertGreater(android_block_start, -1)
+        # Bis zum Desktop-Zweig darf `webbrowser.open("file://...")` NICHT vorkommen.
+        desktop_marker = source.find("Desktop:", android_block_start)
+        android_block = source[android_block_start:desktop_marker if desktop_marker > 0 else len(source)]
+        self.assertNotIn('webbrowser.open(f"file://', android_block)
+        self.assertNotIn("webbrowser.open('file://", android_block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/android_print_utils.py
+++ b/utils/android_print_utils.py
@@ -242,10 +242,17 @@ def _make_runnable(py_callable):
 
 def get_downloads_path():
     """
-    Gibt den Pfad zum Download-Ordner auf Android zurück.
+    Gibt einen beschreibbaren Pfad für temporäre Export-Dateien auf Android zurück.
+
+    Unter Scoped Storage (targetSdk ≥ 29, Android 10+) ist das öffentliche
+    Download-Verzeichnis `/storage/emulated/0/Download/` für normale Apps
+    nicht mehr direkt beschreibbar — `open(..., 'w')` scheitert mit
+    `PermissionError: [Errno 13] Permission denied`. Deshalb wird die
+    app-private externe Ablage bevorzugt; sie ist auf jeder Android-Version
+    ohne Runtime-Permission beschreibbar.
 
     Returns:
-        str: Pfad zum Download-Ordner oder None
+        str: Pfad zu einem beschreibbaren Verzeichnis oder None
     """
     if not is_android():
         return None
@@ -257,16 +264,18 @@ def get_downloads_path():
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
         context = PythonActivity.mActivity
 
-        downloads_dir = Environment.getExternalStoragePublicDirectory(
-            Environment.DIRECTORY_DOWNLOADS)
+        # App-private externe Ablage — immer beschreibbar, kein Permission nötig
+        try:
+            alt_dir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+            if alt_dir is not None:
+                if not alt_dir.exists():
+                    alt_dir.mkdirs()
+                if alt_dir.exists():
+                    return alt_dir.getAbsolutePath()
+        except Exception as e:
+            Logger.warning(f"Android: getExternalFilesDir fehlgeschlagen: {e}")
 
-        if downloads_dir and downloads_dir.exists():
-            return downloads_dir.getAbsolutePath()
-
-        alt_dir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
-        if alt_dir and alt_dir.exists():
-            return alt_dir.getAbsolutePath()
-
+        # Letzter Fallback: app-internes Verzeichnis
         return context.getFilesDir().getAbsolutePath()
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Behebt zwei Android-Bugs, die den PDF/HTML-Export unter targetSdk 35 brechen.

**Bug 1 — `PermissionError` beim HTML-Schreiben:**
`get_downloads_path()` in `utils/android_print_utils.py` lieferte zuerst `/storage/emulated/0/Download/`. Unter Scoped Storage (Android 10+, targetSdk ≥ 29) ist dieses öffentliche Verzeichnis für normale Apps nicht mehr beschreibbar — `open(..., 'w')` scheitert mit `[Errno 13] Permission denied`. Folge: der PDF-Export bricht beim Erstellen der Zwischen-HTML ab.

**Fix:** App-private externe Ablage (`getExternalFilesDir(DOWNLOADS)`) bevorzugen. Sie ist auf jeder Android-Version ohne Runtime-Permission beschreibbar. Die finale PDF wird ohnehin per `PrintManager`-Dialog gespeichert, daher reicht die app-private Zwischenablage.

**Bug 2 — `FileUriExposedException` beim HTML-Öffnen:**
`HTMLManager._open_via_localhost` rief auf Android `webbrowser.open("file://...")` als Fallback auf. Intent.getData() mit `file://` wirft seit Android 7 eine `FileUriExposedException` → die gesamte Öffnungskette brach ab, obwohl `_open_file_on_android` eine FileProvider-Strategie als Strategie 2 bereithält.

**Fix:** Der Android-Zweig wirft jetzt eine Exception. Dadurch fällt der Aufrufer korrekt auf die FileProvider-Strategie weiter.

## Test plan
- [x] `python "test units/run_all_tests.py" test_android_scoped_storage` — 7 neue Tests
- [x] `python -m unittest "test units.test_android_thread_safety"` — bestehende Assertions bleiben grün (`HTTP-Server auf Android deaktiviert` und `Thread-Safety` weiterhin im Source)
- [ ] Manuell auf Android-Gerät: Charakter laden, PDF-Export via Charakterbogen-Tab, Druckdialog muss öffnen
- [ ] Manuell auf Android-Gerät: HTML-Export, Browser/Share-Intent öffnet korrekt (FileProvider-Pfad)
- [ ] Desktop-Regression: HTML-Export weiter über lokalen HTTP-Server (unverändert)

https://claude.ai/code/session_01RvSB3xi2CLhQAoBdfrFSkz