### PR TITLE
volk_popup: Scrollbar im 'Abstammung löschen' Dialog auf Android-Standard anpassen

### DIFF
--- a/views/volk_popup.py
+++ b/views/volk_popup.py
@@ -2433,9 +2433,11 @@ class VolkDialogHandler:
             height=scroll_height,
             do_scroll_x=False,
             do_scroll_y=True,
-            bar_width=dp(15),
-            bar_margin=dp(4),
+            bar_width=dp(20) if _mobile else dp(15),
+            bar_margin=dp(8) if _mobile else dp(4),
         )
+        if _mobile:
+            scroll.scroll_type = ['bars', 'content']
         scroll.add_widget(content)
 
         main_content = MDBoxLayout(


### PR DESCRIPTION
bar_width und bar_margin auf _mobile-abhängige Werte gesetzt (dp(20)/dp(8) auf Mobile,
dp(15)/dp(4) auf Desktop), und scroll_type=['bars', 'content'] auf Mobile aktiviert –
entspricht dem Standard aller anderen ScrollViews in der Datei.

https://claude.ai/code/session_01HASs3m3f2oK3q2xSPv8DkG