### PR TITLE
Refactor Magieaffin to select AH talents instead of skills

### DIFF
--- a/functions/volk_funktionen.py
+++ b/functions/volk_funktionen.py
@@ -6,13 +6,95 @@ ERWEITERT: Spezielle Behandlung für Menschen - nur ein freies Attribut gleichze
 """
 
 import logging
+import re
 from kivy.logger import Logger
 
 # Konstanten
 DEFAULT_TALENT_TEXT = 'Wähle ein freies Talent'
-DEFAULT_ATTRIBUT_TEXT = 'Wähle ein Attribut'  
+DEFAULT_ATTRIBUT_TEXT = 'Wähle ein Attribut'
 DEFAULT_FERTIGKEIT_TEXT = 'Wähle eine Fertigkeit'
 NO_TALENT_AVAILABLE_TEXT = 'Keine freien Talente verfügbar'
+
+# Matcht "Arkane Fertigkeit: Glaube (Willenskraft)" oder
+# "...erhält die arkane Fertigkeit Glaube (Willenskraft) und beginnt..."
+_ARKANE_FERTIGKEIT_PATTERN = re.compile(
+    r"arkane Fertigkeit:?\s+(.+?)\s*\(", re.IGNORECASE
+)
+_VORAUSSETZUNG_WUERFEL_PATTERN = re.compile(r"^(.+?)\s+W\d+\+?$")
+
+# Whitelist bekannter arkaner Fertigkeiten (über alle Settings hinweg).
+# Wird genutzt um aus den Voraussetzungen die richtige Fertigkeit zu erkennen,
+# ohne andere Skill-Voraussetzungen (z.B. "Glücksspiel W6+") fälschlich zu wählen.
+_BEKANNTE_ARKANE_FERTIGKEITEN = {
+    'Glaube', 'Zaubern', 'Fokus', 'Psionik', 'Hexerei',
+    'Verrückte Wissenschaft', 'Alchemie', 'Darbietung',
+    'Heldenmagie', 'Runenmagie',
+}
+
+# Hartkodierter Fallback für die Standard-AH-Talente (SWAE-Basis).
+# Nur als letzte Reserve, wenn weder Beschreibung noch Voraussetzungen die
+# Arkane Fertigkeit eindeutig liefern.
+_AH_FERTIGKEIT_FALLBACK = {
+    'AH (Wunder)': 'Glaube',
+    'AH (Magie)': 'Zaubern',
+    'AH (Psionik)': 'Psionik',
+    'AH (Begabt)': 'Fokus',
+    'AH (Verrückte Wissenschaft)': 'Verrückte Wissenschaft',
+}
+
+
+def _ist_ah_talent(talent_name: str) -> bool:
+    """Prüft ob ein Talentname ein Arkaner Hintergrund (AH) Variante ist."""
+    if not talent_name:
+        return False
+    return talent_name.startswith("AH (") or talent_name.startswith("AH:")
+
+
+def _fertigkeit_aus_voraussetzungen(voraussetzungen):
+    """Sucht in den Talent-Voraussetzungen nach einer bekannten Arkanen Fertigkeit.
+    Berücksichtigt auch komma-separierte Voraussetzungs-Strings."""
+    if not voraussetzungen:
+        return None
+
+    eintraege = []
+    for v in voraussetzungen:
+        if isinstance(v, str):
+            eintraege.extend(part.strip() for part in v.split(','))
+
+    for eintrag in eintraege:
+        match = _VORAUSSETZUNG_WUERFEL_PATTERN.match(eintrag)
+        if not match:
+            continue
+        name = match.group(1).strip()
+        if name in _BEKANNTE_ARKANE_FERTIGKEITEN:
+            return name
+    return None
+
+
+def extrahiere_arkane_fertigkeit_aus_ah(talent):
+    """
+    Ermittelt die Arkane Fertigkeit eines AH-Talents anhand mehrerer Quellen:
+    1. Beschreibung ("Arkane Fertigkeit: X" oder "...erhält die arkane Fertigkeit X (...)")
+    2. Voraussetzungen mit Whitelist bekannter Arkaner Fertigkeiten
+    3. Hartkodierter Fallback für die SWAE-Standard-AHs
+
+    Returns:
+        str oder None: Name der Arkanen Fertigkeit
+    """
+    if not talent:
+        return None
+
+    beschreibung = getattr(talent, 'beschreibung', '') or ''
+    match = _ARKANE_FERTIGKEIT_PATTERN.search(beschreibung)
+    if match:
+        return match.group(1).strip()
+
+    fertigkeit = _fertigkeit_aus_voraussetzungen(getattr(talent, 'voraussetzungen', None))
+    if fertigkeit:
+        return fertigkeit
+
+    talent_name = getattr(talent, 'name', '') or ''
+    return _AH_FERTIGKEIT_FALLBACK.get(talent_name)
 NO_ATTRIBUT_AVAILABLE_TEXT = 'Keine Attribute verfügbar'
 NO_FERTIGKEIT_AVAILABLE_TEXT = 'Keine Fertigkeiten verfügbar'
 
@@ -705,29 +787,42 @@ def waehle_freie_fertigkeit(charakter, volk_name, fertigkeit_name):
         return False
 
 
-def waehle_magieaffin_fertigkeit(charakter, volk_name, fertigkeit_name):
+def waehle_magieaffin_fertigkeit(charakter, volk_name, ah_talent_name):
     """
