### PR TITLE
fix(android): Debounce für Listen-Filter, behebt nicht-löschbare Suchfelder

### DIFF
--- a/views/ausruestung_view.py
+++ b/views/ausruestung_view.py
@@ -935,6 +935,12 @@ class AusruestungWidget(MDBoxLayout):
     only_owned_items = BooleanProperty(False)
     is_filter_expanded = BooleanProperty(True)
 
+    # Debounce-Latenz fürs Filtern beim Tippen — verhindert auf Android,
+    # dass jeder Tastendruck einen RecycleView-Refresh und damit einen
+    # Layout-Pass auslöst, der die IME-Verbindung zur Soft-Tastatur stört
+    # (Symptom: Backspace im Suchfeld bleibt wirkungslos).
+    _FILTER_DEBOUNCE_S = 0.25
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._initialize_controller()
@@ -982,7 +988,7 @@ class AusruestungWidget(MDBoxLayout):
         Event-Handler für den Button (Android Checkbox Workaround).
         """
         self.only_owned_items = not self.only_owned_items
-        self.filter_ausruestung()
+        self._apply_filter()
 
     def update_sort_option(self, option):
         """Aktualisiert die Sortieroptionen"""
@@ -992,14 +998,33 @@ class AusruestungWidget(MDBoxLayout):
             self.current_sort_option = option
             self.sort_order = 'asc'
 
-        self.filter_ausruestung()
+        self._apply_filter()
 
     def filter_ausruestung(self, *args):
-        """Filtert und sortiert die Ausrüstungsgegenstände"""
+        """
+        Plant das Filtern verzögert (Debounce gegen Fokus-Verlust auf
+        Android beim Tippen). Sofortige Filteranwendung erfolgt über
+        _apply_filter() direkt.
+        """
+        existing = getattr(self, '_filter_event', None)
+        if existing is not None:
+            existing.cancel()
+        self._filter_event = Clock.schedule_once(
+            self._apply_filter, self._FILTER_DEBOUNCE_S
+        )
+
+    def _restore_search_focus(self, field):
+        """Stellt den Fokus auf dem Suchfeld wieder her, falls verloren."""
+        if field and not field.focus:
+            field.focus = True
+
+    def _apply_filter(self, _dt=0):
+        """Filtert und sortiert die Ausrüstungsgegenstände (synchron)."""
+        self._filter_event = None
         if not self.controller or not hasattr(self.controller, 'charakter'):
             self.set_debug_message("Controller oder Charakter nicht verfügbar")
             return
-            
+
         search_input = self.ids.get('search_input')
         category_label = self.ids.get('category_label')
         search_term = search_input.text.lower() if search_input else ''
@@ -1078,14 +1103,22 @@ class AusruestungWidget(MDBoxLayout):
             # RecycleView vollständig leeren und neu befüllen
             self.ids.recycleview.data = []
             self.ids.recycleview.data = filtered_items
-            
+
             # Debug-Info
             if not filtered_items:
                 self.set_debug_message(f"Keine Ergebnisse für Suche: '{search_term}', Kategorie: '{selected_kategorie}'")
             else:
                 self.clear_debug_message()
-                
+
             Logger.debug(f"Ausrüstung gefiltert: {len(filtered_items)} Ergebnisse")
+
+            # Fokus-Sicherheitsnetz: Der RecycleView-Refresh kann auf Android
+            # die IME-Verbindung kurz unterbrechen. Bei aktivem Filtertext den
+            # Fokus auf nächstem Frame wiederherstellen.
+            if search_input and search_input.text:
+                Clock.schedule_once(
+                    lambda dt: self._restore_search_focus(search_input), 0
+                )
             
         except Exception as e:
             Logger.error(f"Fehler beim Filtern der Ausrüstung: {str(e)}", exc_info=True)
@@ -1208,9 +1241,9 @@ class AusruestungWidget(MDBoxLayout):
         # Ausrüstung abrufen und Kategorien aktualisieren
         alle_ausruestung = self.controller.charakter.ausruestung
         self._update_kategorien(alle_ausruestung)
-        
-        # Initiale Filterung
-        self.filter_ausruestung()
+
+        # Initiale Filterung (sofort, kein Debounce beim Init)
+        self._apply_filter()
 
     def _update_kategorien(self, ausruestung_dict):
         """Aktualisiert die Liste der verfügbaren Kategorien"""
@@ -1238,9 +1271,9 @@ class AusruestungWidget(MDBoxLayout):
         # Ausrüstung abrufen und Kategorien aktualisieren
         alle_ausruestung = self.controller.charakter.ausruestung
         self._update_kategorien(alle_ausruestung)
-        
-        # Filterung erneut anwenden
-        self.filter_ausruestung()
+
+        # Filterung erneut anwenden (sofort, da explizite UI-Aktualisierung nach Datenänderung)
+        self._apply_filter()
 
     def open_category_menu(self):
         """Öffnet das Kategorie-Auswahlmenü"""
@@ -1264,7 +1297,7 @@ class AusruestungWidget(MDBoxLayout):
         if category_label:
             category_label.text = text
         self.menu.dismiss()
-        self.filter_ausruestung()
+        self._apply_filter()
 
     def set_debug_message(self, message):
         """Setzt eine Debug-Nachricht im UI"""

--- a/views/handicaps_view.py
+++ b/views/handicaps_view.py
@@ -666,6 +666,12 @@ class HandicapsWidget(MDBoxLayout):
     only_selected_items = BooleanProperty(False)  # Neue Property für den Filter
     is_filter_expanded = BooleanProperty(True)
 
+    # Debounce-Latenz fürs Filtern beim Tippen — verhindert auf Android,
+    # dass jeder Tastendruck einen RecycleView-Refresh und damit einen
+    # Layout-Pass auslöst, der die IME-Verbindung zur Soft-Tastatur stört
+    # (Symptom: Backspace im Suchfeld bleibt wirkungslos).
+    _FILTER_DEBOUNCE_S = 0.25
+
     def __init__(self, **kwargs):
         """Initialisiert das HandicapsWidget und setzt Grundkonfiguration."""
         super().__init__(**kwargs)
@@ -712,8 +718,8 @@ class HandicapsWidget(MDBoxLayout):
             Logger.debug(f"Filter 'Nur ausgewählte Handicaps' aktiviert")
         else:
             Logger.debug(f"Filter 'Nur ausgewählte Handicaps' deaktiviert")
-        
-        self.filter_handicaps()
+
+        self._apply_filter()
 
     def _filter_handicaps_data(self, alle_handicaps, search_term, selected_stufe):
         """
