### PR TITLE
Volkseigenarten: Fertigkeitsboni und Spezial-Effekte korrekt anwenden

### DIFF
--- a/functions/volkseigenarten_funktionen.py
+++ b/functions/volkseigenarten_funktionen.py
@@ -410,6 +410,7 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
         'wahlmoeglichkeiten_counts': {},
         'attribute_bonuses': {},
         'fertigkeits_startboni': {},
+        'fertigkeits_modifier_boni': {},
         'spezielle_effekte': [],
         'handicaps': [],
         'auto_talente': []
@@ -489,10 +490,51 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
                     elif optionen.get('auswahl_verzoegert'):
                         effects['wahlmoeglichkeiten']['freie_nicht_grundfertigkeit'] = True
                         _bump_count('freie_nicht_grundfertigkeit')
+            elif effekt.get('fertigkeit_w4_bonus'):
+                # Eigenart "Fertigkeit (W4)": startet eine beliebige Nicht-Grundfertigkeit
+                # auf W4 statt W4-2. Wird wie nicht_grundfertigkeit_bonus behandelt.
+                if optionen and optionen.get('typ') in ('fertigkeit_auswahl', 'nicht_grundfertigkeit_auswahl'):
+                    fertigkeit = optionen.get('ausgewaehlt')
+                    if fertigkeit:
+                        effects['fertigkeits_startboni'][fertigkeit] = (
+                            effects['fertigkeits_startboni'].get(fertigkeit, 0)
+                            + effekt.get('fertigkeit_w4_bonus', 2) * 2
+                        )
+                    elif optionen.get('auswahl_verzoegert'):
+                        effects['wahlmoeglichkeiten']['freie_fertigkeit_w4'] = True
+                        _bump_count('freie_fertigkeit_w4')
+            elif effekt.get('fertigkeits_bonus'):
+                # Eigenart "Fertigkeitsbonus" (+1/+2): flacher Modifier auf eine bestimmte
+                # Fertigkeit. Erhöht NICHT den Würfeltyp, sondern wird als +X/+Y auf alle
+                # Proben mit dieser Fertigkeit gerechnet.
+                if optionen and optionen.get('typ') == 'fertigkeit_auswahl':
+                    fertigkeit = optionen.get('ausgewaehlt')
+                    bonus = effekt.get('fertigkeits_bonus', 1)
+                    if fertigkeit:
+                        effects['fertigkeits_modifier_boni'][fertigkeit] = (
+                            effects['fertigkeits_modifier_boni'].get(fertigkeit, 0) + bonus
+                        )
+                    elif optionen.get('auswahl_verzoegert'):
+                        effects['wahlmoeglichkeiten']['freier_fertigkeitsbonus'] = bonus
+                        _bump_count('freier_fertigkeitsbonus')
             elif effekt.get('geschaeftssinn'):