-    Wählt eine Arkane Fertigkeit für Magieaffin aus und erhöht sie.
-    Setzt auch das freie Arkaner-Hintergrund-Talent (AH).
+    Wählt einen Arkanen Hintergrund (AH) für Magieaffin aus.
+    Setzt das gewählte AH-Talent und erhöht die in der Talent-Beschreibung
+    angegebene Arkane Fertigkeit von W4-2 auf W4+0.
 
     Args:
         charakter: Das Charakterobjekt
         volk_name: Name des Volks
-        fertigkeit_name: Name der Arkanen Fertigkeit (Glaube/Zaubern/Fokus/Psionik)
+        ah_talent_name: Name des AH-Talents (z.B. "AH (Wunder)")
 
     Returns:
         bool: True bei Erfolg, False bei Fehler
     """
     try:
-        Logger.debug(f"Wähle Magieaffin-Arkane Fertigkeit '{fertigkeit_name}' für Volk '{volk_name}'")
-
-        ARKANE_FERTIGKEITEN = ["Glaube", "Zaubern", "Fokus", "Psionik"]
-        if fertigkeit_name not in ARKANE_FERTIGKEITEN:
-            Logger.warning(f"Ungültige Arkane Fertigkeit für Magieaffin: '{fertigkeit_name}'")
-            return False
+        Logger.debug(f"Wähle Magieaffin-AH '{ah_talent_name}' für Volk '{volk_name}'")
 
         if not hasattr(charakter, 'voelker') or volk_name not in charakter.voelker:
             Logger.error(f"Volk '{volk_name}' nicht gefunden")
+            return False
+
+        if not hasattr(charakter, 'talente') or ah_talent_name not in charakter.talente:
+            Logger.warning(f"AH-Talent '{ah_talent_name}' nicht im Charakter")
+            return False
+
+        ah_talent = charakter.talente[ah_talent_name]
+        if not _ist_ah_talent(ah_talent_name):
+            Logger.warning(f"Talent '{ah_talent_name}' ist kein AH-Talent")
+            return False
+
+        fertigkeit_name = extrahiere_arkane_fertigkeit_aus_ah(ah_talent)
+        if not fertigkeit_name:
+            Logger.warning(
+                f"Konnte Arkane Fertigkeit nicht aus '{ah_talent_name}' "
+                f"extrahieren (Beschreibung: {getattr(ah_talent, 'beschreibung', '')!r})"
+            )
             return False
 
         volk = charakter.voelker[volk_name]
@@ -738,8 +833,8 @@ def waehle_magieaffin_fertigkeit(charakter, volk_name, fertigkeit_name):
         # Arkane Fertigkeit erhöhen: W4-2 -> W4+0 (Nicht-Grundfertigkeit)
         if fertigkeit_name in charakter.fertigkeiten:
             fertigkeit = charakter.fertigkeiten[fertigkeit_name]
-            alter_modifier = getattr(fertigkeit, 'modifier', 0)
             if hasattr(fertigkeit, 'wuerfel') and hasattr(fertigkeit.wuerfel, 'modifier'):
+                alter_modifier = fertigkeit.wuerfel.modifier
                 fertigkeit.wuerfel.modifier = 0  # W4-2 -> W4+0
                 Logger.info(f"Magieaffin: '{fertigkeit_name}' von W4{alter_modifier:+d} auf W4+0 erhöht")
             else:
@@ -747,19 +842,18 @@ def waehle_magieaffin_fertigkeit(charakter, volk_name, fertigkeit_name):
         else:
             Logger.warning(f"Magieaffin: Fertigkeit '{fertigkeit_name}' nicht im Charakter gefunden")
 
-        # Magieaffin-Auswahl im Volk speichern
+        # Magieaffin-Auswahl im Volk speichern (sowohl AH-Talent als auch Fertigkeit)
         if 'magieaffin_auswahl' not in volk.effects:
             volk.effects['magieaffin_auswahl'] = {}
+        volk.effects['magieaffin_auswahl']['ah_talent'] = ah_talent_name
         volk.effects['magieaffin_auswahl']['fertigkeit'] = fertigkeit_name
 
-        # Arkaner-Hintergrund-Talent (AH) automatisch auswählen
-        if 'Arkaner Hintergrund' in charakter.talente:
-            ah_talent = charakter.talente['Arkaner Hintergrund']
-            if not ah_talent.ausgewaehlt:
-                ah_talent.ausgewaehlt = True
-                if 'Arkaner Hintergrund' not in charakter.selected_talente:
-                    charakter.selected_talente.append('Arkaner Hintergrund')
-                Logger.info(f"Magieaffin: 'Arkaner Hintergrund' Talent automatisch ausgewählt")
+        # Gewähltes AH-Talent automatisch auswählen
+        if not ah_talent.ausgewaehlt:
+            ah_talent.ausgewaehlt = True
+            if ah_talent_name not in charakter.selected_talente:
+                charakter.selected_talente.append(ah_talent_name)
+            Logger.info(f"Magieaffin: AH-Talent '{ah_talent_name}' automatisch ausgewählt")
 
         # Abgeleitete Werte neu berechnen
         if hasattr(charakter, 'berechne_abgeleitete_werte'):
@@ -793,43 +887,68 @@ def waehle_magieaffin_fertigkeit(charakter, volk_name, fertigkeit_name):
 
 
 def _reset_magieaffin(charakter, volk_name):
-    """Setzt die Magieaffin-Auswahl zurück."""
+    """Setzt die Magieaffin-Auswahl zurück (AH-Talent abwählen, Fertigkeit auf W4-2)."""
     try:
         if not hasattr(charakter, 'voelker') or volk_name not in charakter.voelker:
             return
 
         volk = charakter.voelker[volk_name]
-        alte_auswahl = volk.effects.get('magieaffin_auswahl', {}).get('fertigkeit')
+        auswahl = volk.effects.get('magieaffin_auswahl', {})
+        alte_fertigkeit = auswahl.get('fertigkeit')
+        altes_ah_talent = auswahl.get('ah_talent')
 
-        if not alte_auswahl:
+        if not alte_fertigkeit and not altes_ah_talent:
             return
 
-        Logger.info(f"Setze Magieaffin-Auswahl '{alte_auswahl}' zurück für Volk '{volk_name}'")
+        Logger.info(
+            f"Setze Magieaffin zurück für Volk '{volk_name}' "
+            f"(AH={altes_ah_talent!r}, Fertigkeit={alte_fertigkeit!r})"
+        )
 
         # Arkane Fertigkeit zurücksetzen: W4+0 -> W4-2
-        if alte_auswahl in charakter.fertigkeiten:
-            fertigkeit = charakter.fertigkeiten[alte_auswahl]
+        if alte_fertigkeit and alte_fertigkeit in charakter.fertigkeiten:
+            fertigkeit = charakter.fertigkeiten[alte_fertigkeit]
             if hasattr(fertigkeit, 'wuerfel') and hasattr(fertigkeit.wuerfel, 'modifier'):
                 if fertigkeit.wuerfel.modifier == 0:
                     fertigkeit.wuerfel.modifier = -2
-                    Logger.debug(f"Magieaffin: '{alte_auswahl}' von W4+0 auf W4-2 zurückgesetzt")
+                    Logger.debug(f"Magieaffin: '{alte_fertigkeit}' von W4+0 auf W4-2 zurückgesetzt")
 
-        # Arkaner-Hintergrund-Talent entfernen falls durch Magieaffin gesetzt
-        if 'Arkaner Hintergrund' in charakter.talente:
-            ah_talent = charakter.talente['Arkaner Hintergrund']
-            if ah_talent.ausgewaehlt and 'Arkaner Hintergrund' in charakter.selected_talente:
+        # AH-Talent abwählen (entweder das gespeicherte oder Fallback auf das generische)
+        ziel_talent = altes_ah_talent or 'Arkaner Hintergrund'
+        if ziel_talent in charakter.talente:
+            ah_talent = charakter.talente[ziel_talent]
+            if ah_talent.ausgewaehlt and ziel_talent in charakter.selected_talente:
                 ah_talent.ausgewaehlt = False
-                charakter.selected_talente.remove('Arkaner Hintergrund')
-                Logger.debug(f"Magieaffin: 'Arkaner Hintergrund' Talent entfernt")
+                charakter.selected_talente.remove(ziel_talent)
+                Logger.debug(f"Magieaffin: AH-Talent '{ziel_talent}' entfernt")
 
     except Exception as e:
         Logger.error(f"Fehler beim Zurücksetzen von Magieaffin: {e}")
 
 
 def get_magieaffin_optionen(charakter, volk_name):
-    """Gibt die verfügbaren Arkanen Fertigkeiten für Magieaffin zurück."""
-    ARKANE_FERTIGKEITEN = ["Glaube", "Zaubern", "Fokus", "Psionik"]
-    return ARKANE_FERTIGKEITEN
+    """
+    Gibt die für Magieaffin verfügbaren Arkanen Hintergrund Talente (AH) zurück.
+    Jedes AH-Talent legt seine Arkane Fertigkeit selbst fest (z.B. AH (Wunder) -> Glaube).
+
+    Returns:
+        list: Liste von Tupeln (ah_talent_name, arkane_fertigkeit_name), alphabetisch sortiert
+    """
+    if not hasattr(charakter, 'talente') or not charakter.talente:
+        return []
+
+    ah_talente = []
+    for name, talent in charakter.talente.items():
+        if not _ist_ah_talent(name):
+            continue
+        if not getattr(talent, 'aktiv', True):
+            continue
+        fertigkeit = extrahiere_arkane_fertigkeit_aus_ah(talent)
+        if fertigkeit:
+            ah_talente.append((name, fertigkeit))
+
+    ah_talente.sort(key=lambda x: x[0])
+    return ah_talente
 
 
 def get_aktuelle_magieaffin_fertigkeit(charakter, volk_name):
@@ -839,6 +958,17 @@ def get_aktuelle_magieaffin_fertigkeit(charakter, volk_name):
             return None
         volk = charakter.voelker[volk_name]
         return volk.effects.get('magieaffin_auswahl', {}).get('fertigkeit')
+    except Exception:
+        return None
+
+
+def get_aktuelles_magieaffin_ah(charakter, volk_name):
+    """Gibt das aktuell gewählte AH-Talent für Magieaffin zurück (oder None)."""
+    try:
+        if not hasattr(charakter, 'voelker') or volk_name not in charakter.voelker:
+            return None
+        volk = charakter.voelker[volk_name]
+        return volk.effects.get('magieaffin_auswahl', {}).get('ah_talent')
     except Exception:
         return None
 

--- a/views/voelker_view.py
+++ b/views/voelker_view.py
@@ -761,11 +761,20 @@ class VoelkerWidget(MDBoxLayout):
         if wahl.get('fertigkeit'):
             selections.append(('Freie Fertigkeit', wahl['fertigkeit']))
 
-        # Magieaffin
-        from functions.volk_funktionen import get_aktuelle_magieaffin_fertigkeit, hat_volk_magieaffin
+        # Magieaffin (zeigt das gewählte AH-Talent + die zugeordnete Arkane Fertigkeit)
+        from functions.volk_funktionen import (
+            get_aktuelle_magieaffin_fertigkeit,
+            get_aktuelles_magieaffin_ah,
+            hat_volk_magieaffin,
+        )
         if hat_volk_magieaffin(self.controller.charakter, self.selected_volk_name):
+            magieaffin_ah = get_aktuelles_magieaffin_ah(self.controller.charakter, self.selected_volk_name)
             magieaffin_fertigkeit = get_aktuelle_magieaffin_fertigkeit(self.controller.charakter, self.selected_volk_name)
-            if magieaffin_fertigkeit:
+            if magieaffin_ah:
+                anzeige = f"{magieaffin_ah} ({magieaffin_fertigkeit})" if magieaffin_fertigkeit else magieaffin_ah
+                selections.append(('Magieaffin', anzeige))
+            elif magieaffin_fertigkeit:
+                # Backward-Compat: Alte Auswahl ohne AH-Talent
                 selections.append(('Magieaffin', magieaffin_fertigkeit))
             else:
                 selections.append(('Magieaffin', 'Auswählen...'))
@@ -1025,7 +1034,8 @@ class VoelkerWidget(MDBoxLayout):
         # TODO: Implementieren ähnlich wie _on_edit_attribut
 
     def _on_edit_magieaffin(self):
-        """Öffnet einen Dialog zum Auswählen der Arkanen Fertigkeit für Magieaffin."""
+        """Öffnet einen Dialog zum Auswählen eines Arkanen Hintergrunds (AH) für Magieaffin.
+        Das gewählte AH-Talent legt automatisch die zugehörige Arkane Fertigkeit fest."""
         from kivymd.uix.dialog import MDDialog, MDDialogHeadlineText, MDDialogContentContainer, MDDialogButtonContainer
         from kivymd.uix.boxlayout import MDBoxLayout
         from kivymd.uix.chip import MDChip, MDChipText
@@ -1037,12 +1047,24 @@ class VoelkerWidget(MDBoxLayout):
             return
 
         charakter = self.controller.charakter
-        from functions.volk_funktionen import get_magieaffin_optionen, get_aktuelle_magieaffin_fertigkeit
+        from functions.volk_funktionen import get_magieaffin_optionen, get_aktuelles_magieaffin_ah
 
-        fertigkeit_optionen = get_magieaffin_optionen(charakter, volk_name)
-        aktuelle_fertigkeit = get_aktuelle_magieaffin_fertigkeit(charakter, volk_name)
+        ah_optionen = get_magieaffin_optionen(charakter, volk_name)
+        aktuelles_ah = get_aktuelles_magieaffin_ah(charakter, volk_name)
 
-        scroll_height = min(dp(350), len(fertigkeit_optionen) * dp(52))
+        if not ah_optionen:
+            from services.service_container import service_container
+            ds = service_container.get_dialog_service()
+            if ds:
+                ds.show_warning_dialog(
+                    "Im aktiven Setting ist kein Arkaner Hintergrund (AH) verfügbar. "
+                    "Magieaffin kann daher nicht ausgewählt werden."
+                )
+            else:
+                Logger.warning("Magieaffin: Keine AH-Talente im aktiven Setting verfügbar")
+            return
+
+        scroll_height = min(dp(350), len(ah_optionen) * dp(52))
         content_height = dp(86) + scroll_height
         content = MDBoxLayout(
             orientation="vertical",
@@ -1053,7 +1075,7 @@ class VoelkerWidget(MDBoxLayout):
         )
 
         info_label = MDLabel(
-            text="Wähle eine Arkane Fertigkeit:",
+            text="Wähle einen Arkanen Hintergrund:",
             bold=True,
             size_hint_y=None,
             height=dp(34),
@@ -1067,20 +1089,23 @@ class VoelkerWidget(MDBoxLayout):
         )
         chips_box.bind(minimum_height=chips_box.setter('height'))
 
-        for fert in fertigkeit_optionen:
+        for ah_name, fertigkeit_name in ah_optionen:
             chip_kwargs = {
                 'type': "filter",
                 'size_hint_y': None,
                 'height': dp(40),
-                'on_release': lambda x, f=fert: self._on_magieaffin_chosen(f),
+                'on_release': lambda x, ah=ah_name: self._on_magieaffin_chosen(ah),
             }
             if hasattr(self, 'theme_cls') and self.theme_cls:
-                if fert == aktuelle_fertigkeit:
+                if ah_name == aktuelles_ah:
                     chip_kwargs['md_bg_color'] = self.theme_cls.primaryContainerColor
                 else:
                     chip_kwargs['md_bg_color'] = self.theme_cls.surfaceColor
 
-            chip = MDChip(MDChipText(text=fert), **chip_kwargs)
+            chip = MDChip(
+                MDChipText(text=f"{ah_name}  →  {fertigkeit_name}"),
+                **chip_kwargs,
+            )
             chips_box.add_widget(chip)
 
         scroll = MDScrollView(size_hint_y=None, height=scroll_height, do_scroll_x=False)
@@ -1102,8 +1127,8 @@ class VoelkerWidget(MDBoxLayout):
         self._magieaffin_dialog = dialog
         dialog.open()
 
-    def _on_magieaffin_chosen(self, fertigkeit_name):
-        """Wird aufgerufen wenn eine Arkane Fertigkeit im Magieaffin-Dialog ausgewählt wird."""
+    def _on_magieaffin_chosen(self, ah_talent_name):
+        """Wird aufgerufen wenn ein AH-Talent im Magieaffin-Dialog ausgewählt wird."""
         from kivy.clock import Clock
         from functions.volk_funktionen import waehle_magieaffin_fertigkeit
 
@@ -1112,14 +1137,14 @@ class VoelkerWidget(MDBoxLayout):
             return
 
         charakter = self.controller.charakter
-        Logger.info(f"[DEBUG] Wähle Magieaffin-Arkane Fertigkeit '{fertigkeit_name}' für '{volk_name}'")
+        Logger.info(f"[DEBUG] Wähle Magieaffin-AH '{ah_talent_name}' für '{volk_name}'")
 
-        success = waehle_magieaffin_fertigkeit(charakter, volk_name, fertigkeit_name)
+        success = waehle_magieaffin_fertigkeit(charakter, volk_name, ah_talent_name)
 
         if success:
             if volk_name not in self.voelker_auswahlen:
                 self.voelker_auswahlen[volk_name] = {}
-            self.voelker_auswahlen[volk_name]['magieaffin'] = fertigkeit_name
+            self.voelker_auswahlen[volk_name]['magieaffin'] = ah_talent_name
 
             if hasattr(self, '_magieaffin_dialog') and self._magieaffin_dialog:
                 self._magieaffin_dialog.dismiss()
@@ -1127,9 +1152,9 @@ class VoelkerWidget(MDBoxLayout):
             Clock.schedule_once(lambda dt: self._update_zusatzelemente(), 0.1)
             Clock.schedule_once(lambda dt: self._update_selected_volk_details(), 0.1)
 
-            Logger.info(f"Magieaffin-Arkane Fertigkeit für '{volk_name}' erfolgreich auf '{fertigkeit_name}' gesetzt")
+            Logger.info(f"Magieaffin-AH für '{volk_name}' erfolgreich auf '{ah_talent_name}' gesetzt")
         else:
-            Logger.error(f"Fehler beim Setzen der Magieaffin-Arkanen Fertigkeit für '{volk_name}'")
+            Logger.error(f"Fehler beim Setzen des Magieaffin-AH für '{volk_name}'")
 
     def _create_zusatzelement_section(self, titel, volk_name, auswahl_typ, get_options_func, select_func, placeholder_text, get_alle_items_func=None):
         """Erstellt eine Sektion für Zusatzelemente mit Inline-Chip-Auswahl.


