### PR TITLE
Fix: Roboter Handicaps korrigiert

### DIFF
--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -442,8 +442,8 @@
         "Roboter": {
             "name": "Roboter",
             "handicaps": [
-                "Pazifist (schwer)",
-                "Programmiert (schwer)"
+                "Pazifist_schwer",
+                "Programmiert"
             ],
             "talente": [],
             "besonderheiten": [
@@ -464,8 +464,8 @@
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
                 "auto_handicaps": [
-                    "Pazifist (schwer)",
-                    "Programmiert (schwer)"
+                    "Pazifist_schwer",
+                    "Programmiert"
                 ],
                 "spezielle_effekte": {
                     "roboter": true,


### PR DESCRIPTION
## Beschreibung

Korrigiert die Auto-Handicaps für Roboter im SciFi Kompendium.

### Problem
- `Pazifist (schwer)` und `Programmiert (schwer)` existieren nicht
- Korrekten Keys: `Pazifist_schwer` und `Programmiert`


### Lösung
- `auto_handicaps`: von `["Pazifist (schwer)", "Programmiert (schwer)"]` zu `["Pazifist_schwer", "Programmiert"]`

### Datei
- `settings/SciFi Kompendium.json`

---
_MiniMax Agent_