### PR TITLE
PR 7 / Schritt 1d: Migration alter Stufen-IDs für Custom-Volk-Saves

### DIFF
--- a/functions/volkseigenarten_funktionen.py
+++ b/functions/volkseigenarten_funktionen.py
@@ -107,6 +107,17 @@ EFFEKT_TYPEN = {
 }
 
 
+# Mapping alter Eigenart-IDs (vor Stufen-Konsolidierung in Commit a335405)
+# auf die neue konsolidierte ID + Stufen-Label. Wird in
+# `lade_eigenarten_fuer_bearbeitung` angewendet, damit alte Custom-Volk-Saves
+# beim Editieren auf das neue Schema überführt werden.
+STUFEN_MIGRATIONS = {
+    'fliegen_stufe1': {'neue_id': 'fliegen', 'stufe_label': 'Bewegungsweite 6'},
+    'fliegen_stufe2': {'neue_id': 'fliegen', 'stufe_label': 'Bewegungsweite 12'},
+    'fliegen_stufe3': {'neue_id': 'fliegen', 'stufe_label': 'Bewegungsweite 24, Sprint 2W6'},
+}
+
+
 def stufen_kosten_bereich(eigenart):
     """
     Gibt den (min, max) Kosten-Bereich der Stufen einer Eigenart zurück.
@@ -682,24 +693,38 @@ def lade_eigenarten_fuer_bearbeitung(volk_dict):
     """
     Lädt die Eigenarten aus einem gespeicherten Volk-Dictionary.
     Rekonstruiert die positive/negative Listen für den Wizard.
-    
+
     Args:
         volk_dict: Das Dictionary des gespeicherten Volkes
