### PR TITLE
PR 8 / Schritt 2 Rest: kosten_per_instanz + Effekte summieren

### DIFF
--- a/functions/volkseigenarten_funktionen.py
+++ b/functions/volkseigenarten_funktionen.py
@@ -191,10 +191,17 @@ def berechne_punktestand(ausgewaehlte_eigenarten):
     Berechnet den aktuellen Punktestand basierend auf ausgewählten Eigenarten.
     Start: 2 Punkte (für positive Eigenarten)
     Positive Eigenarten kosten Punkte, negative geben Punkte zurück.
-    
+
+    Eigenart-Schema-Feld `kosten_per_instanz` (Default: True):
+      - True (Default):  Jede Instanz kostet einzeln. Beispiel: 2× Robustheit
+        (kosten=1) ⇒ 2 EP positive_kosten.
+      - False:           Nur die erste Instanz pro ID zählt. Vorbereitung für
+        Sonderfälle wie Macht (Schritt 3a) mit `kosten_zusatz_je_weitere`,
+        wo eine eigene Formel die Folge-Instanzen tariefiert.
+
     Args:
         ausgewaehlte_eigenarten: Liste von dicts mit 'id', 'kosten', optional 'optionen'
-        
+
     Returns:
         dict: {
             'start_punkte': 2,
@@ -205,12 +212,21 @@ def berechne_punktestand(ausgewaehlte_eigenarten):
         }
     """
     config = lade_volkseigenarten_config()
-    
+
     positive_kosten = 0
     negative_punkte = 0
-    
+    bereits_gezaehlt_ids = set()  # für kosten_per_instanz=False
+
     for eigenart in ausgewaehlte_eigenarten:
         kosten = eigenart.get('kosten', 0)
+        kosten_per_instanz = eigenart.get('kosten_per_instanz', True)
+        eid = eigenart.get('id')
+
+        if not kosten_per_instanz and eid:
+            if eid in bereits_gezaehlt_ids:
+                continue
+            bereits_gezaehlt_ids.add(eid)
+
         if kosten > 0:
             positive_kosten += kosten
         else:
@@ -385,14 +401,22 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
                     effects['wahlmoeglichkeiten']['freies_attribut'] = True
                 _bump_count('freies_attribut')
             if attribut:
-                effects['attribute_bonuses'][attribut] = effekt.get('attribut_bonus', 2)
+                # Schritt 2e: Boni summieren statt überschreiben, damit z.B.
+                # zwei explizite Bonus-Eigenarten auf dasselbe Attribut sich
+                # addieren. (Regelbedingt selten, defensiv korrekt.)
+                effects['attribute_bonuses'][attribut] = (
+                    effects['attribute_bonuses'].get(attribut, 0) + effekt.get('attribut_bonus', 2)
+                )
 
         elif effekt_typ == 'fertigkeits_bonus':
             if effekt.get('grundfertigkeit_bonus'):
                 if optionen and optionen.get('typ') == 'grundfertigkeit_auswahl':
                     fertigkeit = optionen.get('ausgewaehlt')
                     if fertigkeit:
-                        effects['fertigkeits_startboni'][fertigkeit] = effekt.get('grundfertigkeit_bonus', 2)
+                        effects['fertigkeits_startboni'][fertigkeit] = (
+                            effects['fertigkeits_startboni'].get(fertigkeit, 0)
+                            + effekt.get('grundfertigkeit_bonus', 2)
+                        )
                     elif optionen.get('auswahl_verzoegert'):
                         effects['wahlmoeglichkeiten']['freie_grundfertigkeit'] = True
                         _bump_count('freie_grundfertigkeit')
@@ -400,12 +424,17 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
                 if optionen and optionen.get('typ') == 'nicht_grundfertigkeit_auswahl':
                     fertigkeit = optionen.get('ausgewaehlt')
                     if fertigkeit:
-                        effects['fertigkeits_startboni'][fertigkeit] = effekt.get('nicht_grundfertigkeit_bonus', 2)
+                        effects['fertigkeits_startboni'][fertigkeit] = (
+                            effects['fertigkeits_startboni'].get(fertigkeit, 0)
+                            + effekt.get('nicht_grundfertigkeit_bonus', 2)
+                        )
                     elif optionen.get('auswahl_verzoegert'):
                         effects['wahlmoeglichkeiten']['freie_nicht_grundfertigkeit'] = True
                         _bump_count('freie_nicht_grundfertigkeit')
             elif effekt.get('geschaeftssinn'):
-                effects['fertigkeits_startboni']['Überzeugen/Schätzen'] = 2
+                effects['fertigkeits_startboni']['Überzeugen/Schätzen'] = (
+                    effects['fertigkeits_startboni'].get('Überzeugen/Schätzen', 0) + 2
+                )
 
         elif effekt_typ == 'wahlmoeglichkeit':
             for key, value in effekt.items():
@@ -433,12 +462,13 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
                              'koerpersprache_malus', 'verstand_malus', 'erholung_malus',
                              'treffer_bonus_gegner', 'bewegung_malus', 'sicht_malus',
                              'erholungsbonus', 'erholungsbonus_angeschlagen', 'lebenserwartung_mult']:
-                    if key == 'bewegungsweite_bonus':
-                        effects.setdefault('bewegungsweite_bonus', 0)
-                        effects['bewegungsweite_bonus'] += value
-                    elif key == 'robustheit_bonus':
-                        effects.setdefault('robustheit_bonus', 0)
-                        effects['robustheit_bonus'] += value
+                    # Schritt 2e: Numerische Effekte summieren statt überschreiben.
+                    # `lebenserwartung_mult` ist ein Multiplikator; wir multiplizieren
+                    # statt zu summieren. Alle anderen Werte sind additiv.
+                    if key == 'lebenserwartung_mult':
+                        effects[key] = effects.get(key, 1) * value
+                    elif isinstance(value, (int, float)):
+                        effects[key] = effects.get(key, 0) + value
                     else:
                         effects[key] = value
 

--- a/plans/volkseigenarten_mehrfachauswahl_und_stufen_plan.md
+++ b/plans/volkseigenarten_mehrfachauswahl_und_stufen_plan.md
@@ -50,9 +50,9 @@ Adressiert die **Pro-Charakter-Auswahl** für Eigenarten mit `max_auswahl > 1` u
 ### ⏳ Offen
 
 #### Schritt 2 (Rest)
-- [ ] Schritt 2a — Schema: `kosten_per_instanz` Feld (aktuell implizit)
-- [ ] Schritt 2c — Anzeige Einzel-Instanzen mit ×-Entfernen-Button in der **Wizard**-Übersicht (Volk-Editor; im Völker-Tab durch slot-spezifische Edit-Buttons bereits abgedeckt)
-- [ ] Schritt 2e — `eigenart_zu_effekte`: gleiche Effekte summieren statt überschreiben (additive Effekte wie 2× Robustheit; Multi-Slot-Branch hat nur den `auswahl_verzoegert`-Pfad via `wahlmoeglichkeiten_counts` gelöst, nicht das direkte Effekt-Stacking)
+- [x] Schritt 2a — Schema: `kosten_per_instanz`-Feld erkannt in `berechne_punktestand` (Default True; bei False zählt pro ID nur die erste Instanz, Vorbereitung für Sonderfälle wie Macht 2+1+1+…)
+- [ ] Schritt 2c — Anzeige Einzel-Instanzen mit ×-Entfernen-Button in der **Wizard**-Übersicht (erfordert Widgetisierung des Review-Steps; eigener Folge-PR — im Völker-Tab durch slot-spezifische Edit-Buttons bereits abgedeckt)
+- [x] Schritt 2e — `eigenart_zu_effekte` summiert numerische Effekte (`attribute_bonuses`, `fertigkeits_startboni`, alle additiven Felder im `spezieller_effekt`-Pfad) statt zu überschreiben; `lebenserwartung_mult` als Multiplikator multipliziert
 
 #### Schritt 3 — Sonderfälle
 - [ ] Schritt 3a — Macht (2 + 1 je weitere), AH (Begabt) Aktivierung
@@ -396,9 +396,10 @@ Eigenarten aus den Regeln, die heute komplett fehlen, in einem separaten Branch 
 5. **✅ PR 5 (#182) — Bugfix Attributs-Schwäche-Edit + Stepper-Counter.** — **ERLEDIGT**
 6. **⏳ PR 6 — Multi-Slot im Völker-Tab.** Branch `claude/volkseigenarten-multi-instance`; muss **vor** Schritt 3 Sonderfälle gemerged werden, weil die Sonderfälle-Logik (Macht 2+1, Talent 2+Rang, Superkraft 2+X) auf `wahlmoeglichkeiten_counts` aufbaut — **OFFEN, Branch fertig**
 7. **⏳ PR 7 — Schritt 1d.** Migration Tests für `fliegen_stufe` — **OFFEN**
-8. **⏳ PR 8 — Schritt 2 (Rest).** Einzel-Instanzen Anzeige im Wizard, Effekte summieren statt überschreiben — **OFFEN**
-9. **⏳ PR 9 — Schritt 3 Sonderfälle.** Macht / Talent / Superkräfte — **OFFEN**
-10. **⏳ PR 10+ — Schritt 4 Vollständigkeit.** Pro Themenblock ein PR — **OFFEN**
+8. **✅ PR 8 — Schritt 2 (Rest, 2a + 2e).** `kosten_per_instanz`-Feld in `berechne_punktestand`; Effekte summieren in `eigenart_zu_effekte` (Attribut-, Fertigkeits- und numerische Special-Effects); 9 neue Tests in `test_volkseigenarten_schritt_2_rest.py` — **ERLEDIGT**
+9. **⏳ PR 8b — Schritt 2c.** Wizard-Review-Step widgetisieren mit Einzel-Instanzen + ×-Buttons — **OFFEN, erfordert UI-Rewrite**
+10. **⏳ PR 9 — Schritt 3 Sonderfälle.** Macht / Talent / Superkräfte — **OFFEN**
+11. **⏳ PR 10+ — Schritt 4 Vollständigkeit.** Pro Themenblock ein PR — **OFFEN**
 
 ---
 

--- a/test units/test_volkseigenarten_schritt_2_rest.py
+++ b/test units/test_volkseigenarten_schritt_2_rest.py
@@ -1,0 +1,134 @@
+"""
+Tests für Schritt 2 (Rest) des Volkseigenarten-Plans:
+- 2a: `kosten_per_instanz`-Feld in `berechne_punktestand`
+- 2e: Numerische Effekte werden in `eigenart_zu_effekte` summiert
+       statt überschrieben.
+"""
+
+import unittest
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from functions.volkseigenarten_funktionen import (
+    berechne_punktestand,
+    eigenart_zu_effekte,
+)
+
+
+class TestKostenPerInstanzFlag(unittest.TestCase):
+    """`kosten_per_instanz` (Default True) bestimmt, ob jede Instanz
+    einer Eigenart-ID eigene Kosten verursacht."""
+
+    def test_default_true_zwei_instanzen_zaehlen_doppelt(self):
+        eigenarten = [
+            {'id': 'robustheit_erhoeht', 'kosten': 1},
+            {'id': 'robustheit_erhoeht', 'kosten': 1},
+        ]
+        result = berechne_punktestand(eigenarten)
+        self.assertEqual(result['positive_kosten'], 2)
+
+    def test_kosten_per_instanz_false_zaehlt_nur_einmal(self):
+        eigenarten = [
+            {'id': 'volk_macht', 'kosten': 2, 'kosten_per_instanz': False},
+            {'id': 'volk_macht', 'kosten': 2, 'kosten_per_instanz': False},
+            {'id': 'volk_macht', 'kosten': 2, 'kosten_per_instanz': False},
+        ]
+        result = berechne_punktestand(eigenarten)
+        # Nur die erste Instanz zählt - bereitet Schritt 3a (Macht 2+1+...) vor
+        self.assertEqual(result['positive_kosten'], 2)
+
+    def test_gemischt_kosten_per_instanz(self):
+        """Eigenarten mit kosten_per_instanz=False und ohne mischen sich korrekt."""
+        eigenarten = [
+            {'id': 'volk_macht', 'kosten': 2, 'kosten_per_instanz': False},
+            {'id': 'volk_macht', 'kosten': 2, 'kosten_per_instanz': False},
+            {'id': 'robustheit_erhoeht', 'kosten': 1},
+            {'id': 'robustheit_erhoeht', 'kosten': 1},
+        ]
+        result = berechne_punktestand(eigenarten)
+        # Volk-Macht zählt 1× (2 EP), Robustheit zählt 2× (2 EP) ⇒ 4 EP
+        self.assertEqual(result['positive_kosten'], 4)
+
+    def test_negative_eigenart_mit_kosten_per_instanz_false(self):
+        """Auch negative Eigenarten respektieren das Flag."""
+        eigenarten = [
+            {'id': 'volk_macht_neg', 'kosten': -1, 'kosten_per_instanz': False},
+            {'id': 'volk_macht_neg', 'kosten': -1, 'kosten_per_instanz': False},
+        ]
+        result = berechne_punktestand(eigenarten)
+        self.assertEqual(result['negative_punkte'], 1)
+
+
+class TestEffekteSummierenAttribute(unittest.TestCase):
+    """`eigenart_zu_effekte` summiert Boni statt zu überschreiben."""
+
+    def test_zwei_attribut_bonus_auf_selbes_attribut_summieren(self):
+        # Hypothetische Doppel-Auswahl mit konkretem Attribut (defensiv)
+        eigenart = {
+            'id': 'attr_test',
+            'name': 'Test',
+            'effekt_typ': 'attribut_bonus',
+            'kosten': 2,
+            'effekt': {'attribut_bonus': 2},
+            'optionen': {'typ': 'attribut_auswahl', 'ausgewaehlt': 'Stärke'},
+        }
+        effects = eigenart_zu_effekte([dict(eigenart), dict(eigenart)], [])
+        self.assertEqual(effects['attribute_bonuses']['Stärke'], 4)
+
+    def test_zwei_grundfertigkeit_bonus_auf_selbe_fertigkeit_summieren(self):
+        eigenart = {
+            'id': 'fert_test',
+            'name': 'Test',
+            'effekt_typ': 'fertigkeits_bonus',
+            'kosten': 1,
+            'effekt': {'grundfertigkeit_bonus': 2},
+            'optionen': {'typ': 'grundfertigkeit_auswahl', 'ausgewaehlt': 'Athletik'},
+        }
+        effects = eigenart_zu_effekte([dict(eigenart), dict(eigenart)], [])
+        self.assertEqual(effects['fertigkeits_startboni']['Athletik'], 4)
+
+
+class TestEffekteSummierenSpeziellerEffekt(unittest.TestCase):
+    """Numerische Felder im `spezieller_effekt`-Pfad summieren statt überschreiben."""
+
+    def test_zwei_athletik_malus_summieren(self):
+        eigenart = {
+            'id': 'athletik_test',
+            'name': 'Test',
+            'effekt_typ': 'spezieller_effekt',
+            'kosten': -1,
+            'effekt': {'athletik_malus': 1},
+        }
+        effects = eigenart_zu_effekte([], [dict(eigenart), dict(eigenart)])
+        self.assertEqual(effects.get('athletik_malus'), 2)
+
+    def test_zwei_bewegungsweite_flug_summieren(self):
+        eigenart = {
+            'id': 'flug_test',
+            'name': 'Test',
+            'effekt_typ': 'spezieller_effekt',
+            'kosten': 2,
+            'effekt': {'bewegungsweite_flug': 6},
+        }
+        effects = eigenart_zu_effekte([dict(eigenart), dict(eigenart)], [])
+        self.assertEqual(effects.get('bewegungsweite_flug'), 12)
+
+    def test_lebenserwartung_mult_multipliziert(self):
+        """`lebenserwartung_mult` ist ein Multiplikator und wird multipliziert,
+        nicht summiert."""
+        eigenart = {
+            'id': 'leben_test',
+            'name': 'Test',
+            'effekt_typ': 'spezieller_effekt',
+            'kosten': 1,
+            'effekt': {'lebenserwartung_mult': 2},
+        }
+        effects = eigenart_zu_effekte([dict(eigenart), dict(eigenart)], [])
+        self.assertEqual(effects.get('lebenserwartung_mult'), 4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Schritt 2 (Rest) aus dem Volkseigenarten-Plan. Adressiert zwei Datenfluss-Lücken vor den Sonderfall-PRs (Schritt 3 Macht/Talent/Superkräfte). Schritt 2c (Wizard-Review-Step mit Einzel-Instanzen + ×-Buttons) ist UI-lastig und folgt als separater PR.

## Was sich ändert

**Schritt 2a — `kosten_per_instanz` Schema-Feld**
- Neues optionales Feld an Eigenarten (Default: `True`).
- `True`: jede Instanz kostet einzeln (heute schon das Verhalten, jetzt explizit).
- `False`: nur die erste Instanz pro ID zählt — bereitet die Sonderfall-Logik aus Schritt 3 vor (Macht: 2 + 1 je weitere, Superkraft: 2 + X). `berechne_punktestand` führt dafür ein ID-Set für bereits gezählte Eigenarten.

**Schritt 2e — Effekte summieren statt überschreiben**

Bislang überschrieb `eigenart_zu_effekte` an mehreren Stellen statt zu summieren — bei zwei Instanzen derselben Eigenart blieb nur der zweite Wert übrig. Behoben in:
- `effects['attribute_bonuses'][attribut]` (`attribut_bonus`-Pfad)
- `effects['fertigkeits_startboni'][fertigkeit]` — alle drei Pfade (Grundfertigkeit, Nicht-Grundfertigkeit, Geschäftssinn)
- `spezieller_effekt`-Pfad für `bewegungsweite_flug`, `sozialer_malus`, `athletik_malus`, `ueberreden_malus`, `koerpersprache_malus`, `verstand_malus`, `erholung_malus`, `treffer_bonus_gegner`, `bewegung_malus`, `sicht_malus`, `erholungsbonus`, `erholungsbonus_angeschlagen` (vorher: `else: effects[key] = value` — Überschreibung).
- `lebenserwartung_mult` ist als Multiplikator markiert: zwei Instanzen mit Wert 2 ergeben Faktor 4, nicht 4 (additiv) oder 2 (Überschreibung).
- `bewegungsweite_bonus` und `robustheit_bonus` waren bereits korrekt summiert.

## Test plan

- [x] `python -m unittest "test units.test_volkseigenarten_schritt_2_rest"` — 9/9 grün
- [x] Regression: `test_volkseigenarten_multi_slot`, `test_volkseigenarten_mehrfach`, `test_volkseigenarten_stufen`, `test_setting_funktionen` — 73/73 grün
- [ ] Manuell: Custom-Volk mit 2× Robustheit (`max_auswahl=3`) → Punktestand 2 EP, Volk speichern → `effects.robustheit_bonus = 2`
- [ ] Manuell: Custom-Volk mit zwei verschiedenen Athletik-Malus-Eigenarten → Mali summieren statt zu überschreiben

## Out of Scope (eigener PR 8b)

- **Schritt 2c**: Wizard-Review-Step widgetisieren (statt Markup-Text), pro Instanz ein × zum Entfernen. Im Völker-Tab durch slot-spezifische Edit-Buttons aus PR #196 schon abgedeckt.

## Hinweise

Branch ist von `claude/volkseigenarten-multi-instance` (PR #196) abgezweigt — beide PRs ändern `volkseigenarten_funktionen.py` an unterschiedlichen Stellen. Nach Merge von #196 sollte dieser PR sauber rebasen.

https://claude.ai/code/session_01CkLV4ciPYER9RNRWszhDUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkLV4ciPYER9RNRWszhDUE)_