### PR TITLE
Fix: Korrigiere Feinden statt Feinen

### DIFF
--- a/settings/Fantasy Kompendium.json
+++ b/settings/Fantasy Kompendium.json
@@ -1008,7 +1008,7 @@
         "Rakashaner": {
             "name": "Rakashaner",
             "handicaps": [
-                "Blutrünstig (Grausam zu Feinen, spielen mit ihnen)",
+                "Blutrünstig (Grausam zu Feinden, spielen mit ihnen)",
                 "Nichtschwimmer (-2 Athletik Schwimmen, 3'' Bewegungsweite im Wasser)",
                 "Volksfeind (-2 Überreden mit einem anderen Volk)"
             ],

--- a/settings/SWAE.json
+++ b/settings/SWAE.json
@@ -269,7 +269,7 @@
         "Rakashaner": {
             "name": "Rakashaner",
             "handicaps": [
-                "Blutrünstig (Grausam zu Feinen, spielen mit ihnen)",
+                "Blutrünstig (Grausam zu Feinden, spielen mit ihnen)",
                 "Nichtschwimmer (-2 Athletik Schwimmen, 3'' Bewegungsweite im Wasser)",
                 "Volksfeind (-2 Überreden mit einem anderen Volk)"
             ],

--- a/settings/Superkräfte Kompendium.json
+++ b/settings/Superkräfte Kompendium.json
@@ -326,7 +326,7 @@
         "Rakashaner": {
             "name": "Rakashaner",
             "handicaps": [
-                "Blutrünstig (Grausam zu Feinen, spielen mit ihnen)",
+                "Blutrünstig (Grausam zu Feinden, spielen mit ihnen)",
                 "Nichtschwimmer (-2 Athletik Schwimmen, 3'' Bewegungsweite im Wasser)",
                 "Volksfeind (-2 Überreden mit einem anderen Volk)"
             ],


### PR DESCRIPTION
## Beschreibung

Korrigiert den Rechtschreibfehler "Feinen" zu "Feinden" in den Rakashaner Blutrünstig Beschreibungen.

### Problem
- "Grausam zu **Feinen**" ist grammatisch falsch
- Korrekt muss es "Grausam zu **Feinden**" heißen

### Betroffene Dateien
- `settings/SWAE.json`
- `settings/Fantasy Kompendium.json`
- `settings/Superkräfte Kompendium.json`

---
_MiniMax Agent_