-                effects['fertigkeits_startboni']['Überzeugen/Schätzen'] = (
-                    effects['fertigkeits_startboni'].get('Überzeugen/Schätzen', 0) + 2
+                effects['fertigkeits_startboni']['Überreden'] = (
+                    effects['fertigkeits_startboni'].get('Überreden', 0) + 2
                 )
+
+        elif effekt_typ == 'fertigkeits_malus':
+            # Eigenart "Fertigkeitsabzug" (-1/-2): flacher negativer Modifier auf eine
+            # bestimmte Fertigkeit (häufig oder selten verwendet).
+            malus = effekt.get('fertigkeits_malus', -1)
+            if optionen and optionen.get('typ') in ('grundfertigkeit_auswahl', 'fertigkeit_auswahl'):
+                fertigkeit = optionen.get('ausgewaehlt')
+                if fertigkeit:
+                    effects['fertigkeits_modifier_boni'][fertigkeit] = (
+                        effects['fertigkeits_modifier_boni'].get(fertigkeit, 0) + malus
+                    )
+                elif optionen.get('auswahl_verzoegert'):
+                    effects['wahlmoeglichkeiten']['freier_fertigkeitsmalus'] = malus
+                    _bump_count('freier_fertigkeitsmalus')
 
         elif effekt_typ == 'wahlmoeglichkeit':
             for key, value in effekt.items():
@@ -517,7 +559,12 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
                           'keine_lebenswichtigen_organe', 'waermesicht', 'schlafbedarf',
                           'doppelt_so_weit_springen', 'springer_schadensbonus',
                           'widerstand_naturgewalten', 'anfaelligkeit_naturgewalten',
-                          'halbe_bewegungsweite_graben', 'groesse_punkt']:
+                          'halbe_bewegungsweite_graben', 'groesse_punkt',
+                          'wahrnehmung_w8', 'natuerlicher_kaempfer', 'eiserner_wille',
+                          'schnelle_heilung', 'grundfertigkeit_weniger', 'springer',
+                          'furcht', 'immunisierung', 'ruestung_anpassung',
+                          'sprache_eingeschraenkt', 'wuchtig', 'volle_bewegungsweite_schwimmen',
+                          'atmen_unter_wasser_minuten']:
                     effects['spezielle_effekte'].append({'typ': key, 'wert': value})
                 elif key in ['bewegungsweite_bonus', 'robustheit_bonus', 'bewegungsweite_flug',
                              'sozialer_malus', 'athletik_malus', 'ueberreden_malus',
@@ -661,12 +708,22 @@ def eigenart_zu_besonderheiten(positive_eigenarten, negative_eigenarten):
 
         elif eigenart.get('effekt_typ') == 'fertigkeits_bonus':
             optionen = eigenart.get('optionen', {})
-            if optionen.get('typ') == 'grundfertigkeit_auswahl':
-                ausgewaehlt = optionen.get('ausgewaehlt', optionen.get('standard', 'einer Fertigkeit'))
+            effekt = eigenart.get('effekt', {})
+            ausgewaehlt = optionen.get('ausgewaehlt', optionen.get('standard', 'einer Fertigkeit'))
+            if effekt.get('fertigkeits_bonus'):
+                text_parts.append(f": +{effekt.get('fertigkeits_bonus')} auf {ausgewaehlt}")
+            elif effekt.get('fertigkeit_w4_bonus'):
+                text_parts.append(f": W4 in {ausgewaehlt}")
+            elif optionen.get('typ') == 'grundfertigkeit_auswahl':
                 text_parts.append(f": W6 in {ausgewaehlt}")
             elif optionen.get('typ') == 'nicht_grundfertigkeit_auswahl':
-                ausgewaehlt = optionen.get('ausgewaehlt', 'einer Fertigkeit')
                 text_parts.append(f": W6 in {ausgewaehlt}")
+        elif eigenart.get('effekt_typ') == 'fertigkeits_malus':
+            optionen = eigenart.get('optionen', {})
+            effekt = eigenart.get('effekt', {})
+            ausgewaehlt = optionen.get('ausgewaehlt', 'einer Fertigkeit')
+            malus = effekt.get('fertigkeits_malus', -1)
+            text_parts.append(f": {malus:+d} auf {ausgewaehlt}")
 
         elif eigenart.get('effekt', {}).get('fliegen'):
             bewegung = eigenart.get('effekt', {}).get('bewegungsweite_flug', 6)
@@ -697,13 +754,17 @@ def eigenart_zu_besonderheiten(positive_eigenarten, negative_eigenarten):
         optionen = eigenart.get('optionen', {})
         if optionen.get('typ') == 'text_eingabe' and optionen.get('ausgewaehlt'):
             text_parts.append(f": {optionen.get('ausgewaehlt')}")
+        elif optionen.get('typ') in ('grundfertigkeit_auswahl', 'fertigkeit_auswahl',
+                                     'nicht_grundfertigkeit_auswahl', 'attribut_auswahl') \
+                and optionen.get('ausgewaehlt'):
+            text_parts.append(f": {optionen.get('ausgewaehlt')}")
 
         beschreibung = eigenart.get('beschreibung', '')
         if beschreibung:
             text_parts.append(f" ({beschreibung})")
 
         besonderheiten.append(''.join(text_parts))
-    
+
     return besonderheiten
 
 
@@ -787,7 +848,7 @@ def validiere_volk_erstellung(volk_name, positive_eigenarten, negative_eigenarte
         if eigenart.get('optionen'):
             optionen = eigenart['optionen']
             if optionen.get('typ') in ['attribut_auswahl', 'grundfertigkeit_auswahl',
-                                       'nicht_grundfertigkeit_auswahl']:
+                                       'nicht_grundfertigkeit_auswahl', 'fertigkeit_auswahl']:
                 if not optionen.get('ausgewaehlt') and not optionen.get('auswahl_verzoegert'):
                     fehler.append(f"Eigenart '{eigenart.get('name')}' erfordert eine Auswahl")
             elif optionen.get('typ') == 'text_eingabe':

--- a/models/volk.py
+++ b/models/volk.py
@@ -34,6 +34,7 @@ class Volk(EventDispatcher):
             'bewegungsweite_bonus': 0,    # +1 oder -1
             'fertigkeits_startboni': {},   # {'Wahrnehmung': 2} = W4-2 -> W4+0
             'fertigkeits_startmalus': {}, # {'Allgemeinwissen': -2} = W4 -> W4-2
+            'fertigkeits_modifier_boni': {}, # {'Heimlichkeit': 1} = +1 Modifier auf Proben
             'auto_talente': [],           # Automatisch erhaltene Talente
             'auto_handicaps': [],         # Automatisch erhaltene Handicaps
             'auto_mächte': [],            # Automatisch erhaltene Mächte
@@ -53,6 +54,7 @@ class Volk(EventDispatcher):
                 'bewegungsweite_bonus': 0,    # +1 oder -1
                 'fertigkeits_startboni': {},   # {'Wahrnehmung': 2} = W4-2 -> W4+0
                 'fertigkeits_startmalus': {},  # {'Allgemeinwissen': -2} = W4 -> W4-2
+                'fertigkeits_modifier_boni': {},  # {'Heimlichkeit': 1} = +1 Modifier
                 'auto_talente': [],           # Automatisch erhaltene Talente
                 'auto_handicaps': [],         # Automatisch erhaltene Handicaps
                 'auto_mächte': [],            # Automatisch erhaltene Mächte
@@ -236,6 +238,20 @@ class Volk(EventDispatcher):
                         fertigkeit.wuerfel.modifier = malus  # -2 → W4-2
                         Logger.info(f"Volk {self.name}: {fert_name} von W4 auf W4{malus:+d} reduziert")
 
+            # Flacher Fertigkeits-Modifier anwenden (Eigenart "Fertigkeitsbonus" +1/+2 oder
+            # "Fertigkeitsabzug" -1/-2). Erhöht/Senkt nur den Modifier, nicht den Würfeltyp.
+            for fert_name, mod_bonus in self.effects.get('fertigkeits_modifier_boni', {}).items():
+                if fert_name in charakter.fertigkeiten and mod_bonus != 0:
+                    fertigkeit = charakter.fertigkeiten[fert_name]
+                    fertigkeit.wuerfel.modifier += mod_bonus
+                    Logger.info(
+                        f"Volk {self.name}: {fert_name} Modifier um {mod_bonus:+d} angepasst "
+                        f"(jetzt W{fertigkeit.wert}{fertigkeit.modifier:+d})"
+                    )
+
+            # Spezialeffekte mit konkreter Stat-Änderung anwenden
+            self._apply_spezialeffekt_stat_changes(charakter, grundfertigkeiten)
+
             # Automatische Talente hinzufügen
             for talent_name in self.effects.get('auto_talente', []):
                 if talent_name in charakter.talente and not charakter.talente[talent_name].ausgewaehlt:
@@ -416,6 +432,19 @@ class Volk(EventDispatcher):
                         fertigkeit.wuerfel.modifier = 0
                         Logger.info(f"Volk {self.name}: {fert_name} von W4{malus:+d} auf W4 zurückgesetzt")
 
+            # Flacher Fertigkeits-Modifier rückgängig machen
+            for fert_name, mod_bonus in self.effects.get('fertigkeits_modifier_boni', {}).items():
+                if fert_name in charakter.fertigkeiten and mod_bonus != 0:
+                    fertigkeit = charakter.fertigkeiten[fert_name]
+                    fertigkeit.wuerfel.modifier -= mod_bonus
+                    Logger.info(
+                        f"Volk {self.name}: {fert_name} Modifier um {-mod_bonus:+d} zurückgesetzt "
+                        f"(jetzt W{fertigkeit.wert}{fertigkeit.modifier:+d})"
+                    )
+
+            # Spezialeffekt-Stat-Änderungen rückgängig machen
+            self._remove_spezialeffekt_stat_changes(charakter, grundfertigkeiten)
+
             # Automatische Talente entfernen (nur die von diesem Volk hinzugefügten)
             for talent_name in self.effects.get('auto_talente', []):
                 if talent_name in charakter.selected_talente:
@@ -493,6 +522,73 @@ class Volk(EventDispatcher):
         except Exception as e:
             Logger.error(f"Fehler beim Entfernen der Völker-Effekte für {self.name}: {e}")
             return False
+
+    def _iter_spezielle_effekte(self):
+        """Liefert die spezielle_effekte als Liste von (typ, wert)-Tupeln.
+        Unterstützt sowohl das Listen-Format aus dem Volksgenerator als auch
+        das alte Dict-Format aus _parse_effects_from_text.
+        """
+        spezielle = self.effects.get('spezielle_effekte', [])
+        if isinstance(spezielle, list):
+            for eintrag in spezielle:
+                if isinstance(eintrag, dict):
+                    yield eintrag.get('typ'), eintrag.get('wert')
+        elif isinstance(spezielle, dict):
+            for typ, wert in spezielle.items():
+                yield typ, wert
+
+    def _hat_spezialeffekt_typ(self, typ):
+        """True wenn ein Spezialeffekt mit diesem Typ existiert (und einen Wahrwert hat)."""
+        for t, w in self._iter_spezielle_effekte():
+            if t == typ and w:
+                return True
+        return False
+
+    def _apply_spezialeffekt_stat_changes(self, charakter, grundfertigkeiten):
+        """Wendet Spezialeffekte an, die konkrete Würfel-/Wert-Änderungen am Charakter
+        auslösen (z.B. Scharfe Sinne → Wahrnehmung W8, Natürlicher Kämpfer → Kämpfen W6).
+
+        Die reine Beschreibung-Effekte (z.B. Eiserner Wille als +2 vs Einschüchtern)
+        bleiben in spezielle_effekte hinterlegt; sie werden vom Charakterbogen/SL
+        kontextuell ausgewertet, nicht als Stat-Bonus eingerechnet.
+        """
+        try:
+            # Scharfe Sinne: Wahrnehmung W4+0 → W8+0
+            if self._hat_spezialeffekt_typ('wahrnehmung_w8'):
+                fertigkeit = charakter.fertigkeiten.get('Wahrnehmung')
+                if fertigkeit and fertigkeit.wert == 4 and fertigkeit.modifier == 0:
+                    fertigkeit.wuerfel.value = 8
+                    Logger.info(f"Volk {self.name}: Wahrnehmung von W4 auf W8 erhöht (Scharfe Sinne)")
+
+            # Natürlicher Kämpfer: Kämpfen W4-2 → W6+0
+            if self._hat_spezialeffekt_typ('natuerlicher_kaempfer'):
+                fertigkeit = charakter.fertigkeiten.get('Kämpfen')
+                if fertigkeit and fertigkeit.wert == 4 and fertigkeit.modifier == -2:
+                    fertigkeit.wuerfel.value = 6
+                    fertigkeit.wuerfel.modifier = 0
+                    Logger.info(f"Volk {self.name}: Kämpfen von W4-2 auf W6 erhöht (Natürlicher Kämpfer)")
+        except Exception as e:
+            Logger.error(f"Fehler beim Anwenden von Spezialeffekt-Stat-Änderungen für {self.name}: {e}")
+
+    def _remove_spezialeffekt_stat_changes(self, charakter, grundfertigkeiten):
+        """Macht die Stat-Änderungen aus _apply_spezialeffekt_stat_changes rückgängig."""
+        try:
+            # Scharfe Sinne rückgängig: Wahrnehmung W8+0 → W4+0
+            if self._hat_spezialeffekt_typ('wahrnehmung_w8'):
+                fertigkeit = charakter.fertigkeiten.get('Wahrnehmung')
+                if fertigkeit and fertigkeit.wert == 8 and fertigkeit.modifier == 0:
+                    fertigkeit.wuerfel.value = 4
+                    Logger.info(f"Volk {self.name}: Wahrnehmung von W8 auf W4 zurückgesetzt")
+
+            # Natürlicher Kämpfer rückgängig: Kämpfen W6+0 → W4-2
+            if self._hat_spezialeffekt_typ('natuerlicher_kaempfer'):
+                fertigkeit = charakter.fertigkeiten.get('Kämpfen')
+                if fertigkeit and fertigkeit.wert == 6 and fertigkeit.modifier == 0:
+                    fertigkeit.wuerfel.value = 4
+                    fertigkeit.wuerfel.modifier = -2
+                    Logger.info(f"Volk {self.name}: Kämpfen von W6 auf W4-2 zurückgesetzt")
+        except Exception as e:
+            Logger.error(f"Fehler beim Entfernen von Spezialeffekt-Stat-Änderungen für {self.name}: {e}")
 
     def __str__(self):
         return f"{self.name} (Handicaps: {', '.join(self.handicaps)}, Talente: {', '.join(self.talente)}, Besonderheiten: {', '.join(self.besonderheiten)})"

--- a/views/volk_popup.py
+++ b/views/volk_popup.py
@@ -1078,7 +1078,7 @@ class VolkGeneratorWizard:
         elif typ == 'superkraft_auswahl':
             self._show_superkraft_optionen_dialog(eigenart, liste, checkbox, optionen, eigenart_name)
         elif typ in ('attribut_auswahl', 'grundfertigkeit_auswahl', 'nicht_grundfertigkeit_auswahl',
-                     'magieaffin_auswahl'):
+                     'fertigkeit_auswahl', 'magieaffin_auswahl'):
             self._show_liste_optionen_dialog(eigenart, liste, checkbox, optionen, typ, eigenart_name)
         else:
             # Unbekannter Typ - einfach hinzufuegen
