### PR TITLE
Fix: Gen-Soldaten Skrupellos Handicap von schwer auf leicht

### DIFF
--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -218,7 +218,7 @@
         "Gen-Soldaten": {
             "name": "Gen-Soldaten",
             "handicaps": [
-                "Skrupellos (schwer)"
+                "Skrupellos"
             ],
             "talente": [
                 "Kampfreflexe"
@@ -243,7 +243,7 @@
                     "Kampfreflexe"
                 ],
                 "auto_handicaps": [
-                    "Skrupellos (schwer)"
+                    "Skrupellos"
                 ],
                 "spezielle_effekte": {
                     "schmerzresistenz": true,


### PR DESCRIPTION
## Beschreibung

Korrigiert das Handicap für Gen-Soldaten im SciFi Kompendium.

### Problem
- Gen-Soldaten hatten `Skrupellos (schwer)`
- Dies sollte eigentlich `Skrupellos` (leicht) sein

### Lösung
- `auto_handicaps`: von `["Skrupellos (schwer)"]` zu `["Skrupellos"]`
- `handicaps`: von `["Skrupellos (schwer)"]` zu `["Skrupellos"]`

### Datei
- `settings/SciFi Kompendium.json`

---
_MiniMax Agent_