### PR DESCRIPTION
## Summary
Refactored the Magieaffin (magic affinity) feature to work with Arkane Hintergrund (AH) talents instead of directly selecting arcane skills. The system now intelligently extracts the associated arcane skill from the selected AH talent's description, prerequisites, or fallback mappings.

## Key Changes

- **New extraction logic**: Added `extrahiere_arkane_fertigkeit_aus_ah()` function that determines the arcane skill for an AH talent through multiple strategies:
  - Pattern matching in talent description ("Arkane Fertigkeit: X")
  - Whitelist-based extraction from prerequisites (e.g., "Glaube W6+")
  - Hardcoded fallback for standard SWAE AH talents

- **Updated `waehle_magieaffin_fertigkeit()`**: Changed signature from accepting a skill name to accepting an AH talent name. Now:
  - Validates the selected talent is actually an AH variant
  - Extracts the arcane skill from the talent
  - Stores both the AH talent and skill in effects for proper reset handling
  - Automatically selects the specific AH talent (not generic "Arkaner Hintergrund")

- **Enhanced `get_magieaffin_optionen()`**: Now returns tuples of (ah_talent_name, arcane_skill_name) instead of just skill names, allowing the UI to display both the talent choice and its associated skill

- **Improved reset logic**: `_reset_magieaffin()` now properly handles both the AH talent and skill, with fallback support for legacy selections

- **UI updates**: Modified the Magieaffin dialog to:
  - Display AH talents with their associated skills (e.g., "AH (Wunder) → Glaube")
  - Show helpful warning when no AH talents are available
  - Update display to show selected AH talent with skill in parentheses

- **Helper functions**: Added `_ist_ah_talent()` to identify AH talent variants and new getter `get_aktuelles_magieaffin_ah()` to retrieve the currently selected AH talent

## Implementation Details

- Whitelist of known arcane skills (`_BEKANNTE_ARKANE_FERTIGKEITEN`) prevents false matches with other skill prerequisites
- Regex patterns handle various description formats across different settings
- Backward compatibility maintained for legacy selections without stored AH talent names
- Comprehensive logging for debugging talent extraction and selection issues

https://claude.ai/code/session_01FpGbX5GkSk6J3UEp4NYQjV