### PR TITLE
Savage Pathfinder: Katzenfolk als neues Volk ergänzt

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -558,6 +558,45 @@
                 },
                 "wahlmoeglichkeiten": {}
             }
+        },
+        "Katzenfolk": {
+            "name": "Katzenfolk",
+            "handicaps": [],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
+                "Katzenlück (Freie Wiederholung bei fehlgeschlagenen Ausweichproben)",
+                "Sprinter (Sprintwürfel um einen Typ erhöht)",
+                "Alternativfähigkeit – Katzenkrallen: Natürliche Waffe, Stärke+W4 Schaden (Natürliche Waffen laut Pathfinder für Savage Worlds); ersetzt Beweglich",
+                "Alternativfähigkeit – Sicherer Fall: Landet stets auf den Füßen; reduziert Fallschaden um 1W6+1; ersetzt Sprinter",
+                "Alternativfähigkeit – Geruchssinn: Ignoriert bis zu 4 Punkte Abzüge bei Angriffen gegen durch magische Dunkelheit, Unsichtbarkeit o.ä. verborgene Gegner; ersetzt Nachtsicht"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Katzenfolk"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–100)",
+            "groesse_maennlich": "Zwischen Zwerg und Mensch (~1,30-1,65m, 45-65kg); schlanker Körper mit feinem Fell, Schlitzpupillen, Katzenohren und schlankem Schwanz",
+            "groesse_weiblich": "Zwischen Zwerg und Mensch (~1,25-1,60m, 40-58kg); einziehbare Krallen; Fell-, Haar- und Augenfarbe stark variierend",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {
+                    "nachtsicht": true,
+                    "katzenglueck": true,
+                    "sprinter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         }
     },
     "voelker_selected": {
@@ -568,6 +607,7 @@
         "Halbling": false,
         "Halbork": false,
         "Ifrits": false,
+        "Katzenfolk": false,
         "Mensch": true,
         "Oreads": false,
         "Sylphen": false,


### PR DESCRIPTION
## Zusammenfassung

Katzenfolk als Volk für das **Savage Pathfinder** Setting ergänzt. Neugierige, schlanke Humanoide mit felinen Merkmalen (Fell, Schlitzpupillen, Katzenohren, Schwanz).

**Keine Handicaps.**

**Standardfähigkeiten:**
- Beweglich (Geschicklichkeit W6 statt W4, Max. W12+1)
- Nachtsicht (ignoriert Abzüge für Düstere und Dunkle Beleuchtung)
- Katzenlück (freie Wiederholung bei fehlgeschlagenen Ausweichproben)
- Sprinter (Sprintwürfel um einen Typ erhöht)
- Sprachen: Gemeinsprache, Katzenfolk

**Alternativfähigkeiten:**
- Katzenkrallen: Natürliche Waffe Stärke+W4 (ersetzt Beweglich)
- Sicherer Fall: Landet auf den Füßen, –1W6+1 Fallschaden (ersetzt Sprinter)
- Geruchssinn: Ignoriert bis zu 4 Pkt. Abzüge gegen verborgene Gegner (ersetzt Nachtsicht)

> Hinweis: Dieser PR baut auf PR #213 auf (Aasimars).

## Testplan
- [ ] Savage Pathfinder Setting öffnen → Katzenfolk erscheinen in der Völkerliste
- [ ] Katzenfolk auswählen → Geschicklichkeit auf W6, Nachtsicht und Katzenlück in Besonderheiten
- [ ] JSON valide (kein Parse-Fehler beim Laden)

https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA)_