@@ -1372,6 +1372,8 @@ class VolkGeneratorWizard:
             items = optionen.get('fertigkeiten', ['Athletik', 'Heimlichkeit', 'Überreden', 'Wahrnehmung', 'Allgemeinwissen'])
         elif typ == 'nicht_grundfertigkeit_auswahl':
             items = self._get_nicht_grundfertigkeiten()
+        elif typ == 'fertigkeit_auswahl':
+            items = self._get_alle_fertigkeiten()
         else:
             items = []
 
@@ -1522,7 +1524,8 @@ class VolkGeneratorWizard:
                 self._show_text_optionen_dialog(eigenart, liste, checkbox, optionen, eigenart_name)
             elif opt_typ == 'talent_auswahl':
                 self._show_talent_optionen_dialog(eigenart, liste, checkbox, optionen, eigenart_name)
-            elif opt_typ in ('attribut_auswahl', 'grundfertigkeit_auswahl', 'nicht_grundfertigkeit_auswahl'):
+            elif opt_typ in ('attribut_auswahl', 'grundfertigkeit_auswahl', 'nicht_grundfertigkeit_auswahl',
+                             'fertigkeit_auswahl'):
                 self._show_liste_optionen_dialog(eigenart, liste, checkbox, optionen, opt_typ, eigenart_name)
             else:
                 liste.append(eigenart)
