### PR TITLE
Fix: Parasiten Außenseiter Handicap korrigiert

### DIFF
--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -373,7 +373,7 @@
         "Parasiten": {
             "name": "Parasiten",
             "handicaps": [
-                "Außenseiter (leicht)"
+                "Außenseiter"
             ],
             "talente": [],
             "besonderheiten": [
@@ -393,7 +393,7 @@
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
                 "auto_handicaps": [
-                    "Außenseiter (leicht)"
+                    "Außenseiter"
                 ],
                 "spezielle_effekte": {
                     "gemeinschaft": true,


### PR DESCRIPTION
## Beschreibung

Korrigiert das Auto-Handicap für Parasiten im SciFi Kompendium.

### Problem
- `Außenseiter (leicht)` existiert nicht im SciFi Kompendium

### Lösung
- Geändert zu `Außenseiter`


### Datei
- `settings/SciFi Kompendium.json`

---
_MiniMax Agent_