### PR TITLE
Savage Pathfinder: Tieflinge als neues Volk ergänzt

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -687,6 +687,55 @@
                 },
                 "wahlmoeglichkeiten": {}
             }
+        },
+        "Tieflinge": {
+            "name": "Tieflinge",
+            "handicaps": [
+                "Außenseiter (Leicht) (-2 auf alle Überreden-Proben; werden von anderen oft belächelt oder gering geschätzt)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Intelligent (Verstand W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Dunkelheit (1×/Tag als eingeschränkte freie Aktion: geringes Dunkel als Angeborene Macht wirken)",
+                "Teuflische Zauberei (Tieflinge-Zauberer mit Abgrundsblut oder Infernalblut reduzieren die Ranganforderung für Fortgeschrittenes Blut auf Veteran)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Teuflischer Sprinter: Gewinnt das Talent Schnell (Fleet-Footed); ersetzt Intelligent",
+                "Alternativfähigkeit – Greifbarer Schwanz: Kann mit dem Schwanz verstaute Gegenstände als freie Aktion hervorholen; ersetzt Teuflische Zauberei",
+                "Alternativfähigkeit – Verkümmerte Flügel: Fliegen mit Bewegungsweite 6; am Ende jeder Flug-Runde Konstitutionsprobe oder Erschöpfung; ersetzt Teuflische Zauberei"
+            ],
+            "sprachen": [
+                "Abyssalisch",
+                "Gemeinsprache",
+                "Infernalisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); individuelle teuflische Merkmale wie Hörner, gezackter Schwanz, unnatürlich gefärbte Augen, Klauen oder kleine Flügel",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); kein Tieflinge gleicht dem anderen – von seltsam schön bis erschreckend fremdländisch",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2,
+                    "Verstand": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "fertigkeits_modifier_boni": {
+                    "Überreden": -2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "dunkelheit_macht": true,
+                    "teuflische_zauberei": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         }
     },
     "voelker_selected": {
@@ -703,6 +752,7 @@
         "Mensch": true,
         "Oreads": false,
         "Sylphen": false,
+        "Tieflinge": false,
         "Undinen": false,
         "Weinranken-Leshy": false,
         "Zwerg": false


### PR DESCRIPTION
## Zusammenfassung

Tieflinge als Volk für das **Savage Pathfinder** Setting ergänzt. Nachkommen von Menschen und Teufeln/Dämonen – gleichzeitig mehr und weniger als sterblich.

**Handicap:**
- Außenseiter (Leicht) (–2 auf alle Überreden-Proben; Gegenstück zu Goblins' schwerem Außenseiter)

**Standardfähigkeiten:**
- Beweglich (Geschicklichkeit W6 statt W4, Max. W12+1)
- Intelligent (Verstand W6 statt W4, Max. W12+1)
- Dunkelsicht (ignoriert Beleuchtungsabzüge bis 10"/20 Meter)
- Dunkelheit (1×/Tag eingeschränkte freie Aktion: geringes Dunkel als Angeborene Macht)
- Teuflische Zauberei (Abgrundsblut oder Infernalblut senkt Ranganforderung für Fortgeschrittenes Blut auf Veteran)
- Heimischer Außenseiter (Typus Außenseiter statt Humanoid)
- Sprachen: Abyssalisch, Gemeinsprache, Infernalisch

**Alternativfähigkeiten:**
- Teuflischer Sprinter: Talent Schnell (Fleet-Footed) (ersetzt Intelligent)
- Greifbarer Schwanz: verstaute Gegenstände als freie Aktion hervorholen (ersetzt Teuflische Zauberei)
- Verkümmerte Flügel: Fliegen BW 6 mit Konstitutionsprobe/Runde gegen Erschöpfung (ersetzt Teuflische Zauberei)

> Hinweis: Dieser PR baut auf PR #216 auf (Goblin).

## Testplan
- [ ] Savage Pathfinder Setting öffnen → Tieflinge erscheinen in der Völkerliste
- [ ] Tieflinge auswählen → Geschicklichkeit und Verstand auf W6, Überreden –2 Modifier
- [ ] Dunkelsicht, Dunkelheit und Teuflische Zauberei in Besonderheiten
- [ ] JSON valide (kein Parse-Fehler beim Laden)

https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YECyF98CDXxCCcLejcsBfA)_