@@ -1560,6 +1563,26 @@ class VolkGeneratorWizard:
             return
         self._last_stufe_radio_time = now
         self._select_stufe(index, stufen, selected_index, radio_checkboxes)
+
+    def _get_alle_fertigkeiten(self):
+        """Lädt alle Fertigkeiten (Grund- und Nicht-Grundfertigkeiten) aus dem aktiven
+        Setting des Charakters. Wird für Eigenarten verwendet, bei denen jede beliebige
+        Fertigkeit gewählt werden darf (z.B. Fertigkeitsbonus +1/+2)."""
+        try:
+            from kivymd.app import MDApp
+            app = MDApp.get_running_app()
+            if app and hasattr(app, 'controller') and app.controller:
+                charakter = app.controller.charakter
+                if isinstance(charakter.fertigkeiten, dict):
+                    alle = sorted(charakter.fertigkeiten.keys())
+                    if alle:
+                        return alle
+        except Exception as e:
+            Logger.warning(f"volk_popup: Fehler beim Laden aller Fertigkeiten: {e}")
+        # Fallback: SWAE Standard-Fertigkeiten
+        return ['Allgemeinwissen', 'Athletik', 'Heimlichkeit', 'Heilung', 'Einschüchtern',
+                'Kämpfen', 'Provozieren', 'Recherche', 'Reiten', 'Reparieren', 'Schießen',
+                'Steuern', 'Überleben', 'Überreden', 'Wahrnehmung', 'Zaubern']
 
     def _get_nicht_grundfertigkeiten(self):
         """Lädt Nicht-Grundfertigkeiten aus dem aktiven Setting des Charakters."""


