### PR TITLE
Fix Android: Charakter-Löschen-Fehler wenn Datei nicht existiert

### DIFF
--- a/functions/auto_character_generator.py
+++ b/functions/auto_character_generator.py
@@ -1828,7 +1828,15 @@ class AutoCharacterGenerator:
 
     def _save_character(self, charakter: Charakter, char_name: str, save_dir: str) -> Path:
         """Speichert den Charakter als JSON"""
-        chars_ordner = project_root / "chars" / save_dir
+        try:
+            from kivy.utils import platform as kivy_platform
+            if kivy_platform == 'android':
+                from utils.path_utils import get_chars_path
+                chars_ordner = Path(get_chars_path()) / save_dir
+            else:
+                chars_ordner = project_root / "chars" / save_dir
+        except Exception:
+            chars_ordner = project_root / "chars" / save_dir
         chars_ordner.mkdir(parents=True, exist_ok=True)
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/views/charakter_verwaltung_widget.py
+++ b/views/charakter_verwaltung_widget.py
@@ -727,6 +727,14 @@ class CharakterVerwaltungWidget(MDBoxLayout):
 
             def do_delete(*args):
                 try:
+                    if not os.path.exists(selected_path):
+                        Logger.warning(f"Datei nicht mehr vorhanden: {selected_path}")
+                        if dialog_service:
+                            dialog_service.show_warning_dialog(
+                                f"Datei '{fname}' ist nicht mehr vorhanden (bereits gelöscht)."
+                            )
+                        self._exit_char_delete()
+                        return
                     os.remove(selected_path)
                     Logger.info(f"Charakter gelöscht: {selected_path}")
                     if dialog_service:


### PR DESCRIPTION
Zwei Probleme behoben:

1. charakter_verwaltung_widget.py: do_delete() prüft jetzt ob die Datei
   existiert bevor os.remove() aufgerufen wird. Wenn die Datei nicht mehr
   vorhanden ist (z.B. bereits gelöscht oder falscher Pfad), wird eine
   Hinweis-Meldung angezeigt statt eines harten Fehler-Dialogs.

2. auto_character_generator.py: _save_character() verwendet auf Android
   get_chars_path() statt project_root / 'chars'. Damit werden auto-generierte
   Charaktere immer ins persistente Benutzerverzeichnis gespeichert, das auch
   der FileManager anzeigt - und nicht ins App-Bundle-Verzeichnis.

https://claude.ai/code/session_01JYsnpKpfWeKW7uSx9smZ57