### PR TITLE
fix: Schnellspeichern überschreibt vorherigen Charakter nach "Neuer Charakter"

### DIFF
--- a/views/charakter_verwaltung_widget.py
+++ b/views/charakter_verwaltung_widget.py
@@ -258,18 +258,13 @@ class CharakterVerwaltungWidget(MDBoxLayout):
                 return
             
             controller = app.controller
-            
-            from models.charakter import Charakter
-            
-            neuer_char = Charakter(
-                active_setting_name=setting_name,
-                char_name=char_name
-            )
-            
-            controller.charakter = neuer_char
-            controller.on_charakter_changed()
-            
-            Logger.info(f"Neuer Charakter '{char_name}' mit Setting '{setting_name}' erstellt")
+
+            # Über controller.neuer_charakter() gehen, damit current_character_file_path
+            # zurückgesetzt und der Undo-Stack geleert wird. Sonst würde Schnellspeichern
+            # später blind in die zuvor geladene Datei schreiben.
+            if not controller.neuer_charakter(char_name=char_name, setting_name=setting_name):
+                self._show_error_dialog("Charakter konnte nicht erstellt werden.")
+                return
             
             try:
                 dialog_service = service_container.get_dialog_service()


### PR DESCRIPTION
_create_character_with_setting hat den Charakter direkt zugewiesen statt
controller.neuer_charakter() aufzurufen. Dadurch blieb
current_character_file_path auf der zuvor geladenen Datei stehen, und das
nächste Schnellspeichern hat diese Datei mit dem neuen Charakter überschrieben.

Über den Controller-Helper wird der Pfad jetzt korrekt zurückgesetzt (und
nebenbei Undo-Stack geleert sowie on_setting_changed dispatched).

https://claude.ai/code/session_01Xw6PgaUrsJ889Z1oh2MuFG