-        
+
     Returns:
         tuple: (positive_eigenarten, negative_eigenarten)
     """
     positive_eigenarten = []
     negative_eigenarten = []
-    
+
     eigenarten = volk_dict.get('eigenarten', [])
-    
+
     for eigenart in eigenarten:
         eigenart_typ = eigenart.get('typ', 'positiv')
         eigenart_id = eigenart.get('id')
-        
+
+        # Eigenart-Typ ist in der Persistenz deutsch ('positiv'/'negativ'),
+        # die Config-Keys sind aber englisch ('positive'/'negative').
+        # Für den Lookup übersetzen.
+        config_typ = 'positive' if eigenart_typ == 'positiv' else 'negative'
+
+        # Migration: alte Stufen-IDs (vor Konsolidierung in Commit a335405) auf
+        # die neue konsolidierte Eigenart umschreiben und die Stufenwahl
+        # rekonstruieren, damit der Wizard das korrekte Radio aktiviert.
+        migrated_stufe = None
+        if eigenart_id in STUFEN_MIGRATIONS:
+            mig = STUFEN_MIGRATIONS[eigenart_id]
+            eigenart_id = mig['neue_id']
+            migrated_stufe = mig['stufe_label']
+
         if eigenart_id:
-            volle_eigenart = get_eigenart_by_id(eigenart_id, eigenart_typ)
+            volle_eigenart = get_eigenart_by_id(eigenart_id, config_typ)
             if volle_eigenart:
                 eigenart_data = dict(volle_eigenart)
             else:
@@ -723,8 +748,15 @@ def lade_eigenarten_fuer_bearbeitung(volk_dict):
                 'optionen': None
             }
 
-        # Persistierte Stufen-Auswahl wiederherstellen (sowohl kosten als auch effekt)
+        # Persistierte Stufen-Auswahl wiederherstellen (sowohl kosten als auch effekt).
+        # Migrierte alte IDs setzen ihre Stufenwahl per Label-Lookup, sonst die
+        # bereits im Save persistierte ausgewaehlte_stufe.
         gespeicherte_stufe = eigenart.get('ausgewaehlte_stufe')
+        if migrated_stufe and eigenart_data.get('stufen') and not gespeicherte_stufe:
+            for stufe in eigenart_data['stufen']:
+                if stufe.get('label') == migrated_stufe:
+                    gespeicherte_stufe = stufe
+                    break
         if gespeicherte_stufe and eigenart_data.get('stufen'):
             wende_stufe_an(eigenart_data, gespeicherte_stufe)
 
@@ -732,7 +764,7 @@ def lade_eigenarten_fuer_bearbeitung(volk_dict):
             positive_eigenarten.append(eigenart_data)
         else:
             negative_eigenarten.append(eigenart_data)
-    
+
     return positive_eigenarten, negative_eigenarten
 
 

--- a/plans/volkseigenarten_mehrfachauswahl_und_stufen_plan.md
+++ b/plans/volkseigenarten_mehrfachauswahl_und_stufen_plan.md
@@ -395,7 +395,7 @@ Eigenarten aus den Regeln, die heute komplett fehlen, in einem separaten Branch 
 4. **✅ PR 4 — Verzögerte Auswahl.** `auswahl_verzoegert` in Config, `_show_optionen_dialog`, `eigenart_zu_effekte` — **ERLEDIGT**
 5. **✅ PR 5 (#182) — Bugfix Attributs-Schwäche-Edit + Stepper-Counter.** — **ERLEDIGT**
 6. **⏳ PR 6 — Multi-Slot im Völker-Tab.** Branch `claude/volkseigenarten-multi-instance`; muss **vor** Schritt 3 Sonderfälle gemerged werden, weil die Sonderfälle-Logik (Macht 2+1, Talent 2+Rang, Superkraft 2+X) auf `wahlmoeglichkeiten_counts` aufbaut — **OFFEN, Branch fertig**
-7. **⏳ PR 7 — Schritt 1d.** Migration Tests für `fliegen_stufe` — **OFFEN**
+7. **✅ PR 7 — Schritt 1d.** Migration Tests für `fliegen_stufe` (`STUFEN_MIGRATIONS`-Tabelle in `volkseigenarten_funktionen.py`, ergänzte 8 Tests in `test_volkseigenarten_stufen_migration.py`, behebt zudem Pre-existing Bug: `eigenart_typ` wurde als deutsches `'positiv'/'negativ'` an `get_eigenart_by_id` gegeben, das aber englische Keys erwartet) — **ERLEDIGT**
 8. **⏳ PR 8 — Schritt 2 (Rest).** Einzel-Instanzen Anzeige im Wizard, Effekte summieren statt überschreiben — **OFFEN**
 9. **⏳ PR 9 — Schritt 3 Sonderfälle.** Macht / Talent / Superkräfte — **OFFEN**
 10. **⏳ PR 10+ — Schritt 4 Vollständigkeit.** Pro Themenblock ein PR — **OFFEN**

--- a/test units/test_volkseigenarten_stufen_migration.py
+++ b/test units/test_volkseigenarten_stufen_migration.py
@@ -1,0 +1,147 @@
+"""
+Tests für die Migration alter Stufen-IDs (vor Konsolidierung in Commit a335405).
+
+Vor der Stufen-Konsolidierung waren `fliegen_stufe1`, `fliegen_stufe2` und
+`fliegen_stufe3` separate Eigenarten-IDs. Nach der Konsolidierung gibt es
+nur noch `fliegen` mit einem `stufen`-Array. Bestehende Custom-Volk-Saves
+mit alten IDs müssen beim Öffnen im Wizard auf das neue Schema gemappt
+werden, sonst zeigt der Wizard die Stufenauswahl als „nicht gewählt" an
+und das Volk wäre nicht speicherbar.
+"""
+
+import unittest
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from functions.volkseigenarten_funktionen import (
+    lade_eigenarten_fuer_bearbeitung,
+    STUFEN_MIGRATIONS,
+)
+
+
+class TestStufenMigrationsTabelle(unittest.TestCase):
+    """Stellt sicher, dass die Migrations-Tabelle alle erwarteten Einträge hat."""
+
+    def test_alle_drei_fliegen_stufen_gemappt(self):
+        self.assertIn('fliegen_stufe1', STUFEN_MIGRATIONS)
+        self.assertIn('fliegen_stufe2', STUFEN_MIGRATIONS)
+        self.assertIn('fliegen_stufe3', STUFEN_MIGRATIONS)
+
+    def test_alle_eintraege_zeigen_auf_fliegen(self):
+        for alt_id, mig in STUFEN_MIGRATIONS.items():
+            if alt_id.startswith('fliegen_'):
+                self.assertEqual(mig['neue_id'], 'fliegen')
+                self.assertIn('stufe_label', mig)
+
+
+class TestLadeEigenartenMitMigration(unittest.TestCase):
+    """`lade_eigenarten_fuer_bearbeitung` muss alte IDs umschreiben und die
+    Stufenwahl rekonstruieren."""
+
+    def test_fliegen_stufe2_wird_zu_fliegen_mit_bw12(self):
+        volk_dict = {
+            'eigenarten': [
+                {'id': 'fliegen_stufe2', 'typ': 'positiv', 'name': 'Fliegen', 'kosten': 4}
+            ]
+        }
+        positive, negative = lade_eigenarten_fuer_bearbeitung(volk_dict)
+
+        self.assertEqual(len(positive), 1)
+        self.assertEqual(len(negative), 0)
+        self.assertEqual(positive[0]['id'], 'fliegen')
+        # Stufe muss gesetzt sein und auf BW 12 zeigen
+        self.assertIn('ausgewaehlte_stufe', positive[0])
+        stufe = positive[0]['ausgewaehlte_stufe']
+        self.assertEqual(stufe.get('label'), 'Bewegungsweite 12')
+        self.assertEqual(stufe.get('kosten'), 4)
+        self.assertEqual(stufe.get('effekt', {}).get('bewegungsweite_flug'), 12)
+
+    def test_fliegen_stufe1_wird_zu_fliegen_mit_bw6(self):
+        volk_dict = {
+            'eigenarten': [
+                {'id': 'fliegen_stufe1', 'typ': 'positiv'}
+            ]
+        }
+        positive, _ = lade_eigenarten_fuer_bearbeitung(volk_dict)
+
+        self.assertEqual(positive[0]['id'], 'fliegen')
+        self.assertEqual(positive[0]['ausgewaehlte_stufe']['label'], 'Bewegungsweite 6')
+        self.assertEqual(positive[0]['kosten'], 2)
+
+    def test_fliegen_stufe3_wird_zu_fliegen_mit_bw24(self):
+        volk_dict = {
+            'eigenarten': [
+                {'id': 'fliegen_stufe3', 'typ': 'positiv'}
+            ]
+        }
+        positive, _ = lade_eigenarten_fuer_bearbeitung(volk_dict)
+
+        self.assertEqual(positive[0]['id'], 'fliegen')
+        self.assertEqual(
+            positive[0]['ausgewaehlte_stufe']['label'],
+            'Bewegungsweite 24, Sprint 2W6',
+        )
+
+    def test_neue_fliegen_id_unveraendert(self):
+        """Modernes Save mit `fliegen` + `ausgewaehlte_stufe` darf nicht doppelt
+        migriert werden."""
+        volk_dict = {
+            'eigenarten': [
+                {
+                    'id': 'fliegen',
+                    'typ': 'positiv',
+                    'ausgewaehlte_stufe': {
+                        'label': 'Bewegungsweite 12',
+                        'kosten': 4,
+                        'effekt': {'fliegen': True, 'bewegungsweite_flug': 12},
+                    },
+                }
+            ]
+        }
+        positive, _ = lade_eigenarten_fuer_bearbeitung(volk_dict)
+        self.assertEqual(positive[0]['id'], 'fliegen')
+        self.assertEqual(
+            positive[0]['ausgewaehlte_stufe']['label'], 'Bewegungsweite 12'
+        )
+
+    def test_unbekannte_id_bleibt_unberuehrt(self):
+        """Eine ID, die weder in der Migrations-Tabelle noch in der Config ist,
+        landet unverändert als Fallback-Eintrag in der Liste."""
+        volk_dict = {
+            'eigenarten': [
+                {'id': 'voellig_unbekannt', 'typ': 'positiv', 'name': 'Test', 'kosten': 1}
+            ]
+        }
+        positive, _ = lade_eigenarten_fuer_bearbeitung(volk_dict)
+        self.assertEqual(len(positive), 1)
+        self.assertEqual(positive[0]['id'], 'voellig_unbekannt')
+
+    def test_gemischte_alte_und_neue_ids(self):
+        """Ein Volk mit gemischten Eigenarten (alte Stufen-IDs + moderne IDs)
+        wird vollständig korrekt geladen."""
+        volk_dict = {
+            'eigenarten': [
+                {'id': 'fliegen_stufe2', 'typ': 'positiv'},
+                {'id': 'nachtsicht', 'typ': 'positiv'},
+                {'id': 'attributsschwäche', 'typ': 'negativ'},
+            ]
+        }
+        positive, negative = lade_eigenarten_fuer_bearbeitung(volk_dict)
+        self.assertEqual(len(positive), 2)
+        self.assertEqual(len(negative), 1)
+        ids_pos = {e['id'] for e in positive}
+        self.assertIn('fliegen', ids_pos)
+        self.assertIn('nachtsicht', ids_pos)
+        # Migrierte Stufe ist gesetzt
+        fliegen = next(e for e in positive if e['id'] == 'fliegen')
+        self.assertEqual(fliegen['ausgewaehlte_stufe']['label'], 'Bewegungsweite 12')
+        # Nicht-Stufen-Eigenart hat keine ausgewaehlte_stufe
+        nachtsicht = next(e for e in positive if e['id'] == 'nachtsicht')
+        self.assertNotIn('ausgewaehlte_stufe', nachtsicht)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Schritt 1d aus dem Volkseigenarten-Plan. Bestehende Custom-Volk-Saves, die noch die alten getrennten Stufen-IDs (`fliegen_stufe1`, `fliegen_stufe2`, `fliegen_stufe3`) enthalten, ließen sich nach der Konsolidierung in Commit `a335405` nicht mehr fehlerfrei im Volk-Editor bearbeiten — die Stufenauswahl ging verloren und der Speichern-Button blieb wegen fehlender Stufenwahl deaktiviert.

## Was sich ändert

- Neue Konstante `STUFEN_MIGRATIONS` in `functions/volkseigenarten_funktionen.py` mit Mapping `alte_id` → `{neue_id, stufe_label}` für die drei Fliegen-Stufen.
- `lade_eigenarten_fuer_bearbeitung` schreibt vor dem Lookup die ID um und rekonstruiert die `ausgewaehlte_stufe` per Label-Lookup. Moderne IDs mit bereits persistierter `ausgewaehlte_stufe` werden nicht doppelt migriert.
- **Bonus-Fix**: `eigenart_typ` wird in der Persistenz als deutsches `'positiv'` / `'negativ'` geschrieben, `get_eigenart_by_id` erwartet aber englisch (`positive`/`negative`). Bislang fiel der Lookup immer in den Fallback-Pfad und Stufen-Eigenarten verloren beim Edit-Reload ihr `stufen`-Array. Jetzt wird vor dem Lookup übersetzt.
- 8 Regressionstests in `test units/test_volkseigenarten_stufen_migration.py`.

## Test plan

- [x] `python -m unittest "test units.test_volkseigenarten_stufen_migration"` — 8/8 grün
- [x] Regression: `python -m unittest "test units.test_volkseigenarten_multi_slot" "test units.test_volkseigenarten_mehrfach" "test units.test_volkseigenarten_stufen" "test units.test_setting_funktionen"` — 72/72 grün
- [ ] Manuell: altes Custom-Volk-JSON mit `effects.eigenarten = [{"id": "fliegen_stufe2", "typ": "positiv"}]` laden, Volk-Editor öffnen → Eigenart erscheint als „Fliegen" mit aktiviertem „Bewegungsweite 12"-Radio. Speichern → neue Form persistiert.

https://claude.ai/code/session_01CkLV4ciPYER9RNRWszhDUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkLV4ciPYER9RNRWszhDUE)_