### PR DESCRIPTION
Mehrere Volkseigenarten waren in der Volksgenerierung als wählbar
sichtbar, ihre Effekte wurden aber nie tatsächlich auf den Charakter
angewendet, weil sowohl die Konvertierung in `Volk.effects` als auch
die `apply_effects_to_charakter`-Logik die entsprechenden Schlüssel
nicht kannten.

Konkret:
- Fertigkeitsbonus +1/+2: `effekt_typ=fertigkeits_bonus` mit
  `fertigkeits_bonus`-Wert wurde im `eigenart_zu_effekte`-Branch nicht
  ausgewertet. Neuer `fertigkeits_modifier_boni`-Topf hält diese flachen
  Modifier, ohne den Würfeltyp der Fertigkeit zu verändern. Das
  `fertigkeit_auswahl`-Optionsschema wird zusätzlich in der UI und in
  der Validierung unterstützt.
- Fertigkeitsabzug -1/-2: neuer `effekt_typ=fertigkeits_malus`-Branch,
  wird im selben `fertigkeits_modifier_boni`-Topf negativ verbucht.
- Fertigkeit (W4): `fertigkeit_w4_bonus` wird wie eine Nicht-Grund-
  fertigkeitserhöhung von W4-2 → W4 behandelt.
- Scharfe Sinne (`wahrnehmung_w8`), Natürlicher Kämpfer
  (`natuerlicher_kaempfer`), Eiserner Wille (`eiserner_wille`),
  Schnelle Heilung (`schnelle_heilung`) und weitere Whitelist-Lücken
  in `spezielle_effekt`-Konvertierung geschlossen, sodass diese
  Effekte überhaupt im Volk gespeichert werden.
- Volk.apply/remove_effects_to_charakter wendet die neuen
  `fertigkeits_modifier_boni` an und setzt für `wahrnehmung_w8`
  (Wahrnehmung W4 → W8) sowie `natuerlicher_kaempfer` (Kämpfen
  W4-2 → W6) die Würfel direkt um — und macht beides beim Volkswechsel
  sauber rückgängig.
- Geschäftssinn schrieb bisher den Bonus auf die nicht existierende
  Fertigkeit "Überzeugen/Schätzen". Korrektur auf "Überreden", die in
  SWAE tatsächlich vorhanden ist.

Erweiterungen in der UI:
- volk_popup.py kennt nun `fertigkeit_auswahl` als Options-Typ und
  zeigt einen Auswahl-Dialog mit allen Fertigkeiten des aktiven
  Settings.

https://claude.ai/code/session_01LLm3aunkNweZAbzwkq2kPi