### PR TITLE
Fix: Draken Langsam Handicap auf Langsam_leicht korrigiert

### DIFF
--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -99,7 +99,7 @@
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
                 "auto_handicaps": [
-                    "Langsam"
+                    "Langsam_leicht"
                 ],
                 "spezielle_effekte": {
                     "hartes_haupt": true,
@@ -2368,8 +2368,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,


### PR DESCRIPTION
## Beschreibung

Korrigiert das automatische Handicap für das Volk Draken im SciFi Kompendium.

### Problem
- Draken hatte `auto_handicaps: ["Langsam"]`
- Dies referenziert ein nicht existierendes Handicap "Langsam"


### Lösung
- Geändert zu `auto_handicaps: ["Langsam_leicht"]`
- Das Handicap "Langsam_leicht" existiert im SciFi Kompendium mit korrekter Beschreibung

### Datei
- `settings/SciFi Kompendium.json`

---
_MiniMax Agent_