@@ -779,9 +785,9 @@ class HandicapsWidget(MDBoxLayout):
         
         # Stufen extrahieren und sortieren
         self._update_stufen(alle_handicaps)
-        
-        # Handicaps filtern und anzeigen
-        self.filter_handicaps()
+
+        # Handicaps filtern und anzeigen (sofort, kein Debounce beim Init)
+        self._apply_filter()
 
     def _update_stufen(self, handicaps_dict):
         """Aktualisiert die Liste der verfügbaren Handicap-Stufen."""
@@ -802,13 +808,13 @@ class HandicapsWidget(MDBoxLayout):
             
         # RecycleView leeren
         self.ids.recycleview.data = []
-        
+
         # Stufen neu laden
         alle_handicaps = self.controller.charakter.handicaps
         self._update_stufen(alle_handicaps)
-        
-        # Filter neu anwenden
-        self.filter_handicaps()
+
+        # Filter neu anwenden (sofort, da explizite UI-Aktualisierung nach Datenänderung)
+        self._apply_filter()
 
     def toggle_sort_order(self):
         """
@@ -816,17 +822,29 @@ class HandicapsWidget(MDBoxLayout):
         Event-Handler für den Sortierbutton.
         """
         self.sort_order = 'name_desc' if self.sort_order == 'name_asc' else 'name_asc'
-        self.filter_handicaps()
+        self._apply_filter()
 
     def filter_handicaps(self, *args):
         """
-        Filtert die Handicaps basierend auf Suchtext und Kategorie.
-        Event-Handler für Änderungen an Suchtext oder Kategorie.
+        Plant das Filtern verzögert (Debounce). Wird vom on_text-Binding
+        des Suchfelds aufgerufen. Sofortige Filteranwendung erfolgt über
+        _apply_filter() direkt, um Aktionen wie Sortier-Toggle nicht zu
+        verzögern.
         """
+        existing = getattr(self, '_filter_event', None)
+        if existing is not None:
+            existing.cancel()
+        self._filter_event = Clock.schedule_once(
+            self._apply_filter, self._FILTER_DEBOUNCE_S
+        )
+
+    def _apply_filter(self, _dt=0):
+        """Eigentliche Filterlogik (synchron)."""
+        self._filter_event = None
         if not self.controller or not hasattr(self.controller, 'charakter'):
             Logger.error("HandicapsWidget: Controller oder Charakter nicht verfügbar")
             return
