### PR TITLE
Fix: Leerlinge Außenseiter Handicap korrigiert

### DIFF
--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -324,7 +324,7 @@
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
                 "auto_handicaps": [
-                    "Außenseiter (leicht)",
+                    "Außenseiter",
                     "Neugierig",
                     "Trennungsangst"
                 ],


### PR DESCRIPTION
## Beschreibung

Korrigiert das Auto-Handicap für Leerlinge im SciFi Kompendium.

### Problem
- `Außenseiter (leicht)` existiert nicht im SciFi Kompendium
- Dadurch wurde das Auto-Handicap nicht korrekt angewendet

### Lösung
- Geändert zu `Außenseiner` (ohne "(leicht)")

### Datei
- `settings/SciFi Kompendium.json`

---
_MiniMax Agent_