### PR TITLE
Fix: Floraner erhält Auto-Talent Zäh wie Leder

### DIFF
--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -157,7 +157,7 @@
                 "Blutlos (stabilisiert sich automatisch bei Verbluten)",
                 "Geringeres Schlafbedürfnis (nur halb so viel Schlaf)",
                 "Keine lebenswichtigen Organe (kein zusätzlicher Schaden durch Angesagte Ziele)",
-                "Zäh (kein zweites Angeschlagen verursacht Wunde)"
+                "Zäh wie Leder (Talent kostenlos erhalten)"
             ],
             "sprachen": [],
             "altersspanne": "Variabel",
@@ -170,7 +170,9 @@
                 "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
-                "auto_talente": [],
+                "auto_talente": [
+                    "Zäh wie Leder"
+                ],
                 "spezielle_effekte": {
                     "abhaengigkeit_sonnenlicht": true,
                     "blutlos": true,


### PR DESCRIPTION
## Beschreibung

Fügt dem Volk Floraner im SciFi Kompendium das Auto-Talent "Zäh wie Leder" hinzu und korrigiert die Textbeschreibung.

### Änderungen
1. **auto_talente**: Floraner erhält `["Zäh wie Leder"]`
2. **besonderheiten**: Text von "Zäh (kein zweites Angeschlagen verursacht Wunde)" zu "Zäh wie Leder (Talent kostenlos erhalten)" korrigiert

### Datei
- `settings/SciFi Kompendium.json`

---
_MiniMax Agent_