-            
+
         search_input = self.ids.get('search_input')
         category_label = self.ids.get('category_label')
         search_term = search_input.text.lower() if search_input else ''
@@ -834,17 +852,17 @@ class HandicapsWidget(MDBoxLayout):
 
         # Handicaps vom Modell abrufen
         alle_handicaps = self.controller.charakter.handicaps
-        
+
         # Gefilterte Liste erstellen
         filtered_data = self._filter_handicaps_data(
             alle_handicaps,
-            search_term, 
+            search_term,
             selected_stufe
         )
-        
+
         # Sortieren
         filtered_data = self._sort_handicaps_data(filtered_data)
-        
+
         # Index nach Sortierung aktualisieren
         for i, item in enumerate(filtered_data):
             item['index'] = i
@@ -852,6 +870,20 @@ class HandicapsWidget(MDBoxLayout):
         # An RecycleView übergeben
         self.ids.recycleview.data = filtered_data
         Logger.debug(f"HandicapsWidget: {len(filtered_data)} Handicaps gefiltert und sortiert")
+
+        # Fokus-Sicherheitsnetz: Der RecycleView-Refresh kann auf Android
+        # die IME-Verbindung kurz unterbrechen. Wenn das Suchfeld noch
+        # Inhalt hat, stellen wir den Fokus auf dem nächsten Frame wieder
+        # her, damit weitere Tastendrücke (insbesondere Backspace) wirken.
+        if search_input and search_input.text:
+            Clock.schedule_once(
+                lambda dt: self._restore_search_focus(search_input), 0
+            )
+
+    def _restore_search_focus(self, field):
+        """Stellt den Fokus auf dem Suchfeld wieder her, falls verloren."""
+        if field and not field.focus:
+            field.focus = True
 
     def _sort_handicaps_data(self, data):
         """
@@ -890,4 +922,4 @@ class HandicapsWidget(MDBoxLayout):
         if category_label:
             category_label.text = text
         self.menu.dismiss()
-        self.filter_handicaps()
+        self._apply_filter()

--- a/views/maechte_view.py
+++ b/views/maechte_view.py
@@ -349,6 +349,12 @@ class KraefteWidget(MDBoxLayout):
     is_filter_expanded = BooleanProperty(True)
     current_mode = StringProperty("maechte")  # "maechte" oder "superkraefte"
 
+    # Debounce-Latenz fürs Filtern beim Tippen — verhindert auf Android,
+    # dass jeder Tastendruck einen RecycleView-Refresh und damit einen
+    # Layout-Pass auslöst, der die IME-Verbindung zur Soft-Tastatur stört
+    # (Symptom: Backspace im Suchfeld bleibt wirkungslos).
+    _FILTER_DEBOUNCE_S = 0.25
+
     # Mapping für Ränge, um numerische Sortierung zu ermöglichen
     RANG_MAPPING = {
         'A': 1,    # Anfänger
@@ -426,7 +432,7 @@ class KraefteWidget(MDBoxLayout):
             Logger.info(f"KraefteWidget: Modus gewechselt zu '{new_mode}'")
             self.current_mode = new_mode
             # Mächte-View wird immer angezeigt - kein UI-Umbau nötig
-            self.filter_maechte()
+            self._apply_filter()
 
     # ==================== MÄCHTE-FUNKTIONALITÄT ====================
 
@@ -436,7 +442,7 @@ class KraefteWidget(MDBoxLayout):
         Event-Handler für den Button (Android Checkbox Workaround).
         """
         self.only_selected_items = not self.only_selected_items
-        self.filter_maechte()
+        self._apply_filter()
         Logger.debug(f"Filter 'Nur ausgewählte Mächte' gesetzt auf: {self.only_selected_items}")
 
     def update_sort_option(self, option):
@@ -451,14 +457,24 @@ class KraefteWidget(MDBoxLayout):
             self.sort_order = 'asc'
 
         Logger.debug(f"Sortierung aktualisiert: {self.current_sort_option}, {self.sort_order}")
-        self.filter_maechte()
+        self._apply_filter()
 
     def filter_maechte(self, *args):
         """
-        Filtert und sortiert die Mächte.
-        Event-Handler für Änderungen am Suchtext oder Filter.
-        Funktioniert im Mächte- und Superkräfte-Modus (Kombi-Ansicht).
+        Plant das Filtern verzögert (Debounce gegen Fokus-Verlust auf
+        Android beim Tippen). Sofortige Filteranwendung erfolgt über
+        _apply_filter() direkt.
         """
