### PR TITLE
Savage Pathfinder: Ifrits und Oreads als neue Völker ergänzt

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -317,6 +317,54 @@
                 },
                 "wahlmoeglichkeiten": {}
             }
+        },
+        "Oreads": {
+            "name": "Oreads",
+            "handicaps": [
+                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Stark (Stärke W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Granitene Haut (Felsige Wucherungen gewähren +2 Rüstung)",
+                "Elementarzauberei (Oread-Zauberer mit dem Talent Elementarblut [Erde] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+                "Angeborene Macht: Blitz / Magischer Stein (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Eisenwuchs: 1×/Tag kann ein berührtes nicht-magisches Eisen- oder Stahlstück zu einem Gegenstand bis 4,5 kg wachsen (10 Minuten); ersetzt Angeborene Macht",
+                "Alternativfähigkeit – Stein im Blut (Schnell): Schnelle Regeneration für 2 Runden wenn durch Säure Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Stark; schließt Stein im Blut (Langsam) aus",
+                "Alternativfähigkeit – Stein im Blut (Langsam): Langsame Regeneration wenn durch Säure Erschüttert oder Verwundet; ersetzt Elementarzauberei; schließt Stein im Blut (Schnell) aus",
+                "Alternativfähigkeit – Tückische Erde: 1×/Tag kann der Oread eine große Schablone (Reichweite Verstand) in schweres Gelände verwandeln (Erde, Stein oder Sand); Dauer in Minuten je nach Rang: Anfänger 1, Erfahren 2, Veteran 3, Held 4, Legendär 5; ersetzt Granitene Haut"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Terranisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut und Haar in steinigen Tönen (Schwarz, Braun, Grau, Weiß)",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit glänzender Obsidian-Haut, Gesteinsvorsprüngen oder kristallinen Haarspitzen",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Stärke": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": -1,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Langsam_leicht"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "granit_haut": true,
+                    "elementarzauberei_erde": true,
+                    "angeborene_macht_erde": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         }
     },
     "voelker_selected": {
@@ -327,6 +375,7 @@
         "Halbork": false,
         "Ifrits": false,
         "Mensch": true,
+        "Oreads": false,
         "Zwerg": false
     },
     "attribute": {


### PR DESCRIPTION
## Zusammenfassung

Zwei neue elementarberührte Völker für das **Savage Pathfinder** Setting ergänzt.

### Ifrits (Feuer)
Menschen mit elementarer Feuer-Abstammung (z.B. Efrit-Vorfahren).

**Standardfähigkeiten:**
- Beweglich (Geschicklichkeit W6 statt W4, Max. W12+1)
- Dunkelsicht (ignoriert Beleuchtungsabzüge bis 10"/20 Meter)
- Elementarzauberei (Elementarblut [Feuer] senkt Rang für Fortgeschrittenes Elementarblut auf Veteran)
- Angeborene Macht: Ausbruch / Brennende Hände (Willenskraft, 1×/Tag, keine Modifikatoren)
- Heimischer Außenseiter (Typus Außenseiter statt Humanoid)
- Sprachen: Gemeinsprache, Ignanisch

**Alternativfähigkeiten:** Wüstenspiegelung, Efrit-Magie, Feuer im Blut

---

### Oreads (Erde)
Menschen mit elementarer Erd-Abstammung (z.B. Schaitan-Vorfahren).

**Standardfähigkeiten:**
- Stark (Stärke W6 statt W4, Max. W12+1)
- Dunkelsicht (ignoriert Beleuchtungsabzüge bis 10"/20 Meter)
- Granitene Haut (+2 Rüstung durch felsige Wucherungen)
- Elementarzauberei (Elementarblut [Erde] senkt Rang für Fortgeschrittenes Elementarblut auf Veteran)
- Angeborene Macht: Blitz / Magischer Stein (Willenskraft, 1×/Tag, keine Modifikatoren)
- Heimischer Außenseiter (Typus Außenseiter statt Humanoid)
- Handicap: Verringerte Bewegungsweite
- Sprachen: Gemeinsprache, Terranisch

**Alternativfähigkeiten:** Eisenwuchs, Stein im Blut (Schnell), Stein im Blut (Langsam), Tückische Erde

## Testplan
- [ ] Savage Pathfinder Setting öffnen → Ifrits und Oreads erscheinen in der Völkerliste
- [ ] Ifrits auswählen → Geschicklichkeit startet auf W6, Dunkelsicht aktiv
- [ ] Oreads auswählen → Stärke startet auf W6, Bewegungsweite -1, Langsam_leicht Handicap automatisch gesetzt
- [ ] JSON valide (kein Parse-Fehler beim Laden)

https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA)_