### PR TITLE
Savage Pathfinder: Goblin als neues Volk ergänzt

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -639,12 +639,61 @@
                 },
                 "wahlmoeglichkeiten": {}
             }
+        },
+        "Goblin": {
+            "name": "Goblin",
+            "handicaps": [
+                "Größe -1 (Reduzierte Größe und Robustheit um 1)",
+                "Außenseiter (Schwer) (-2 auf alle Überreden-Proben; werden von anderen oft gemobbt)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Flink (Geschicklichkeit W8 statt W4, Maximum W12+2)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Fähiger Reiter (Beginnt mit W4 in Reiten)",
+                "Heimlich (Heimlichkeit W6 statt W4, Maximum W12+1)",
+                "Alternativfähigkeit – Alles essen: Freie Wiederholung bei Überleben-Proben zur Nahrungssuche; +2 bei Konstitutionsproben gegen toxische Substanzen; ersetzt Fähiger Reiter",
+                "Alternativfähigkeit – Harter Schädel, große Zähne: Natürliche Waffe Biss, Stärke+W4 Schaden; ersetzt Heimlich",
+                "Alternativfähigkeit – Übergroße Ohren: Wahrnehmung W6 statt W4, Maximum W12+1; ersetzt Fähiger Reiter"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Goblinisch"
+            ],
+            "altersspanne": "Jugend mit 3, Erwachsen mit 7–8, maximales Alter 50+ (selten über 20 ohne Beschützer)",
+            "groesse_maennlich": "Klein (~85-100cm, 17-22kg); knochige Gestalt, übergroßer kahler Schädel, riesige Ohren, kleine rote oder gelbe Augen",
+            "groesse_weiblich": "Klein (~80-95cm, 15-20kg); Hautfarbe variiert: Grün, Grau, Blau, Schwarz oder Blassgrau; riesiges Maul mit zackigen Zähnen",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 4
+                },
+                "robustheit_bonus": -1,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {
+                    "Heimlichkeit": 2,
+                    "Reiten": 2
+                },
+                "fertigkeits_modifier_boni": {
+                    "Überreden": -2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Klein"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         }
     },
     "voelker_selected": {
         "Aasimars": false,
         "Dhampire": false,
         "Elf": false,
+        "Goblin": false,
         "Gnom": false,
         "Halbelf": false,
         "Halbling": false,


### PR DESCRIPTION
## Zusammenfassung

Goblins als Volk für das **Savage Pathfinder** Setting ergänzt. Kleine, hässliche Humanoide mit übernatürlicher Flinkhheit – einst Feinde, jetzt auf der Suche nach einem Platz in der Welt.

**Handicaps:**
- Größe –1 (–1 Robustheit, auto: Klein)
- Außenseiter (Schwer) (–2 auf alle Überreden-Proben, werden oft gemobbt)

**Standardfähigkeiten:**
- Flink (Geschicklichkeit **W8** statt W4, Maximum W12+2 — stärker als andere Völker!)
- Dunkelsicht (ignoriert Beleuchtungsabzüge bis 10"/20 Meter)
- Fähiger Reiter (beginnt mit W4 in Reiten, d.h. Fertigkeitsbonus +2 auf Nicht-Grundfertigkeit)
- Heimlich (Heimlichkeit W6 statt W4, Max. W12+1)
- Sprachen: Gemeinsprache, Goblinisch

**Alternativfähigkeiten:**
- Alles essen: Überleben-Reroll + +2 vs. Gifte/Toxine beim Essen (ersetzt Fähiger Reiter)
- Harter Schädel, große Zähne: Natürliche Waffe Biss Stärke+W4 (ersetzt Heimlich)
- Übergroße Ohren: Wahrnehmung W6 statt W4, Max. W12+1 (ersetzt Fähiger Reiter)

> Hinweis: Dieser PR baut auf PR #215 auf (Dhampire).

## Testplan
- [ ] Savage Pathfinder Setting öffnen → Goblin erscheinen in der Völkerliste
- [ ] Goblin auswählen → Geschicklichkeit startet auf W8, Robustheit –1, Überreden –2 Modifier, Klein automatisch als Handicap
- [ ] Heimlichkeit auf W6, Reiten auf W4 (statt W4–2)
- [ ] JSON valide (kein Parse-Fehler beim Laden)

https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA)_