+        existing = getattr(self, '_filter_event', None)
+        if existing is not None:
+            existing.cancel()
+        self._filter_event = Clock.schedule_once(
+            self._apply_filter, self._FILTER_DEBOUNCE_S
+        )
+
+    def _apply_filter(self, _dt=0):
+        """Eigentliche Filter- und Sortierlogik (synchron)."""
+        self._filter_event = None
         if not self.controller or not hasattr(self.controller, 'charakter'):
             Logger.error("MaechteWidget: Controller oder Charakter nicht verfügbar")
             return
@@ -467,7 +483,8 @@ class KraefteWidget(MDBoxLayout):
             Logger.debug("MaechteWidget: IDs noch nicht verfügbar (Post-Init?)")
             return
 
-        search_term = self.ids.search_input.text.lower()
+        search_input = self.ids.search_input
+        search_term = search_input.text.lower()
 
         alle_maechte = self.controller.charakter.maechte
 
@@ -479,6 +496,19 @@ class KraefteWidget(MDBoxLayout):
 
         self.ids.recycleview.data = filtered_data
         Logger.debug(f"Mächte gefiltert und sortiert: {len(filtered_data)} Einträge")
+
+        # Fokus-Sicherheitsnetz: Der RecycleView-Refresh kann auf Android
+        # die IME-Verbindung kurz unterbrechen. Bei aktivem Filtertext den
+        # Fokus auf nächstem Frame wiederherstellen.
+        if search_input.text:
+            Clock.schedule_once(
+                lambda dt: self._restore_search_focus(search_input), 0
+            )
+
+    def _restore_search_focus(self, field):
+        """Stellt den Fokus auf dem Suchfeld wieder her, falls verloren."""
+        if field and not field.focus:
+            field.focus = True
 
     def _filter_maechte_data(self, alle_maechte, search_term):
         """Filtert die Macht-Daten nach Suchbegriff und Auswahlstatus."""
@@ -527,7 +557,8 @@ class KraefteWidget(MDBoxLayout):
         Initialisierung nach dem Laden des Widgets.
         Wird einmalig durch Clock.schedule_once aufgerufen.
         """
-        self.filter_maechte()
+        # Sofort anwenden, kein Debounce beim Init
+        self._apply_filter()
         Logger.debug("KraefteWidget: Post-Init abgeschlossen")
 
     def refresh_widget(self):
@@ -537,7 +568,8 @@ class KraefteWidget(MDBoxLayout):
         """
         if hasattr(self.ids, 'recycleview'):
             self.ids.recycleview.data = []
-        self.filter_maechte()
+        # Sofort anwenden, da explizite UI-Aktualisierung nach Datenänderung
+        self._apply_filter()
         Logger.debug("KraefteWidget: Widget aktualisiert")
 
     # ==================== RANGPRÜFUNG ====================

--- a/views/talente_view.py
+++ b/views/talente_view.py
@@ -739,6 +739,12 @@ class TalenteWidget(MDBoxLayout):
     sort_order = StringProperty(DEFAULT_SORT_ORDER)
     only_selected_items = BooleanProperty(False)  # Property für den Filter
     only_available_talents = BooleanProperty(False)
+
+    # Debounce-Latenz fürs Filtern beim Tippen — verhindert auf Android,
+    # dass jeder Tastendruck einen RecycleView-Refresh und damit einen
+    # Layout-Pass auslöst, der die IME-Verbindung zur Soft-Tastatur stört
+    # (Symptom: Backspace im Suchfeld bleibt wirkungslos).
+    _FILTER_DEBOUNCE_S = 0.25
     is_filter_expanded = BooleanProperty(True)
 
     def __init__(self, **kwargs):
@@ -783,7 +789,7 @@ class TalenteWidget(MDBoxLayout):
         Event-Handler für den Button (Android Checkbox Workaround).
         """
         self.only_selected_items = not self.only_selected_items
-        self.filter_talente()
+        self._apply_filter()
         Logger.debug(f"Filter 'Nur ausgewählte Talente' gesetzt auf: {self.only_selected_items}")
 
     def toggle_only_available_talents(self):
@@ -918,17 +924,28 @@ class TalenteWidget(MDBoxLayout):
             self.sort_order = 'asc'
 
         Logger.debug(f"Sortierung aktualisiert: {self.current_sort_option}, {self.sort_order}")
-        self.filter_talente()
+        self._apply_filter()
 
     def filter_talente(self, *args):
         """
