### PR TITLE
Savage Pathfinder: Dhampire als neues Volk ergänzt

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -597,10 +597,53 @@
                 },
                 "wahlmoeglichkeiten": {}
             }
+        },
+        "Dhampire": {
+            "name": "Dhampire",
+            "handicaps": [
+                "Lichtempfindlich (-1 auf Eigenschaftswürfe bei Sichterfordernissen im hellen Licht)",
+                "Verringerte Vitalität (-1 Robustheit)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Nachtsicht (Ignoriert alle Beleuchtungsabzüge)",
+                "Untote spüren (Als eingeschränkte Aktion: Untote innerhalb von 20\"/40 Meter erspüren; als eingeschränkte freie Aktion: Anzahl und ungefähre Stärke der Untoten ermitteln)",
+                "Untotenresistenz (Freie Wiederholung beim Widerstand gegen Krankheiten; immun gegen Energieentzug)",
+                "Alternativfähigkeit – Tageskind: Nicht durch Tageslicht beeinträchtigt; verliert Lichtempfindlichkeit; Nachtsicht wird durch Nachtsicht (nur Düster/Dunkel) ersetzt",
+                "Alternativfähigkeit – Fangzähne: Natürliche Waffe Biss, Stärke+W4 Schaden (Natürliche Waffen laut Pathfinder für Savage Worlds); ersetzt Untotenresistenz",
+                "Alternativfähigkeit – Vampirische Empathie: Kann mit Fledermäusen, Ratten und Wölfen kommunizieren; freie Wiederholung bei fehlgeschlagenen Überreden-Proben mit diesen Tieren; ersetzt Untote spüren"
+            ],
+            "sprachen": [
+                "Gemeinsprache"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110), jedoch mit übernatürlicher Langlebigkeit ähnlich wie Elfen",
+            "groesse_maennlich": "Hochgewachsen und schlank (1,70-2,00m, 60-85kg); unheimlich schöne Züge, verlängerte Eckzähne, oft gespenstische Blässe im Tageslicht",
+            "groesse_weiblich": "Hochgewachsen und schlank (1,65-1,90m, 55-75kg); übernatürlich flüssige Bewegungen; dunkle Haut wirkt manchmal wie ein Bluterguss",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2
+                },
+                "robustheit_bonus": -1,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "lichtempfindlich": true,
+                    "untote_spueren": true,
+                    "untotenresistenz": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         }
     },
     "voelker_selected": {
         "Aasimars": false,
+        "Dhampire": false,
         "Elf": false,
         "Gnom": false,
         "Halbelf": false,


### PR DESCRIPTION
## Zusammenfassung

Dhampire als Volk für das **Savage Pathfinder** Setting ergänzt. Die halb-lebenden Kinder von Vampiren und menschlichen Müttern – Kinder der Tragödie mit übernatürlichen Kräften und ebensolchen Schwächen.

**Handicaps:**
- Lichtempfindlich (–1 auf Eigenschaftswürfe bei Sichterfordernissen im hellen Licht)
- Verringerte Vitalität (–1 Robustheit)

**Standardfähigkeiten:**
- Beweglich (Geschicklichkeit W6 statt W4, Max. W12+1)
- Nachtsicht (ignoriert alle Beleuchtungsabzüge)
- Untote spüren (eingeschränkte Aktion: Untote in 20"/40m erspüren; eingeschränkte freie Aktion: Anzahl + Stärke ermitteln)
- Untotenresistenz (freie Wiederholung gegen Krankheiten; immun gegen Energieentzug)
- Sprachen: nur Gemeinsprache

**Alternativfähigkeiten:**
- Tageskind: Verliert Lichtempfindlichkeit, Nachtsicht → nur Düster/Dunkel
- Fangzähne: Natürliche Waffe Biss, Stärke+W4 (ersetzt Untotenresistenz)
- Vampirische Empathie: Kommunikation mit Fledermäusen/Ratten/Wölfen + freie Wiederholung bei Überreden (ersetzt Untote spüren)

> Hinweis: Dieser PR baut auf PR #214 auf (Katzenfolk).

## Testplan
- [ ] Savage Pathfinder Setting öffnen → Dhampire erscheinen in der Völkerliste
- [ ] Dhampire auswählen → Geschicklichkeit auf W6, Robustheit –1, Lichtempfindlich und Untotenresistenz in Besonderheiten
- [ ] JSON valide (kein Parse-Fehler beim Laden)

https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA)_