-        Filtert und sortiert die Talente.
-        Event-Handler für Änderungen an Suchtext oder Kategorie.
+        Plant das Filtern verzögert (Debounce gegen Fokus-Verlust auf
+        Android beim Tippen). Sofortige Filteranwendung erfolgt über
+        _apply_filter() direkt.
         """
+        existing = getattr(self, '_filter_event', None)
+        if existing is not None:
+            existing.cancel()
+        self._filter_event = Clock.schedule_once(
+            self._apply_filter, self._FILTER_DEBOUNCE_S
+        )
+
+    def _apply_filter(self, _dt=0):
+        """Eigentliche Filter- und Sortierlogik (synchron)."""
+        self._filter_event = None
         if not self.controller or not hasattr(self.controller, 'charakter'):
             Logger.error("TalenteWidget: Controller oder Charakter nicht verfügbar")
             return
-            
+
         search_input = self.ids.get('search_input')
         category_label = self.ids.get('category_label')
         search_term = search_input.text.lower() if search_input else ''
@@ -936,17 +953,17 @@ class TalenteWidget(MDBoxLayout):
 
         # Talente vom Modell abrufen
         alle_talente = self.controller.charakter.talente
-        
+
         # Gefilterte Liste erstellen
         filtered_data = self._filter_talente_data(
             alle_talente,
-            search_term, 
+            search_term,
             selected_kategorie
         )
-        
+
         # Sortieren
         filtered_data = self._sort_talente_data(filtered_data)
-        
+
         # Index nach Sortierung aktualisieren
         for i, item in enumerate(filtered_data):
             item['index'] = i
@@ -954,6 +971,19 @@ class TalenteWidget(MDBoxLayout):
         # An RecycleView übergeben
         self.ids.recycleview.data = filtered_data
         Logger.debug(f"Talente gefiltert und sortiert: {len(filtered_data)} Einträge")
+
+        # Fokus-Sicherheitsnetz: Der RecycleView-Refresh kann auf Android
+        # die IME-Verbindung kurz unterbrechen. Bei aktivem Filtertext den
+        # Fokus auf nächstem Frame wiederherstellen.
+        if search_input and search_input.text:
+            Clock.schedule_once(
+                lambda dt: self._restore_search_focus(search_input), 0
+            )
+
+    def _restore_search_focus(self, field):
+        """Stellt den Fokus auf dem Suchfeld wieder her, falls verloren."""
+        if field and not field.focus:
+            field.focus = True
 
     def _sort_talente_data(self, data):
         """
@@ -987,9 +1017,9 @@ class TalenteWidget(MDBoxLayout):
         
         # Kategorien extrahieren und sortieren
         self._update_kategorien(alle_talente)
-        
-        # Talente filtern und anzeigen
-        self.filter_talente()
+
+        # Talente filtern und anzeigen (sofort, kein Debounce beim Init)
+        self._apply_filter()
 
     def _update_kategorien(self, talente_dict):
         """Aktualisiert die Liste der verfügbaren Talent-Kategorien."""
@@ -1014,9 +1044,9 @@ class TalenteWidget(MDBoxLayout):
         # Kategorien neu laden
         alle_talente = self.controller.charakter.talente
         self._update_kategorien(alle_talente)
-        
-        # Filter neu anwenden
-        self.filter_talente()
+
+        # Filter neu anwenden (sofort, da explizite UI-Aktualisierung nach Datenänderung)
+        self._apply_filter()
 
     def open_category_menu(self):
         """
@@ -1046,4 +1076,4 @@ class TalenteWidget(MDBoxLayout):
         if category_label:
             category_label.text = text
         self.menu.dismiss()
-        self.filter_talente()
+        self._apply_filter()


### PR DESCRIPTION
Synchrones RecycleView-Refresh bei jedem Tastendruck löste auf Android
einen Layout-Pass aus, der die IME-Verbindung der Soft-Tastatur zum
Suchfeld störte — Backspace blieb wirkungslos. filter_handicaps,
filter_talente, filter_maechte und filter_ausruestung werden nun via
Clock.schedule_once mit 250 ms verzögert; interne Aufrufer (Sortier-
Toggle, Kategorie-Auswahl, refresh_widget, post_init etc.) rufen die
neue _apply_filter direkt auf, damit diese Aktionen sofort reagieren.
Zusätzliches Fokus-Sicherheitsnetz nach jedem Refresh stellt den
Fokus auf dem Suchfeld wieder her, falls die IME-Verbindung kollabiert.