### PR TITLE
Savage Pathfinder: 20 neue Handicaps auf Deutsch hinzugefügt

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -1,9997 +1,10177 @@
 {
-    "name": "Savage Pathfinder",
-    "description": "Savage Pathfinder",
-    "voelker": {
-        "Elf": {
-            "name": "Elf",
-            "handicaps": [
-                "Schlank (-1 Robustheit, -1 auf Konstitutionsproben)"
-            ],
-            "talente": [],
-            "besonderheiten": [
-                "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
-                "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-                "Intelligenz (Verstand W6 statt W4, Maximum W12+1)",
-                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
-                "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Elfisch"
-            ],
-            "altersspanne": "Erwachsen mit 115, Alt mit 263, maximales Alter 350–750",
-            "groesse_maennlich": "1,65-2,05m, 52-72kg (Durchschnitt 1,85m, 58kg)",
-            "groesse_weiblich": "1,65-1,95m, 44-57kg (Durchschnitt 1,85m, 53kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Geschicklichkeit": 2,
-                    "Verstand": 2
-                },
-                "robustheit_bonus": -1,
-                "bewegungsweite_bonus": 0,
-                "fertigkeits_startboni": {
-                    "Wahrnehmung": 2
-                },
-                "auto_talente": [],
-                "spezielle_effekte": {
-                    "elfenmagie": true,
-                    "nachtsicht": true,
-                    "geschaerfte_sinne": true
-                },
-                "wahlmoeglichkeiten": {}
-            }
+  "name": "Savage Pathfinder",
+  "description": "Savage Pathfinder",
+  "voelker": {
+    "Elf": {
+      "name": "Elf",
+      "handicaps": [
+        "Schlank (-1 Robustheit, -1 auf Konstitutionsproben)"
+      ],
+      "talente": [],
+      "besonderheiten": [
+        "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
+        "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+        "Intelligenz (Verstand W6 statt W4, Maximum W12+1)",
+        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
+        "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Elfisch"
+      ],
+      "altersspanne": "Erwachsen mit 115, Alt mit 263, maximales Alter 350–750",
+      "groesse_maennlich": "1,65-2,05m, 52-72kg (Durchschnitt 1,85m, 58kg)",
+      "groesse_weiblich": "1,65-1,95m, 44-57kg (Durchschnitt 1,85m, 53kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Geschicklichkeit": 2,
+          "Verstand": 2
         },
-        "Gnom": {
-            "name": "Gnom",
-            "handicaps": [
-                "Größe -1 (Reduzierte Robustheit um 1)",
-                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)",
-                "Zwanghaft (Beginnt mit einer verstandsbasierten Fertigkeit auf W4)"
-            ],
-            "talente": [],
-            "besonderheiten": [
-                "Gnomenmagie (Kann Zaubertricks wirken: Licht, Geräusch, Telekinese, Tierfreund mit 1 Machtpunkt)",
-                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
-                "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
-                "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1)"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Gnomisch",
-                "Sylvanisch"
-            ],
-            "altersspanne": "Erwachsen mit 45, Alt mit 150, maximales Alter 200-500",
-            "groesse_maennlich": "95-110cm, 17-19kg (Durchschnitt 100cm, 18kg)",
-            "groesse_weiblich": "90-105cm, 14-17kg (Durchschnitt 95cm, 16kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Konstitution": 2
-                },
-                "robustheit_bonus": -1,
-                "bewegungsweite_bonus": -1,
-                "fertigkeits_startboni": {
-                    "Wahrnehmung": 2
-                },
-                "auto_talente": [],
-                "auto_handicaps": [
-                    "Klein",
-                    "Langsam_leicht"
-                ],
-                "spezielle_effekte": {
-                    "gnomenmagie": true,
-                    "nachtsicht": true,
-                    "geschaerfte_sinne": true
-                },
-                "wahlmoeglichkeiten": {
-                    "freie_verstandsfertigkeit": true
-                }
-            }
+        "robustheit_bonus": -1,
+        "bewegungsweite_bonus": 0,
+        "fertigkeits_startboni": {
+          "Wahrnehmung": 2
         },
-        "Halbelf": {
-            "name": "Halbelf",
-            "handicaps": [],
-            "talente": [],
-            "besonderheiten": [
-                "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
-                "Flexibilität (Beginnt mit W6 in einem Attribut statt W4, erhöht Maximum nicht)",
-                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Elfisch"
-            ],
-            "altersspanne": "Erwachsen mit 22, Alt mit 93, maximales Alter 125–185",
-            "groesse_maennlich": "1,60-2,00m, 50-82kg (Durchschnitt 1,80m, 70kg)",
-            "groesse_weiblich": "1,55-1,90m, 45-77kg (Durchschnitt 1,75m, 61kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {},
-                "robustheit_bonus": 0,
-                "bewegungsweite_bonus": 0,
-                "fertigkeits_startboni": {},
-                "auto_talente": [],
-                "spezielle_effekte": {
-                    "elfenmagie": true,
-                    "nachtsicht": true
-                },
-                "wahlmoeglichkeiten": {
-                    "freies_attribut": true
-                }
-            }
+        "auto_talente": [],
+        "spezielle_effekte": {
+          "elfenmagie": true,
+          "nachtsicht": true,
+          "geschaerfte_sinne": true
         },
-        "Halbling": {
-            "name": "Halbling",
-            "handicaps": [
-                "Größe -1 (Reduzierte Robustheit um 1)",
-                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)"
-            ],
-            "talente": [
-                "Glück (Zusätzlicher Benny pro Spielsitzung)"
-            ],
-            "besonderheiten": [
-                "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-                "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
-                "Wendig (Athletik W6 statt W4, Maximum W12+1)"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Halblingisch"
-            ],
-            "altersspanne": "Erwachsen mit 22, Alt mit 75, maximales Alter 100–200",
-            "groesse_maennlich": "95-100cm, 14-17kg (Durchschnitt 95cm, 16kg)",
-            "groesse_weiblich": "85-95cm, 12-15kg (Durchschnitt 98cm, 14kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Geschicklichkeit": 2
-                },
-                "robustheit_bonus": -1,
-                "bewegungsweite_bonus": -1,
-                "fertigkeits_startboni": {
-                    "Wahrnehmung": 2,
-                    "Athletik": 2
-                },
-                "auto_talente": [
-                    "Glück"
-                ],
-                "auto_handicaps": [
-                    "Klein",
-                    "Langsam_leicht"
-                ],
-                "spezielle_effekte": {
-                    "geschaerfte_sinne": true
-                },
-                "wahlmoeglichkeiten": {}
-            }
+        "wahlmoeglichkeiten": {}
+      }
+    },
+    "Gnom": {
+      "name": "Gnom",
+      "handicaps": [
+        "Größe -1 (Reduzierte Robustheit um 1)",
+        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)",
+        "Zwanghaft (Beginnt mit einer verstandsbasierten Fertigkeit auf W4)"
+      ],
+      "talente": [],
+      "besonderheiten": [
+        "Gnomenmagie (Kann Zaubertricks wirken: Licht, Geräusch, Telekinese, Tierfreund mit 1 Machtpunkt)",
+        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
+        "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
+        "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1)"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Gnomisch",
+        "Sylvanisch"
+      ],
+      "altersspanne": "Erwachsen mit 45, Alt mit 150, maximales Alter 200-500",
+      "groesse_maennlich": "95-110cm, 17-19kg (Durchschnitt 100cm, 18kg)",
+      "groesse_weiblich": "90-105cm, 14-17kg (Durchschnitt 95cm, 16kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Konstitution": 2
         },
-        "Halbork": {
-            "name": "Halbork",
-            "handicaps": [
-                "Außenseiter (leicht, -2 auf Überredenproben, werden oft abgelehnt oder verspottet)"
-            ],
-            "talente": [],
-            "besonderheiten": [
-                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-                "Einschüchternd (Beginnt mit W4 in Einschüchtern, Maximum W12+1)",
-                "Orkische Wildheit (+1 Robustheit)",
-                "Stark (Stärke W6 statt W4, Maximum W12+1)"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Orkisch"
-            ],
-            "altersspanne": "Erwachsen mit 15, Alt mit 45, maximales Alter 60–80",
-            "groesse_maennlich": "1,50-2,05m, 74-144kg (Durchschnitt 1,80m, 109kg)",
-            "groesse_weiblich": "1,40-1,95m, 56-126kg (Durchschnitt 1,70m, 91kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Stärke": 2
-                },
-                "robustheit_bonus": 1,
-                "bewegungsweite_bonus": 0,
-                "fertigkeits_startboni": {},
-                "auto_talente": [],
-                "auto_handicaps": [
-                    "Außenseiter_leicht"
-                ],
-                "spezielle_effekte": {
-                    "dunkelsicht": true
-                },
-                "wahlmoeglichkeiten": {}
-            }
+        "robustheit_bonus": -1,
+        "bewegungsweite_bonus": -1,
+        "fertigkeits_startboni": {
+          "Wahrnehmung": 2
         },
-        "Mensch": {
-            "name": "Mensch",
-            "handicaps": [],
-            "talente": [],
-            "besonderheiten": [
-                "Anpassungsfähigkeit (Freies Talent und W6 in einem Attribut statt W4, erhöht Maximum nicht)"
-            ],
-            "sprachen": [
-                "Gemeinsprache"
-            ],
-            "altersspanne": "Erwachsen mit 17, Alt mit 53, maximales Alter 70–110",
-            "groesse_maennlich": "1,50-1,95m, 54-100kg (Durchschnitt 1,70m, 79kg)",
-            "groesse_weiblich": "1,50-1,85m, 43-84kg (Durchschnitt 1,60m, 64kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {},
-                "robustheit_bonus": 0,
-                "bewegungsweite_bonus": 0,
-                "fertigkeits_startboni": {},
-                "auto_talente": [],
-                "spezielle_effekte": {},
-                "wahlmoeglichkeiten": {
-                    "freies_talent": true,
-                    "freies_attribut": true
-                }
-            }
+        "auto_talente": [],
+        "auto_handicaps": [
+          "Klein",
+          "Langsam_leicht"
+        ],
+        "spezielle_effekte": {
+          "gnomenmagie": true,
+          "nachtsicht": true,
+          "geschaerfte_sinne": true
         },
-        "Zwerg": {
-            "name": "Zwerg",
-            "handicaps": [
-                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
-            ],
-            "talente": [],
-            "besonderheiten": [
-                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-                "Eiserne Konstitution (+1 beim Widerstand gegen Gift, +1 zum Widerstand oder zur Erholung von Mächten)",
-                "Steingespür (+2 auf Wahrnehmungsproben bei ungewöhnlich bearbeitetem Stein innerhalb von 3m)",
-                "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1, Stärke um einen Würfel höher für Belastung und Mindeststärke)"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Zwergisch"
-            ],
-            "altersspanne": "Erwachsen mit 45, Alt mit 188, maximales Alter 250–450",
-            "groesse_maennlich": "1,20-1,35m, 74-93kg (Durchschnitt 1,30m, 84kg)",
-            "groesse_weiblich": "1,15-1,30m, 61-80kg (Durchschnitt 1,20m, 75kg)",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Konstitution": 2
-                },
-                "robustheit_bonus": 0,
-                "bewegungsweite_bonus": -1,
-                "fertigkeits_startboni": {},
-                "auto_talente": [],
-                "auto_handicaps": [
-                    "Langsam_leicht"
-                ],
-                "spezielle_effekte": {
-                    "dunkelsicht": true,
-                    "eiserne_konstitution": true,
-                    "steingespür": true,
-                    "staerke_bonus_traglast": true
-                },
-                "wahlmoeglichkeiten": {}
-            }
-        },
-        "Ifrits": {
-            "name": "Ifrits",
-            "handicaps": [],
-            "talente": [],
-            "besonderheiten": [
-                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-                "Elementarzauberei (Ifrit-Zauberer mit dem Talent Elementarblut [Feuer] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
-                "Angeborene Macht: Ausbruch / Brennende Hände (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
-                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-                "Alternativfähigkeit – Wüstenspiegelung: +1 auf Proben gegen Hunger und Durst; ersetzt Elementarzauberei",
-                "Alternativfähigkeit – Efrit-Magie: Angeborene Macht wird Wachsen/Schrumpfen (selbst, zwei Größenstufen) statt Ausbruch; modifiziert Angeborene Macht",
-                "Alternativfähigkeit – Feuer im Blut: Schnelle Regeneration für 2 Runden wenn durch Feuer Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Beweglich"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Ignanisch"
-            ],
-            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); oft spitze Ohren, rote oder gefleckte Hörner, flammenartiges Haar",
-            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit messingfarbener Haut oder anthrazitfarbenen Schuppen",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Geschicklichkeit": 2
-                },
-                "robustheit_bonus": 0,
-                "bewegungsweite_bonus": 0,
-                "fertigkeits_startboni": {},
-                "auto_talente": [],
-                "auto_handicaps": [],
-                "spezielle_effekte": {
-                    "dunkelsicht": true,
-                    "elementarzauberei_feuer": true,
-                    "angeborene_macht_feuer": true,
-                    "heimischer_aussenseiter": true
-                },
-                "wahlmoeglichkeiten": {}
-            }
-        },
-        "Oreads": {
-            "name": "Oreads",
-            "handicaps": [
-                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
-            ],
-            "talente": [],
-            "besonderheiten": [
-                "Stark (Stärke W6 statt W4, Maximum W12+1)",
-                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-                "Granitene Haut (Felsige Wucherungen gewähren +2 Rüstung)",
-                "Elementarzauberei (Oread-Zauberer mit dem Talent Elementarblut [Erde] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
-                "Angeborene Macht: Blitz / Magischer Stein (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
-                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-                "Alternativfähigkeit – Eisenwuchs: 1×/Tag kann ein berührtes nicht-magisches Eisen- oder Stahlstück zu einem Gegenstand bis 4,5 kg wachsen (10 Minuten); ersetzt Angeborene Macht",
-                "Alternativfähigkeit – Stein im Blut (Schnell): Schnelle Regeneration für 2 Runden wenn durch Säure Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Stark; schließt Stein im Blut (Langsam) aus",
-                "Alternativfähigkeit – Stein im Blut (Langsam): Langsame Regeneration wenn durch Säure Erschüttert oder Verwundet; ersetzt Elementarzauberei; schließt Stein im Blut (Schnell) aus",
-                "Alternativfähigkeit – Tückische Erde: 1×/Tag kann der Oread eine große Schablone (Reichweite Verstand) in schweres Gelände verwandeln (Erde, Stein oder Sand); Dauer in Minuten je nach Rang: Anfänger 1, Erfahren 2, Veteran 3, Held 4, Legendär 5; ersetzt Granitene Haut"
-            ],
-            "sprachen": [
-                "Gemeinsprache",
-                "Terranisch"
-            ],
-            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut und Haar in steinigen Tönen (Schwarz, Braun, Grau, Weiß)",
-            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit glänzender Obsidian-Haut, Gesteinsvorsprüngen oder kristallinen Haarspitzen",
-            "aktiv": true,
-            "custom": false,
-            "effects": {
-                "attribute_bonuses": {
-                    "Stärke": 2
-                },
-                "robustheit_bonus": 0,
-                "bewegungsweite_bonus": -1,
-                "fertigkeits_startboni": {},
-                "auto_talente": [],
-                "auto_handicaps": [
-                    "Langsam_leicht"
-                ],
-                "spezielle_effekte": {
-                    "dunkelsicht": true,
-                    "granit_haut": true,
-                    "elementarzauberei_erde": true,
-                    "angeborene_macht_erde": true,
-                    "heimischer_aussenseiter": true
-                },
-                "wahlmoeglichkeiten": {}
-            }
+        "wahlmoeglichkeiten": {
+          "freie_verstandsfertigkeit": true
         }
+      }
     },
-    "voelker_selected": {
-        "Elf": false,
-        "Gnom": false,
-        "Halbelf": false,
-        "Halbling": false,
-        "Halbork": false,
-        "Ifrits": false,
-        "Mensch": true,
-        "Oreads": false,
-        "Zwerg": false
-    },
-    "attribute": {
-        "Geschicklichkeit": {
-            "attribut_name": "Geschicklichkeit",
-            "wert": 4,
-            "modifier": 0
+    "Halbelf": {
+      "name": "Halbelf",
+      "handicaps": [],
+      "talente": [],
+      "besonderheiten": [
+        "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
+        "Flexibilität (Beginnt mit W6 in einem Attribut statt W4, erhöht Maximum nicht)",
+        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Elfisch"
+      ],
+      "altersspanne": "Erwachsen mit 22, Alt mit 93, maximales Alter 125–185",
+      "groesse_maennlich": "1,60-2,00m, 50-82kg (Durchschnitt 1,80m, 70kg)",
+      "groesse_weiblich": "1,55-1,90m, 45-77kg (Durchschnitt 1,75m, 61kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {},
+        "robustheit_bonus": 0,
+        "bewegungsweite_bonus": 0,
+        "fertigkeits_startboni": {},
+        "auto_talente": [],
+        "spezielle_effekte": {
+          "elfenmagie": true,
+          "nachtsicht": true
         },
-        "Verstand": {
-            "attribut_name": "Verstand",
-            "wert": 4,
-            "modifier": 0
-        },
-        "Stärke": {
-            "attribut_name": "Stärke",
-            "wert": 4,
-            "modifier": 0
-        },
-        "Konstitution": {
-            "attribut_name": "Konstitution",
-            "wert": 4,
-            "modifier": 0
-        },
-        "Willenskraft": {
-            "attribut_name": "Willenskraft",
-            "wert": 4,
-            "modifier": 0
+        "wahlmoeglichkeiten": {
+          "freies_attribut": true
         }
+      }
     },
-    "fertigkeiten_daten": {
-        "Allgemeinwissen": [
-            "Verstand"
+    "Halbling": {
+      "name": "Halbling",
+      "handicaps": [
+        "Größe -1 (Reduzierte Robustheit um 1)",
+        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)"
+      ],
+      "talente": [
+        "Glück (Zusätzlicher Benny pro Spielsitzung)"
+      ],
+      "besonderheiten": [
+        "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+        "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
+        "Wendig (Athletik W6 statt W4, Maximum W12+1)"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Halblingisch"
+      ],
+      "altersspanne": "Erwachsen mit 22, Alt mit 75, maximales Alter 100–200",
+      "groesse_maennlich": "95-100cm, 14-17kg (Durchschnitt 95cm, 16kg)",
+      "groesse_weiblich": "85-95cm, 12-15kg (Durchschnitt 98cm, 14kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Geschicklichkeit": 2
+        },
+        "robustheit_bonus": -1,
+        "bewegungsweite_bonus": -1,
+        "fertigkeits_startboni": {
+          "Wahrnehmung": 2,
+          "Athletik": 2
+        },
+        "auto_talente": [
+          "Glück"
         ],
-        "Athletik": [
-            "Geschicklichkeit"
+        "auto_handicaps": [
+          "Klein",
+          "Langsam_leicht"
         ],
-        "Heimlichkeit": [
-            "Geschicklichkeit"
-        ],
-        "Überreden": [
-            "Willenskraft"
-        ],
-        "Wahrnehmung": [
-            "Verstand"
-        ],
-        "Kämpfen": [
-            "Geschicklichkeit"
-        ],
-        "Schießen": [
-            "Geschicklichkeit"
-        ],
-        "Diebeskunst": [
-            "Geschicklichkeit"
-        ],
-        "Überleben": [
-            "Verstand"
-        ],
-        "Reiten": [
-            "Geschicklichkeit"
-        ],
-        "Fahren": [
-            "Geschicklichkeit"
-        ],
-        "Seefahrt": [
-            "Geschicklichkeit"
-        ],
-        "Pilot": [
-            "Geschicklichkeit"
-        ],
-        "Darbietung": [
-            "Willenskraft"
-        ],
-        "Einschüchtern": [
-            "Willenskraft"
-        ],
-        "Glaube": [
-            "Willenskraft"
-        ],
-        "Heilen": [
-            "Verstand"
-        ],
-        "Provozieren": [
-            "Verstand"
-        ],
-        "Reparieren": [
-            "Verstand"
-        ],
-        "Glücksspiel": [
-            "Verstand"
-        ],
-        "Kriegskunst": [
-            "Verstand"
-        ],
-        "Okkultismus": [
-            "Verstand"
-        ],
-        "Geisteswissenschaften": [
-            "Verstand"
-        ],
-        "Naturwissenschaften": [
-            "Verstand"
-        ],
-        "Zaubern": [
-            "Verstand"
-        ],
-        "Zaubern (Zauberer)": [
-            "Willenskraft"
-        ],
-        "Verrückte Wissenschaft": [
-            "Verstand"
-        ],
-        "Alchemie": [
-            "Verstand"
-        ],
-        "Fokus": [
-            "Willenskraft"
-        ]
+        "spezielle_effekte": {
+          "geschaerfte_sinne": true
+        },
+        "wahlmoeglichkeiten": {}
+      }
     },
-    "talente": {
-        "Berserker": {
-            "name": "Berserker",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Nach Angeschlagen oder Wunde: Nahkampfangriffe müssen Rücksichtslose Angriffe sein, +1 Würfeltyp Stärke, +2 Robustheit, ignoriere eine Stufe Wundabzüge, Kritischer Fehlschlag bei Kämpfenproben trifft zufälliges Ziel. Erleidet Erschöpfung nach fünf Runden in Folge, kann dies mit Verstandsprobe mit –2 beenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Barbar": {
-            "name": "Barbar",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W6",
-                "KON W6"
-            ],
-            "beschreibung": "Rüstungsbeschränkung (mittelschwer), Behände (Bewegungsweite +2), Kampfrausch (siehe Text)",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Berserker",
-                "Behände",
-                "Kampfrausch"
-            ],
-            "auto_handicaps": [
-                "Rüstungsbeschränkung_mittelschwer"
-            ]
-        },
-        "Kraftvoller Schlag": {
-            "name": "Kraftvoller Schlag",
-            "kategorie": "Barbar",
-            "rang": "F",
-            "voraussetzungen": [
-                "Barbar"
-            ],
-            "beschreibung": "Rücksichtslose Angriffe verursachen +4 Schaden anstatt +2.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Einschüchterndes Niederstarren": {
-            "name": "Einschüchterndes Niederstarren",
-            "kategorie": "Barbar",
-            "rang": "V",
-            "voraussetzungen": [
-                "Barbar"
-            ],
-            "beschreibung": "Der Barbar kann eine Einschüchternprobe als freie Aktion ausführen, wenn ihm im Kampf ein Bube oder besser ausgeteilt wird.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kraftrausch": {
-            "name": "Kraftrausch",
-            "kategorie": "Barbar",
-            "rang": "H",
-            "voraussetzungen": [
-                "Barbar"
-            ],
-            "beschreibung": "Die Stärke des Helden wird um zwei Würfeltypen erhöht.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Barde)": {
-            "name": "AH (Barde)",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "Allgemeinwissen W6"
-            ],
-            "beschreibung": "AH (Barde), Behindernde Rüstung (leicht), Scharfzüngig (kann Darbietung zum Provozieren verwenden)",
-            "neue_maechte": 3,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Scharfzüngig"
-            ],
-            "auto_handicaps": [
-                "Behindernde Rüstung_leicht"
-            ]
-        },
-        "Bannlied": {
-            "name": "Bannlied",
-            "kategorie": "Barde",
-            "rang": "V",
-            "voraussetzungen": [
-                "Barde"
-            ],
-            "beschreibung": "Verbündete innerhalb von 5'' erhalten eine Wurfwiederholung, wenn sie feindlichen Zaubereffekten widerstehen oder sich von ihnen erholen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Klagelied": {
-            "name": "Klagelied",
-            "kategorie": "Barde",
-            "rang": "H",
-            "voraussetzungen": [
-                "Barde"
-            ],
-            "beschreibung": "Feindliche Wildcards innerhalb von 10'' ziehen –2 vom Gesamtwert ab, wenn sie einen Benny ausgeben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Druide)": {
-            "name": "AH (Druide)",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "Überleben W6"
-            ],
-            "beschreibung": "AH (Druide), Behindernde Rüstung (leicht), Bindung mit der Natur, Naturgespür",
-            "neue_maechte": 3,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Bindung mit der Natur",
-                "Naturgespür"
-            ],
-            "auto_handicaps": [
-                "Schwur_schwer",
-                "Behindernde Rüstung_leicht"
-            ]
-        },
-        "Tiergestalt": {
-            "name": "Tiergestalt",
-            "kategorie": "Druide",
-            "rang": "F",
-            "voraussetzungen": [
-                "Druide"
-            ],
-            "beschreibung": "Der Druide erhält Gestaltwandeln. Wirkungsdauer ist eine Stunde, und er wirkt den Zauber mit einem Rang höher als normal.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bevorzugte Mächte (Druide)": {
-            "name": "Bevorzugte Mächte (Druide)",
-            "kategorie": "Druide",
-            "rang": "V",
-            "voraussetzungen": [
-                "Druide"
-            ],
-            "beschreibung": "Als begrenzte freie Aktion kann der Druide bis zu zwei Punkte Abzüge ignorieren, wenn er Schutz, Verstricken oder Waffe verbessern wirkt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Göttliche Meisterschaft (Druide)": {
-            "name": "Göttliche Meisterschaft (Druide)",
-            "kategorie": "Druide",
-            "rang": "H",
-            "voraussetzungen": [
-                "Druide"
-            ],
-            "beschreibung": "Der Druide kann Epische Machtmodifikatoren verwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kämpfer": {
-            "name": "Kämpfer",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W6",
-                "Kämpfen W6"
-            ],
-            "beschreibung": "Kriegerische Anpassungsfähigkeit (kann einmal pro Begegnung ein Kampftalent erhalten)",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Kriegerische Anpassungsfähigkeit"
-            ],
-            "auto_handicaps": []
-        },
-        "Tödlicher Hieb": {
-            "name": "Tödlicher Hieb",
-            "kategorie": "Kämpfer",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kämpfer"
-            ],
-            "beschreibung": "Der Kämpfer addiert +1 auf alle Angriffe, die Schaden verursachen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Verbesserte kriegerische Anpassungsfähigkeit": {
-            "name": "Verbesserte kriegerische Anpassungsfähigkeit",
-            "kategorie": "Kämpfer",
-            "rang": "V",
-            "voraussetzungen": [
-                "Kämpfer"
-            ],
-            "beschreibung": "Der Kämpfer kann jetzt zwei Kampftalente pro Begegnung wählen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kämpferisches Können": {
-            "name": "Kämpferisches Können",
-            "kategorie": "Kämpfer",
-            "rang": "H",
-            "voraussetzungen": [
-                "Kämpfer"
-            ],
-            "beschreibung": "Der Kämpfer erhält eine freie Wiederholung bei jeder misslungenen Kämpfenprobe.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Kleriker)": {
-            "name": "AH (Kleriker)",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "Okkultismus W6"
-            ],
-            "beschreibung": "AH (Kleriker), Energie fokussieren (kann mit Reichweite von Willenskraft heilen)",
-            "neue_maechte": 3,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Gnade",
-                "Energie fokussieren"
-            ],
-            "auto_handicaps": [
-                "Schwur_schwer"
-            ]
-        },
-        "Bevorzugte Mächte (Kleriker)": {
-            "name": "Bevorzugte Mächte (Kleriker)",
-            "kategorie": "Kleriker",
-            "rang": "V",
-            "voraussetzungen": [
-                "Kleriker"
-            ],
-            "beschreibung": "Als begrenzte freie Aktion kann der Kleriker bis zu zwei Punkte Abzüge ignorieren, wenn er Heiligtum, Heilung oder Waffe verbessern wirkt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Göttliche Meisterschaft (Kleriker)": {
-            "name": "Göttliche Meisterschaft (Kleriker)",
-            "kategorie": "Kleriker",
-            "rang": "H",
-            "voraussetzungen": [
-                "Kleriker"
-            ],
-            "beschreibung": "Der Kleriker kann Epische Machtmodifikatoren verwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Magier)": {
-            "name": "AH (Magier)",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6",
-                "Okkultismus W6"
-            ],
-            "beschreibung": "AH (Magier) Arkane Verbindung (Verbindung mit einem Gegenstand für +1 Zaubern oder ein Vertrauter), Behindernde Rüstung (jede), Schule, Zauberbücher",
-            "neue_maechte": 3,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Zauberbücher",
-                "Arkane Verbindung",
-                "Schule"
-            ],
-            "auto_handicaps": [
-                "Behindernde Rüstung_jede"
-            ]
-        },
-        "Bevorzugte Mächte (Magier)": {
-            "name": "Bevorzugte Mächte (Magier)",
-            "kategorie": "Magier",
-            "rang": "F",
-            "voraussetzungen": [
-                "Magier"
-            ],
-            "beschreibung": "Als begrenzte freie Aktion kann der Magier bis zu zwei Punkte Abzüge ignorieren, wenn er Abwehren, Arkanen Schutz oder Aufheben wirkt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Meisterschaft (Magier)": {
-            "name": "Arkane Meisterschaft (Magier)",
-            "kategorie": "Magier",
-            "rang": "V",
-            "voraussetzungen": [
-                "Magier"
-            ],
-            "beschreibung": "Der Magier kann Epische Machtmodifikatoren verwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mönch": {
-            "name": "Mönch",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W6",
-                "WIL W6",
-                "Kämpfen W6"
-            ],
-            "beschreibung": "Rüstungsbeschränkung (jede), Betäubende Fäuste, Beweglichkeit, Kämpferische Disziplin, Waffenloser Schlag",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Betäubende Fäuste",
-                "Beweglichkeit",
-                "Kämpferische Disziplin",
-                "Waffenloser Schlag"
-            ],
-            "auto_handicaps": [
-                "Rüstungsbeschränkung_jede"
-            ]
-        },
-        "Mystische Mächte (Mönch)": {
-            "name": "Mystische Mächte (Mönch)",
-            "kategorie": "Mönch",
-            "rang": "F",
-            "voraussetzungen": [
-                "Mönch"
-            ],
-            "beschreibung": "Der Mönch hat 10 gewidmete Machtpunkte, die er verwenden kann, um Abwehren, Beschleunigung, Eigenschaft erhöhen (Geschicklichkeit, Athletik, Kämpfen oder Heimlichkeit) oder Waffe verbessern zu wirken. Alle wirken nur auf den Mönch selbst.",
-            "neue_maechte": 0,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mächtiges Ki": {
-            "name": "Mächtiges Ki",
-            "kategorie": "Mönch",
-            "rang": "V",
-            "voraussetzungen": [
-                "Mönch",
-                "Mystische Mächte (Mönch)"
-            ],
-            "beschreibung": "Zu den mystischen Mächten des Mönchs gehören jetzt Eigenschaft erhöhen (Stärke), Kriegersegen, Schutz, Wandkrabbler.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Unversehrtheit des Körpers": {
-            "name": "Unversehrtheit des Körpers",
-            "kategorie": "Mönch",
-            "rang": "H",
-            "voraussetzungen": [
-                "Mönch",
-                "Mystische Mächte (Mönch)"
-            ],
-            "beschreibung": "Der Mönch kann 2 Machtpunkte ausgeben, um auf Schaden wegstecken zu würfeln. Dies wird nicht behandelt, als hätte er einen Benny ausgegeben",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Paladin": {
-            "name": "Paladin",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "STÄ W6"
-            ],
-            "beschreibung": "Aura der Tapferkeit (+1 auf Furchtproben innerhalb von 10''), Ehrenkodex, Böses entdecken, Böses niederstrecken (freie Wiederholung bei Angriffswürfen gegen einen gewählten bösen Gegner pro Begegnung)",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Aura der Tapferkeit",
-                "Böses Entdecken",
-                "Böses Niederstrecken"
-            ],
-            "auto_handicaps": [
-                "Ehrenkodex"
-            ]
-        },
-        "Mystische Mächte (Paladin)": {
-            "name": "Mystische Mächte (Paladin)",
-            "kategorie": "Paladin",
-            "rang": "F",
-            "voraussetzungen": [
-                "Paladin"
-            ],
-            "beschreibung": "Der Paladin hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Kämpfen, Stärke, Konstitution), Heilung, Linderung, Waffe verbessern nutzen kann. Alle außer Heilung und Linderung wirken nur auf den Paladin selbst.",
-            "neue_maechte": 0,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Gnade (Paladin)": {
-            "name": "Gnade (Paladin)",
-            "kategorie": "Paladin",
-            "rang": "V",
-            "voraussetzungen": [
-                "Paladin"
-            ],
-            "beschreibung": "Der Paladin kann Abgelenkt, Verwundbar, Angeschlagen bei einem Verbündeten in Willenskraft-Reichweite aufheben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Reittier (Paladin)": {
-            "name": "Reittier (Paladin)",
-            "kategorie": "Paladin",
-            "rang": "H",
-            "voraussetzungen": [
-                "Paladin"
-            ],
-            "beschreibung": "Der Held erhält ein loyales leichtes oder schweres Pferd als Wildcard.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schurke": {
-            "name": "Schurke",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W6",
-                "Wahrnehmung W6",
-                "Heimlichkeit W6"
-            ],
-            "beschreibung": "Rüstungsbeschränkung (leicht), Hinterhältiger Angriff",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Hinterhältiger Angriff"
-            ],
-            "auto_handicaps": [
-                "Rüstungsbeschränkung_leicht"
-            ]
-        },
-        "Reflexbewegung": {
-            "name": "Reflexbewegung",
-            "kategorie": "Schurke",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schurke"
-            ],
-            "beschreibung": "Der Schurke ignoriert den üblichen Abzug von –2 beim Wegspringen und kann versuchen, bei jedem Flächenangriff wegzuspringen, der dies normalerweise nicht erlaubt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Opportunist": {
-            "name": "Opportunist",
-            "kategorie": "Schurke",
-            "rang": "H",
-            "voraussetzungen": [
-                "Schurke"
-            ],
-            "beschreibung": "Der Schurke erhält einen freien Angriff gegen einen Feind, der sich aus dem Nahkampf zurückzieht, auch wenn dieser Rückzug besitzt. Wenn er nicht über Rückzug verfügt, zählt der Gegner als Verwundbar.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Waldläufer": {
-            "name": "Waldläufer",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "Athletik W6, Kämpfen oder Schießen W6",
-                "Überleben W6"
-            ],
-            "beschreibung": "Rüstungsbeschränkung (mittelschwer), Erzfeind, Bevorzugtes Gelände, Wildnis durchqueren",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Erzfeind",
-                "Bevorzugtes Gelände",
-                "Wildnis durchqueren"
-            ],
-            "auto_handicaps": [
-                "Rüstungsbeschränkung_mittelschwer"
-            ]
-        },
-        "Beute": {
-            "name": "Beute",
-            "kategorie": "Waldläufer",
-            "rang": "F",
-            "voraussetzungen": [
-                "Waldläufer"
-            ],
-            "beschreibung": "Der Waldläufer wählt einen zusätzlichen Gegner- und Geländetyp für Erzfeind und Bevorzugtes Gelände.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystische Mächte (Waldläufer)": {
-            "name": "Mystische Mächte (Waldläufer)",
-            "kategorie": "Waldläufer",
-            "rang": "V",
-            "voraussetzungen": [
-                "Waldläufer"
-            ],
-            "beschreibung": "Der Waldläufer hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Athletik, Kämpfen, Schießen), Kriegersegen, Tierfreund, Verstricken nutzen kann. Alle bis auf Verstricken wirken nur auf den Waldläufer selbst.",
-            "neue_maechte": 0,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meisterjäger": {
-            "name": "Meisterjäger",
-            "kategorie": "Waldläufer",
-            "rang": "H",
-            "voraussetzungen": [
-                "Waldläufer"
-            ],
-            "beschreibung": "Der Jäger addiert zusätzliche W6 Schaden, wenn er einen erfolgreichen Angriff mit Athletik (Werfen), Kämpfen oder Schießen gegen einen Erzfeind ausführt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Zauberer)": {
-            "name": "AH (Zauberer)",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6",
-                "WIL W6"
-            ],
-            "beschreibung": "AH (Zauberer), Behindernde Rüstung (jede), Blutlinie",
-            "neue_maechte": 2,
-            "machtpunkte": 15,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Blutlinie"
-            ],
-            "auto_handicaps": [
-                "Behindernde Rüstung_jede"
-            ]
-        },
-        "AH (Hexenmeister)": {
-            "name": "AH (Hexenmeister)",
-            "kategorie": "Klasse",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6",
-                "Okkultismus W4"
-            ],
-            "beschreibung": "AH (Hexenmeister), Behindernde Rüstung (jede), Vertrauter, Hexerei (1 freie Hexerei aus der Liste). Arkane Fertigkeit: Zaubern. Startet mit 2 Mächten aus der Hexenmeister-Liste. Der Vertraute speichert die Zauber des Patrons; tägliche Kommunikation mit dem Vertrauten erforderlich.",
-            "neue_maechte": 2,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "auto_talente": [
-                "Vertrauter"
-            ],
-            "auto_handicaps": [
-                "Behindernde Rüstung_jede"
-            ]
-        },
-        "Weitere Hexerei": {
-            "name": "Weitere Hexerei",
-            "kategorie": "Hexenmeister",
-            "rang": "F",
-            "voraussetzungen": [
-                "Hexenmeister"
-            ],
-            "beschreibung": "Der:ie Hexenmeister:in kann eine neue Hexerei auswählen. Kann einmal pro Rang genommen werden. Hexereien (Auswahl): Agonie, Verstärkung, Verfluchen, Kichern, Verzaubern, Böser Blick, Heilung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Starke Hexerei": {
-            "name": "Starke Hexerei",
-            "kategorie": "Hexenmeister",
-            "rang": "V",
-            "voraussetzungen": [
-                "Hexenmeister"
-            ],
-            "beschreibung": "Der:ie Hexenmeister:in kann eine Starke Hexerei auswählen. Kann einmal pro Rang genommen werden. Starke Hexereien (Auswahl): Vettelnauge, Albträume, Vision, Wachsabbild, Wetterkontrolle.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Meisterschaft (Hexenmeister)": {
-            "name": "Arkane Meisterschaft (Hexenmeister)",
-            "kategorie": "Hexenmeister",
-            "rang": "H",
-            "voraussetzungen": [
-                "Hexenmeister"
-            ],
-            "beschreibung": "Durch ihren finsteren Patron erschließt die Hexe die Geheimnisse ihrer mystischen Kräfte. Erhält Zugriff auf alle Epischen Machtmodifikatoren ihrer Mächte.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mächtige Hexerei": {
-            "name": "Mächtige Hexerei",
-            "kategorie": "Hexenmeister",
-            "rang": "L",
-            "voraussetzungen": [
-                "Hexenmeister",
-                "Mindestens zwei Hexenmeister-Vorteile"
-            ],
-            "beschreibung": "Wild Card. Der:ie Hexenmeister:in kann eine Mächtige Hexerei auswählen. Kann einmal pro Rang genommen werden. Mächtige Hexereien (Auswahl): Todesfluch, Ewiger Schlaf, Erzwungene Wiedergeburt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bevorzugte Mächte (Zauberer)": {
-            "name": "Bevorzugte Mächte (Zauberer)",
-            "kategorie": "Zauberer",
-            "rang": "F",
-            "voraussetzungen": [
-                "Zauberer"
-            ],
-            "beschreibung": "Als begrenzte freie Aktion kann der Zauberer bis zu zwei Punkte von Abzügen ignorieren, wenn er Geschoss, Elementarmanipulation oder Schutz wirkt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Meisterschaft (Zauberer)": {
-            "name": "Arkane Meisterschaft (Zauberer)",
-            "kategorie": "Zauberer",
-            "rang": "V",
-            "voraussetzungen": [
-                "Zauberer"
-            ],
-            "beschreibung": "Der Zauberer kann Epische Machtmodifikatoren verwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mächtige Blutlinie": {
-            "name": "Mächtige Blutlinie",
-            "kategorie": "Zauberer",
-            "rang": "H",
-            "voraussetzungen": [
-                "Zauberer"
-            ],
-            "beschreibung": "Der Zauberer erhält die mächtige Fähigkeit seiner Blutlinie.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Formationskämpfer": {
-            "name": "Formationskämpfer",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Erhöht Überzahlbonus um zusätzlich +1 (Maximum +4).",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kampf mit zwei Waffen": {
-            "name": "Kampf mit zwei Waffen",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Mach einen zusätzlichen Kämpfen- oder Athletik-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnelles Nachladen": {
-            "name": "Schnelles Nachladen",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Schießen W6"
-            ],
-            "beschreibung": "Verringere den Nachlade-Wert der Waffe um 1.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnelles Schießen": {
-            "name": "Schnelles Schießen",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Schießen W6"
-            ],
-            "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Verbessertes Schießen": {
-            "name": "Verbessertes Schießen",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schnelles Schießen"
-            ],
-            "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Rüstung": {
-            "name": "Arkane Rüstung",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Die Behindernde Rüstung des Charakters wird um eine Stufe verbessert (beispielsweise von mittelschwer auf leicht)",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkaner Bogenschütze": {
-            "name": "Arkaner Bogenschütze",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH oder MM",
-                "Schießen W8"
-            ],
-            "beschreibung": "Pfeile verstärken für +1 Schießen und Schaden, oder Pfeile erhalten eine Ausprägung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkaner Bogenschütze II": {
-            "name": "Arkaner Bogenschütze II",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Arkaner Bogenschütze"
-            ],
-            "beschreibung": "Phasenpfeile durchdringen Barrieren, oder Pfeilhagel gilt in großer Flächenschablone.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkaner Bogenschütze III": {
-            "name": "Arkaner Bogenschütze III",
-            "kategorie": "Prestige",
-            "rang": "H",
-            "voraussetzungen": [
-                "Arkaner Bogenschütze II"
-            ],
-            "beschreibung": "Ermächtigter Pfeil mit Flächeneffekt-Macht einmal pro Zug, oder Todespfeil einmal pro Tag (Opfer das durch Pfeil Angeschlagen wird oder eine Wunde erleidet, muss Konstitutionsprobe schaffen, oder es stirbt)",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkaner Betrüger": {
-            "name": "Arkaner Betrüger",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH",
-                "Diebeskunst W8"
-            ],
-            "beschreibung": "Weitreichende Fingerfertigkeit: kann Diebeskunst mit –2 auf Entfernung von 5'' verwenden; Spontaner Angriff: Einmal pro Begegnung kann der Schwindler Hinterhältiger Angriff ohne Überraschungsangriff oder Verwundbar verwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkaner Betrüger II": {
-            "name": "Arkaner Betrüger II",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Arkaner Betrüger"
-            ],
-            "beschreibung": "Unsichtbarer Dieb: einmal pro Tag automatisch Unsichtbarkeit für 1 Machtpunkt mit automatischer Steigerung (kein Wurf)",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkaner Betrüger III": {
-            "name": "Arkaner Betrüger III",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Arkaner Betrüger II"
-            ],
-            "beschreibung": "Überraschungszauber: Die Zauber des Helden profitieren von Hinterhältiger Angriff.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Assassine": {
-            "name": "Assassine",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [],
-            "beschreibung": "Todesangriff: Wenn Assassine mit Überraschungsangriff angreift und mindestens eine Wunde erzielt, muss Opfer Konstitutionsprobe schaffen oder sterben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Assassine II": {
-            "name": "Assassine II",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Assassine"
-            ],
-            "beschreibung": "Meisterliches Verstecken: –4 um Assassinen zu sehen, wenn er sich nicht bewegt. Widerstand gegen Gift: +4 Widerstand gegen Gift",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Assassine III": {
-            "name": "Assassine III",
-            "kategorie": "Prestige",
-            "rang": "H",
-            "voraussetzungen": [
-                "Assassine II"
-            ],
-            "beschreibung": "Todesengel: Der Assassine lässt ein getötetes Opfer zu Staub zerfallen und verhindert eine Wiederauferstehung. Schneller Tod: Einmal pro Tag erhält der Assassine einen Überraschungsangriff gegen ein Opfer seiner Wahl.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Drachenjünger": {
-            "name": "Drachenjünger",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH oder MM",
-                "Okkultismus W6"
-            ],
-            "beschreibung": "Odemangriff: 3W6 Schaden plus Ausprägung, Kegelschablone, einmal pro Begegnung",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Drachenjünger II": {
-            "name": "Drachenjünger II",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Drachenjünger"
-            ],
-            "beschreibung": "Schwingen: Charakter erhält Flügel für Flug, Bewegungsweite 8.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Drachenjünger III": {
-            "name": "Drachenjünger III",
-            "kategorie": "Prestige",
-            "rang": "H",
-            "voraussetzungen": [
-                "Drachenjünger II"
-            ],
-            "beschreibung": "Drachengestalt: Zweimal pro Tag kann der Drachenjünger als beschränkte Aktion die Gestalt eines Drachens seiner Blutlinie annehmen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Duellant": {
-            "name": "Duellant",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Geschicklichkeit W8",
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Chirurgischer Schlag: +2 Schaden mit bestimmten Waffen. Parieren: Duellant kann sich Verteidigen, wenn er noch nicht gehandelt hat, mit Paradebonus +6.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Duellant II": {
-            "name": "Duellant II",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Duellant"
-            ],
-            "beschreibung": "Schwächender Schlag: Verringere Bewegungsweite des Gegners um 2 bis geheilt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Duellant III": {
-            "name": "Duellant III",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Duellant II"
-            ],
-            "beschreibung": "Geschosse abwehren: –2, um mit physischen Fernkampfangriffen getroffen zu werden",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kundschafter-Chronist": {
-            "name": "Kundschafter-Chronist",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Überleben W6",
-                "Allgemeinwissen oder Okkultismus W8"
-            ],
-            "beschreibung": "Finden des Weges: Erhöht Reisegeschwindigkeit um 10 %, kann feindliche Begegnung umgehen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kundschafter-Chronist II": {
-            "name": "Kundschafter-Chronist II",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kundschafter-Chronist"
-            ],
-            "beschreibung": "Epische Geschichten: Erzähle bei der Rast eine Geschichte, um Gruppe einen Benny zu gewähren.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kundschafter-Chronist III": {
-            "name": "Kundschafter-Chronist III",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Kundschafter-Chronist II"
-            ],
-            "beschreibung": "Rufen der Legenden: Beschwöre 5 Schatten für eine Stunde.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystischer Ritter": {
-            "name": "Mystischer Ritter",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH",
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Mystische Aufladung: Erhalte Machtpunkt bei Steigerung mit Angriff oder arkaner Fertigkeit.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystischer Ritter II": {
-            "name": "Mystischer Ritter II",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Mystischer Ritter"
-            ],
-            "beschreibung": "Mystischer Schlag: Gib 2 Machtpunkte nach Angriff aus, und addiere +2 auf Angriff.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystischer Ritter III": {
-            "name": "Mystischer Ritter III",
-            "kategorie": "Prestige",
-            "rang": "H",
-            "voraussetzungen": [
-                "Mystischer Ritter II"
-            ],
-            "beschreibung": "Verb. Mystischer Schlag: Gib zwei Machtpunkte aus, nachdem du einen erfolgreichen Angriffswurf abgelegt hat, um den Schaden des Angriffs um +2 zu erhöhen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystischer Theurg": {
-            "name": "Mystischer Theurg",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (beliebig)"
-            ],
-            "beschreibung": "Magiefusion: Wirke zwei Zauber auf einmal und würfle eine arkane Fertigkeit für jede sowie den Wildcard-Würfel.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystischer Theurg II": {
-            "name": "Mystischer Theurg II",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Mystischer Theurg"
-            ],
-            "beschreibung": "Zaubersynergie: Verringere die Kosten beider Zauber wenn du Magiefusion verwendest.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystischer Theurg III": {
-            "name": "Mystischer Theurg III",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Mystischer Theurg II"
-            ],
-            "beschreibung": "Zaubersynthese: Klassentalente sind für alle Mächte verfügbar.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schattentänzer": {
-            "name": "Schattentänzer",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Darbietung W6",
-                "Heimlichkeit W8",
-                "Diebeskunst W6"
-            ],
-            "beschreibung": "Mächtige Dunkelsicht: Sehen in absoluter oder magischer Dunkelheit",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schattentänzer II": {
-            "name": "Schattentänzer II",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Schattentänzer"
-            ],
-            "beschreibung": "Schattenmantel: freies Schaden wegstecken mit –2 in Düsterer oder Dunkler Beleuchtung",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schattentänzer III": {
-            "name": "Schattentänzer III",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schattentänzer II"
-            ],
-            "beschreibung": "Mystische Mächte (Schattenkraft): 10 gewidmete Machtpunkte zum Wirken von Flächenschlag, Illusion, Teleportation oder Verbündeten beschwören (nur Schatten) (nur selbst)",
-            "neue_maechte": 0,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wissenshüter": {
-            "name": "Wissenshüter",
-            "kategorie": "Prestige",
-            "rang": "F",
-            "voraussetzungen": [
-                "Ver W8"
-            ],
-            "beschreibung": "Legendenkunde: freie Wiederholung bei Allgemeinwissen, Geisteswissenschaften, Okkultismus oder Naturwissenschaften",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wissenshüter II": {
-            "name": "Wissenshüter II",
-            "kategorie": "Prestige",
-            "rang": "V",
-            "voraussetzungen": [
-                "Wissenshüter"
-            ],
-            "beschreibung": "Geheimnis: Erhalte eine Fähigkeit eines Kern-Klassentalents.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wissenshüter III": {
-            "name": "Wissenshüter III",
-            "kategorie": "Prestige",
-            "rang": "H",
-            "voraussetzungen": [
-                "Wissenshüter II"
-            ],
-            "beschreibung": "Höhere Legendenkunde: Erhalte 2 neue Mächte, die in der Kampagne verfügbar sind.",
-            "neue_maechte": 2,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Chi": {
-            "name": "Chi",
-            "kategorie": "Übersinnlich",
-            "rang": "V",
-            "voraussetzungen": [
-                "Kampfkunstmeister"
-            ],
-            "beschreibung": "Einmal pro Kampf kannst du eine misslungene Kämpfenprobe wiederholen, einen Gegner einen erfolgreichen Angriff wiederholen lassen oder +W6 Schaden auf einen waffenlosen Angriff addieren.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mut in Flaschen": {
-            "name": "Mut in Flaschen",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [
-                "KON W8"
-            ],
-            "beschreibung": "Alkohol erhöht Konstitution um einen Würfeltyp und du ignorierst eine Stufe Wundabzüge; –1 Geschicklichkeit, Verstand und verknüpfte Fertigkeiten.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Eiserner Wille": {
-            "name": "Eiserner Wille",
-            "kategorie": "Sozial",
-            "rang": "F",
-            "voraussetzungen": [
-                "Mutig",
-                "Starker Wille"
-            ],
-            "beschreibung": "Der Bonus gilt jetzt zum Widerstehen und Erholen von Mächten.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnell": {
-            "name": "Schnell",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Held kann Aktionskarten von 5 oder weniger abwerfen und neu ziehen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Riesentöter": {
-            "name": "Riesentöter",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "+1W6 Schaden gegen Kreaturen, deren Größe die eigene um 3 oder mehr übersteigt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ermittler": {
-            "name": "Ermittler",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W8",
-                "Geisteswissenschaften W8"
-            ],
-            "beschreibung": "+2 Geisteswissenschaften und auf bestimmte Wahrnehmungsproben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Gelehrter": {
-            "name": "Gelehrter",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W8"
-            ],
-            "beschreibung": "+2 auf eine Wissensfertigkeit",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Reparaturgenie": {
-            "name": "Reparaturgenie",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "Reparieren W8"
-            ],
-            "beschreibung": "+2 auf Reparieren, halbe Zeit bei Steigerung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Alchemist)": {
-            "name": "AH (Alchemist)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Arkane Fertigkeit: Alchemie (Verstand)",
-            "neue_maechte": 3,
-            "machtpunkte": 15,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Chemiker": {
-            "name": "Chemiker",
-            "kategorie": "Alchemist",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Alchemist)",
-                "Alchemie W8"
-            ],
-            "beschreibung": "Die Gebräue des Alchemisten halten eine Woche statt 48 Stunden, wenn sie an andere weitergegeben werden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meisterlicher Alchemist": {
-            "name": "Meisterlicher Alchemist",
-            "kategorie": "Alchemist",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Alchemist)",
-                "Alchemie W10"
-            ],
-            "beschreibung": "Erlaubt die Herstellung permanenter Tränke zu halb so hohen Kosten mit improvisierten Vorräten oder einer Alchemistentasche.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Grabgesang": {
-            "name": "Grabgesang",
-            "kategorie": "Barde",
-            "rang": "H",
-            "voraussetzungen": [
-                "AH (Barde)"
-            ],
-            "beschreibung": "Löst Furcht aus und reduziert Proben von Feinden um -2, wenn sie Bennys verwenden. Der Barde muss singen oder ein Instrument spielen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Heldentum inspirieren": {
-            "name": "Heldentum inspirieren",
-            "kategorie": "Barde",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Barde)",
-                "Darbietung W8"
-            ],
-            "beschreibung": "Erlaubt es, fünf Inspirations-Marker zu generieren, die Kameraden Boni auf Proben oder Schadenswürfe geben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Instrument": {
-            "name": "Instrument",
-            "kategorie": "Barde",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Barde)"
-            ],
-            "beschreibung": "Bietet +1 auf Darbietungsproben, wenn ein Instrument beim Zaubern verwendet wird.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Beschwörer)": {
-            "name": "AH (Beschwörer)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-            "neue_maechte": 5,
-            "machtpunkte": 15,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Diabolist)": {
-            "name": "AH (Diabolist)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-            "neue_maechte": 5,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Elementarist)": {
-            "name": "AH (Elementarist)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-            "neue_maechte": 5,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Illusionist)": {
-            "name": "AH (Illusionist)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-            "neue_maechte": 5,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Nekromant)": {
-            "name": "AH (Nekromant)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-            "neue_maechte": 5,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Schamane)": {
-            "name": "AH (Schamane)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6"
-            ],
-            "beschreibung": "Arkane Fertigkeit: Glaube (Willenskraft)",
-            "neue_maechte": 5,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "AH (Tüftler)": {
-            "name": "AH (Tüftler)",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Arkane Fertigkeit: Reparieren (Verstand)",
-            "neue_maechte": 2,
-            "machtpunkte": 15,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Stärkung": {
-            "name": "Arkane Stärkung",
-            "kategorie": "Beschwörer",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Beschwörer)"
-            ],
-            "beschreibung": "Beschworene Tiere erhalten einen magischen Harnisch, der ihre Robustheit um +2 erhöht.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ungezügelte Beschwörung": {
-            "name": "Ungezügelte Beschwörung",
-            "kategorie": "Beschwörer",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Beschwörer)"
-            ],
-            "beschreibung": "Erlaubt dem Beschwörer, beschworenen Monstern ein Kampftalent seines Rangs oder niedriger zu gewähren.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Höhere Beschwörung": {
-            "name": "Höhere Beschwörung",
-            "kategorie": "Beschwörer",
-            "rang": "H",
-            "voraussetzungen": [
-                "AH (Beschwörer)"
-            ],
-            "beschreibung": "Erlaubt das Beschwören mächtiger Kreaturen wie Barghest, Mammut, Frostmammut, Tyrannosaurus Rex oder jungen Drachen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Zorn der Hölle": {
-            "name": "Zorn der Hölle",
-            "kategorie": "Diabolist",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Diabolist)"
-            ],
-            "beschreibung": "Mächte wie Flächenschlag, Geschoss und Strahl verursachen +2 Schaden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Infernale Rüstung": {
-            "name": "Infernale Rüstung",
-            "kategorie": "Diabolist",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Diabolist)"
-            ],
-            "beschreibung": "Verleiht +2 Rüstung durch eine höllische Aura, macht Heimlichkeit jedoch nahezu unmöglich.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Herzholzstab": {
-            "name": "Herzholzstab",
-            "kategorie": "Druide",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Druide)"
-            ],
-            "beschreibung": "Ein Kampfstab, der zusätzlichen Schaden verursacht und bei Verlust durch ein Ritual ersetzt werden kann.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wahre Form": {
-            "name": "Wahre Form",
-            "kategorie": "Druide",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Druide)"
-            ],
-            "beschreibung": "Ermöglicht Druiden, in Tierform zu sprechen und Mächte zu wirken, mit Risiken bei längerem Verweilen in Tiergestalt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Elementare Absorption": {
-            "name": "Elementare Absorption",
-            "kategorie": "Elementarmagier",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Elementarmagier)"
-            ],
-            "beschreibung": "Erhöht Robustheit um +2 während der Nutzung von Elementarsynergie.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Elementarer Meister": {
-            "name": "Elementarer Meister",
-            "kategorie": "Elementarmagier",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Elementarist)"
-            ],
-            "beschreibung": "Erlaubt die Beherrschung eines zusätzlichen Elements, Mächte können zwischen Elementen gewechselt werden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Böser Blick": {
-            "name": "Böser Blick",
-            "kategorie": "Hexer/Hexe",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Hexer/Hexe)"
-            ],
-            "beschreibung": "Zwingt Feinde zu Willenskraftproben mit -2 bei der Nutzung von Bennys, die fehlschlagen können.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Hexenzeit": {
-            "name": "Hexenzeit",
-            "kategorie": "Hexer/Hexe",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Hexer/Hexe)"
-            ],
-            "beschreibung": "Verleiht Boni während einer besonderen Stunde, z. B. keine Kritischen Fehlschläge und kostenloses Wegstecken von Schaden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Tödliche Illusion": {
-            "name": "Tödliche Illusion",
-            "kategorie": "Illusionist",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Illusionist)",
-                "Zaubern W10"
-            ],
-            "beschreibung": "Erlaubt den Einsatz des Machtmodifikators Tödliche Illusion ohne zusätzliche Machtpunkte.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meisterlicher Illusionist": {
-            "name": "Meisterlicher Illusionist",
-            "kategorie": "Illusionist",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Illusionist)",
-                "Zaubern W8"
-            ],
-            "beschreibung": "Illusionen erhalten die Machtmodifikatoren Beweglich und Geräusch ohne zusätzliche Machtpunkte.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Untote zerstören": {
-            "name": "Untote zerstören",
-            "kategorie": "Kleriker",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Kleriker)"
-            ],
-            "beschreibung": "Kanalisierung positiver Energie, um Untote mit 2W6 (oder 3W6 für 2 Machtpunkte) Schaden zu treffen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Gnade": {
-            "name": "Gnade",
-            "kategorie": "Kleriker",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Kleriker)",
-                "Glaube W8"
-            ],
-            "beschreibung": "Hebt Abgelenkt, Angeschlagen oder Verwundbar durch Einsatz von 1 Machtpunkt auf.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Unheimliche Inspiration": {
-            "name": "Unheimliche Inspiration",
-            "kategorie": "Magier",
-            "rang": "H",
-            "voraussetzungen": [
-                "AH (Magier)"
-            ],
-            "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht mit einem Benny, solange Zugang zu Zauberbüchern besteht.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Zauberbücher": {
-            "name": "Zauberbücher",
-            "kategorie": "Magier",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Magie)"
-            ],
-            "beschreibung": "Erhält drei neue Mächte bei Wahl des Talents Neue Mächte und sofort eine Macht des eigenen Ranges.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Seelengefäß": {
-            "name": "Seelengefäß",
-            "kategorie": "Nekromant",
-            "rang": "L",
-            "voraussetzungen": [
-                "AH (Nekromant)",
-                "Okkultismus W10"
-            ],
-            "beschreibung": "Versteckt die Seele in einem Behälter, um nach dem Tod in einen vorbereiteten Leichnam zurückzukehren.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Untoter Vertrauter": {
-            "name": "Untoter Vertrauter",
-            "kategorie": "Nekromant",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Nekromant)"
-            ],
-            "beschreibung": "Erhält einen untoten Tiergefährten mit speziellen Boni, ähnlich wie das Talent Vertrauter.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Urtümliche Magie": {
-            "name": "Urtümliche Magie",
-            "kategorie": "Schamane",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Schamane)"
-            ],
-            "beschreibung": "Erhöht Schaden von Mächten um +2, verursacht jedoch bei Kritischen Fehlschlägen Betäubung im Umkreis.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Geweihter Fetisch": {
-            "name": "Geweihter Fetisch",
-            "kategorie": "Schamane",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Schamane)",
-                "Glaube W8"
-            ],
-            "beschreibung": "Verleiht eine Freie Wurfwiederholung bei Glaubensproben, wenn ein geweihter Fetisch genutzt wird.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Konstrukt-Vertrauter": {
-            "name": "Konstrukt-Vertrauter",
-            "kategorie": "Tüftler",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Tüftler)"
-            ],
-            "beschreibung": "Erhält einen mechanischen Tiergefährten mit speziellen Vorteilen, ähnlich wie das Talent Vertrauter.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Tüftlerrüstung": {
-            "name": "Tüftlerrüstung",
-            "kategorie": "Tüftler",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Tüftler)"
-            ],
-            "beschreibung": "Ermöglicht modifizierte Rüstung mit Boni auf Arme, Rumpf oder Beine, unterliegt jedoch Ausfällen bei Wunden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Große Macht": {
-            "name": "Große Macht",
-            "kategorie": "Zauberer",
-            "rang": "V",
-            "voraussetzungen": [
-                "AH (Zauberer)"
-            ],
-            "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht bis 20 Machtpunkte mit einem Abzug von -2 auf die Zaubernprobe.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Phänomenale Macht": {
-            "name": "Phänomenale Macht",
-            "kategorie": "Zauberer",
-            "rang": "H",
-            "voraussetzungen": [
-                "AH (Zauberer)",
-                "Große Macht"
-            ],
-            "beschreibung": "Erlaubt das Wirken jeder Macht mit Entschlossenheit und fügt den Entschlossenheitsbonus dem Zauberwurf hinzu.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Auserkoren": {
-            "name": "Auserkoren",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Entschlossenheit hält bis zum Ende der Begegnung an, ohne dass sie mit Bennys aufrechterhalten werden muss. Der Charakter hat ein unverkennbares Mal und wird von mächtigen Feinden verfolgt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bevorzugtes Gelände": {
-            "name": "Bevorzugtes Gelände",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "Überleben W6"
-            ],
-            "beschreibung": "Wähle ein Geländetyp. In diesem Gelände erhält der Charakter eine freie Wiederholung bei Überlebens- und Wahrnehmungsproben sowie eine zusätzliche Aktionskarte zur Initiative.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Erbstück": {
-            "name": "Erbstück",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Gewährt einen magischen Gegenstand im Wert von bis zu 10.000 Goldmünzen. Der Gegenstand muss bei Verlust durch ein Abenteuer wiedergefunden werden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Erzfeind": {
-            "name": "Erzfeind",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "Athletik W6",
-                "Kämpfen oder Schießen W6"
-            ],
-            "beschreibung": "Wähle eine Art von Feind. Der Charakter erhält eine freie Wiederholung bei Überlebensproben, um diese zu verfolgen, und bei Angriffen auf diese Feinde.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Feenblütig": {
-            "name": "Feenblütig",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Gewährt eine freie Wiederholung, um feindlichen Mächten und zauberähnlichen Effekten zu widerstehen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Betäubungsschlag": {
-            "name": "Betäubungsschlag",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "STÄ W8"
-            ],
-            "beschreibung": "Schläge mit stumpfen Waffen zwingen Gegner zu Konstitutionsproben. Bei einem Misserfolg wird der Gegner Betäubt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Böe": {
-            "name": "Böe",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [],
-            "beschreibung": "Mächtige Flügelschläge können Gegner in einem Kegel Angeschlagen machen oder Betäuben, wenn ein Joker gezogen wird.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Doppelschuss": {
-            "name": "Doppelschuss",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Athletik W8 für Wurfwaffen oder Schießen W8 für Bögen"
-            ],
-            "beschreibung": "Erlaubt das Schießen oder Werfen von zwei Geschossen in einem Angriff mit separaten Angriffswürfen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Vierfachschuss": {
-            "name": "Vierfachschuss",
-            "kategorie": "Kampf",
-            "rang": "H",
-            "voraussetzungen": [
-                "Doppelschuss",
-                "Athletik W10 für Wurfwaffen oder Schießen W10 für Bögen"
-            ],
-            "beschreibung": "Erlaubt das zweimalige Nutzen des Talents Doppelschuss pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Unglaubliche Reflexe": {
-            "name": "Unglaubliche Reflexe",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Geschicklichkeit W8",
-                "Athletik W8"
-            ],
-            "beschreibung": "Der Charakter ignoriert den üblichen -2 Geschicklichkeits-Abzug beim Wegspringen und kann bei Flächeneffekten oder Angriffen wie Strahl oder Verwirrung Wegspringen anwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Versengen": {
-            "name": "Versengen",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "KON W8"
-            ],
-            "beschreibung": "Erhöht den Schaden einer Odemwaffe um einen Würfeltyp und erlaubt die Wahl zwischen Kegel- und Strahlschablone.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Verteidiger": {
-            "name": "Verteidiger",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kämpfen W6"
-            ],
-            "beschreibung": "Erlaubt das Teilen des Parade- und Deckungsbonus eines Schildes mit einem Verbündeten in der Nähe als freie Aktion.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wildling": {
-            "name": "Wildling",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Kämpfen W6"
-            ],
-            "beschreibung": "Ein Rücksichtsloser Angriff verursacht +4 Schaden statt +2.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Zerschmettern": {
-            "name": "Zerschmettern",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W8"
-            ],
-            "beschreibung": "Fügt bei Angriffen auf Objekte +W6 Schaden hinzu, wobei die Schadenswürfel nicht explodieren können.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Artefakterschaffer": {
-            "name": "Artefakterschaffer",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (beliebig)"
-            ],
-            "beschreibung": "Erlaubt die Herstellung von temporären Arkane Apparaturen und permanenter magischer Gegenstände.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meisterlicher Artefakterschaffer": {
-            "name": "Meisterlicher Artefakterschaffer",
-            "kategorie": "Macht",
-            "rang": "H",
-            "voraussetzungen": [
-                "Artefakterschaffer",
-                "Okkultismus W10"
-            ],
-            "beschreibung": "Erhöht die Belohnung für Okkultismusproben bei der Herstellung magischer Gegenstände auf 1000 G pro Erfolg oder Steigerung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bevorzugte Macht": {
-            "name": "Bevorzugte Macht",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (beliebig)",
-                "Glaube oder Zaubern W8"
-            ],
-            "beschreibung": "Erlaubt das Ignorieren von bis zu zwei Punkten Abzügen bei der Aktivierung einer ausgewählten Macht.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Blutmagie": {
-            "name": "Blutmagie",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (beliebig)"
-            ],
-            "beschreibung": "Gewährt W6 Machtpunkte zurück, wenn der Charakter einem bewussten Wesen eine Wunde zufügt, die nicht weggesteckt wird.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Epische Meisterschaft": {
-            "name": "Epische Meisterschaft",
-            "kategorie": "Macht",
-            "rang": "V",
-            "voraussetzungen": [
-                "AH (beliebig)",
-                "Glaube oder Zaubern W6"
-            ],
-            "beschreibung": "Gewährt Zugang zu epischen Machtmodifikatoren für alle Mächte des Helden. Gilt für alle arkanen Hintergründe, die der Charakter besitzt, wenn er die Voraussetzungen erfüllt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mystische Kräfte": {
-            "name": "Mystische Kräfte",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "Fortgeschritten"
-            ],
-            "beschreibung": "Erlaubt das Erlernen von 10 dedizierten Machtpunkten mit ausgewählten Mächten, die automatisch aktiviert werden können. Die Mächte und Einschränkungen sind abhängig vom gewählten Paket (z. B. Barbar, Kämpfer, Mönch, etc.).",
-            "neue_maechte": 0,
-            "machtpunkte": 10,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schlachtenmagie": {
-            "name": "Schlachtenmagie",
-            "kategorie": "Macht",
-            "rang": "V",
-            "voraussetzungen": [
-                "AH (beliebig)",
-                "Glaube oder Zaubern W10"
-            ],
-            "beschreibung": "Erlaubt das Wirken von Zaubern auf große Einheiten von Statisten. Siehe Regeln für Schlachtenmagie.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Stillzauberer": {
-            "name": "Stillzauberer",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (jeder außer Barde)",
-                "Okkultismus W8"
-            ],
-            "beschreibung": "Erlaubt das Wirken von Zaubern ohne zu sprechen. Funktioniert auch unter Wasser, in einem Vakuum, oder innerhalb der Macht Stille.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Übertragung": {
-            "name": "Übertragung",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (beliebig)"
-            ],
-            "beschreibung": "Erlaubt das Übertragen von bis zu fünf Machtpunkten auf eine andere Person in Sichtweite als begrenzte freie Aktion.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Vertrauter": {
-            "name": "Vertrauter",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Diabolist, Druide, Elementarmagier, Schamane, Hexer, Nekromant, Hexer, Zauberer, Hexenmeister)"
-            ],
-            "beschreibung": "Gewährt einen loyalen magischen Begleiter, der 5 eigene Machtpunkte hat und als Wildcard fungiert. Der Vertraute kann keine Zauber wirken, aber der Meister kann auf seine Machtpunkte zugreifen.",
-            "neue_maechte": 0,
-            "machtpunkte": 5,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Entdecker": {
-            "name": "Entdecker",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "KON W6",
-                "Überleben W8"
-            ],
-            "beschreibung": "Ermöglicht eine zusätzliche Aktionskarte bei Reisen und verkürzt die Reisezeit der Gruppe um 10%.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Fallengespür": {
-            "name": "Fallengespür",
-            "kategorie": "Experte",
-            "rang": "F",
-            "voraussetzungen": [
-                "Reparieren W6"
-            ],
-            "beschreibung": "Ermöglicht eine Wahrnehmungsprobe zum Erkennen von Fallen in 10 Metern Entfernung und ignoriert 2 Punkte Abzüge beim Entschärfen von Fallen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Giftmischer": {
-            "name": "Giftmischer",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "Alchemie, Heilen oder Überleben W6"
-            ],
-            "beschreibung": "Erstellt Gifte in der Hälfte der Zeit, die Kontaktgifte halten 12 statt 4 Stunden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Im Sattel geboren": {
-            "name": "Im Sattel geboren",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "Geschicklichkeit W8",
-                "Reiten W6"
-            ],
-            "beschreibung": "Verleiht eine freie Wiederholung bei Reitenproben, erhöht die Bewegungsweite des Reittiers um 2 und den Sprintwürfel um einen Würfeltyp.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kundschafter": {
-            "name": "Kundschafter",
-            "kategorie": "Experte",
-            "rang": "F",
-            "voraussetzungen": [
-                "Überleben W6"
-            ],
-            "beschreibung": "Ermöglicht Wahrnehmungsproben zum frühzeitigen Erkennen von Gefahren, verbessert Wachsamkeit und gibt Boni auf Allgemeinwissen über bereiste Orte.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Reittier": {
-            "name": "Reittier",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "Reiten W6"
-            ],
-            "beschreibung": "Gewährt ein treues, aufsteigbares Reittier mit besonderen Fähigkeiten. Ermöglicht die Wahl eines mächtigen Reittiers auf höheren Rängen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ritter": {
-            "name": "Ritter",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "STÄ W8",
-                "KON W8",
-                "Kämpfen W8",
-                "Reiten W6"
-            ],
-            "beschreibung": "Repräsentiert einen Lehnsherrn, gewährt +1 auf Einschüchtern- oder Überredenproben gegenüber Autorität-respektierenden Personen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schatzjäger": {
-            "name": "Schatzjäger",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "Wahrnehmung W8",
-                "Okkultismus W8"
-            ],
-            "beschreibung": "Erlaubt Verstandsproben zur Einschätzung von Schätzen und magischen Gegenständen. Ermöglicht das Neuwürfeln von magischen Gegenstandseffekten mit einem Benny.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Steingespür": {
-            "name": "Steingespür",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "Reparieren W6"
-            ],
-            "beschreibung": "Erhöht Wahrnehmungsproben um +2, um Fallen oder versteckte Türen in Stein zu entdecken.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Troubadour": {
-            "name": "Troubadour",
-            "kategorie": "Experte",
-            "rang": "F",
-            "voraussetzungen": [
-                "Allgemeinwissen W6",
-                "Darbietung W8"
-            ],
-            "beschreibung": "Gewährt +2 auf Allgemeinwissenproben und erlaubt die Nutzung von Darbietung statt Kriegskunst für Anführertalente.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Täuscher": {
-            "name": "Täuscher",
-            "kategorie": "Sozial",
-            "rang": "F",
-            "voraussetzungen": [
-                "VER W8"
-            ],
-            "beschreibung": "Erlaubt das Ziel, bei Herausforderungen entweder mit Verstand oder Willenskraft zu widerstehen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Aura der Tapferkeit": {
-            "name": "Aura der Tapferkeit",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Verbündete im Umkreis von 20 Metern erhalten +1 auf Furchtproben und -1 auf der Furchttabelle.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bestienflüsterer": {
-            "name": "Bestienflüsterer",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Erlaubt es, mit einer Tiergattung zu kommunizieren und Informationen von ihnen zu erhalten, abhängig von ihrer Intelligenz.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnelle Verwandlung": {
-            "name": "Schnelle Verwandlung",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Erlaubt eine Formveränderung als begrenzte Aktion statt der üblichen 10 Minuten.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Aristokrat": {
-            "name": "Aristokrat",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "+2 auf Allgemeinwissen und Informationsbeschaffung in der Oberschicht.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Resistenz": {
-            "name": "Arkane Resistenz",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –2 verringert.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Starke Arkane Resistenz": {
-            "name": "Starke Arkane Resistenz",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "Arkane Resistenz"
-            ],
-            "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –4 verringert.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Attraktiv": {
-            "name": "Attraktiv",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "KON W6"
-            ],
-            "beschreibung": "+1 auf Darbietung und Überreden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Sehr Attraktiv": {
-            "name": "Sehr Attraktiv",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "Attraktiv"
-            ],
-            "beschreibung": "+2 auf Darbietung und Überreden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Aufmerksamkeit": {
-            "name": "Aufmerksamkeit",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "+2 auf Wahrnehmungsproben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Beidhändig": {
-            "name": "Beidhändig",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Ignoriere den Abzug von –2 für Aktionen mit der falschen Hand.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bekannt": {
-            "name": "Bekannt",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "+1 auf Überredenproben, wenn erkannt (Allgemeinwissen), doppelte normale Summe für Darbietung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Berühmt": {
-            "name": "Berühmt",
-            "kategorie": "Hintergrund",
-            "rang": "F",
-            "voraussetzungen": [
-                "Bekannt"
-            ],
-            "beschreibung": "+2 auf Überredenproben, wenn erkannt (Allgemeinwissen), fünffache normale Summe oder mehr für Darbietung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Charismatisch": {
-            "name": "Charismatisch",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Freie Wiederholung bei der Verwendung von Überreden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Elan": {
-            "name": "Elan",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "+2 beim Ausgeben eines Bennys für die Wiederholung einer Eigenschaftsprobe.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Flink": {
-            "name": "Flink",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W6"
-            ],
-            "beschreibung": "Bewegungsweite +2, erhöhe Sprintwürfel um einen Schritt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Glück": {
-            "name": "Glück",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "+1 Benny zu Beginn jeder Sitzung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Großes Glück": {
-            "name": "Großes Glück",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "Glück"
-            ],
-            "beschreibung": "+2 Bennys zu Beginn jeder Sitzung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kräftig": {
-            "name": "Kräftig",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W6",
-                "KON W6"
-            ],
-            "beschreibung": "Größe (und somit Robustheit) +1. Behandle Stärke als einen Würfeltyp höher für Belastung und Mindeststärke bei Waffen, Rüstung und Ausrüstung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Linguist": {
-            "name": "Linguist",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Charakter hat einen W6 in Sprachen gleich halbem Verstandswürfel.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mutig": {
-            "name": "Mutig",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6"
-            ],
-            "beschreibung": "+2 auf Furchtproben und –2 bei Würfen auf der Furchttabelle.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Reich": {
-            "name": "Reich",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Charakter beginnt mit dreifachem Startkapital und einem Jahreseinkommen von $150.000.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Stinkreich": {
-            "name": "Stinkreich",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "Reich"
-            ],
-            "beschreibung": "Fünffaches Startkapital und $500.000 Jahreseinkommen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Rohling": {
-            "name": "Rohling",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W6",
-                "KON W6"
-            ],
-            "beschreibung": "Verknüpfe Athletik mit Stärke anstelle von Geschicklichkeit (auch für Herausfordern). Kurze Entfernung von geworfenen Gegenständen +1. Verdopple den Bonus für die angepasste mittlere Entfernung und nochmal für die weite Entfernung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnelle Heilung": {
-            "name": "Schnelle Heilung",
-            "kategorie": "Hintergrund",
-            "rang": "A",
-            "voraussetzungen": [
-                "KON W8"
-            ],
-            "beschreibung": "+2 Konstitution für natürliche Heilung, Wurf alle 3 Tage.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ausweichen": {
-            "name": "Ausweichen",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "–2 bei Angriffen durch Fernkampfwaffen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnelles Ausweichen": {
-            "name": "Schnelles Ausweichen",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Ausweichen"
-            ],
-            "beschreibung": "+2 auf Wegspringen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Beidhändiger Fernkampf": {
-            "name": "Beidhändiger Fernkampf",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Führe einen zusätzlichen Angriff mit Athletik (Werfen) oder Schießen mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Beidhändiger Kampf": {
-            "name": "Beidhändiger Kampf",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Führe einen zusätzlichen Kämpfen-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Berechnend": {
-            "name": "Berechnend",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W8"
-            ],
-            "beschreibung": "Ignoriere 2 Punkte Abzüge bei einer Aktion mit einer Aktionskarte von 5 oder weniger.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Block": {
-            "name": "Block",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kämpfen W8"
-            ],
-            "beschreibung": "+1 Parade, ignoriere 1 Punkt Überzahlbonus.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Harter Block": {
-            "name": "Harter Block",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Block"
-            ],
-            "beschreibung": "+2 Parade, ignoriere 2 Punkt Überzahlbonus.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Eisenkiefer": {
-            "name": "Eisenkiefer",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "KON W8"
-            ],
-            "beschreibung": "+2 auf Schaden wegstecken und Konstitutionsproben, um K.O.-Schlägen zu widerstehen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Erstschlag": {
-            "name": "Erstschlag",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Freier Kämpfen-Angriff einmal pro Runde, wenn sich ein Feind in Reichweite bewegt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schneller Erstschlag": {
-            "name": "Schneller Erstschlag",
-            "kategorie": "Kampf",
-            "rang": "H",
-            "voraussetzungen": [
-                "Erstschlag"
-            ],
-            "beschreibung": "Freie Kämpfen-Angriffe gegen bis zu drei Gegner, wenn sie sich in Reichweite bewegen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Finte": {
-            "name": "Finte",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Du kannst einen Feind bei einer Kämpfen-Herausforderung mit Verstand statt mit Geschicklichkeit widerstehen lassen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Improvisationsgabe": {
-            "name": "Improvisationsgabe",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "Ignoriere den Abzug von –2, wenn du mit improvisierten Waffen angreifst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kampfkünstler": {
-            "name": "Kampfkünstler",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Kämpfen W6"
-            ],
-            "beschreibung": "Unbewaffnetes Kämpfen +1, Fäuste und Füße zählen als Natürliche Waffen, addiere W4 auf den Schaden unbewaffneter Angriffe (oder erhöhe den Schaden um einen Würfeltyp, wenn du bereits einen Würfel hast).",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kampfkunstmeister": {
-            "name": "Kampfkunstmeister",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kampfkünstler"
-            ],
-            "beschreibung": "Unbewaffnetes Kämpfen +2, erhöhe Schadenswürfel um einen Würfeltyp.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kampfreflexe": {
-            "name": "Kampfreflexe",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [],
-            "beschreibung": "+2 Erholungsproben gegen Angeschlagen oder Betäubt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Keine Gnade": {
-            "name": "Keine Gnade",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [],
-            "beschreibung": "+2 Schaden, wenn du einen Benny ausgibst, um den Schadenswurf zu wiederholen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Killerinstinkt": {
-            "name": "Killerinstinkt",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [],
-            "beschreibung": "Freie Wiederholung für vergleichende Proben, wenn er Herausfordern einleitet.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kühler Kopf": {
-            "name": "Kühler Kopf",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "VER W8"
-            ],
-            "beschreibung": "Ziehe jede Runde eine zusätzliche Aktionskarte und wähle, welche du verwenden willst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Sehr Kühler Kopf": {
-            "name": "Sehr Kühler Kopf",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kühler Kopf"
-            ],
-            "beschreibung": "Ziehe jede Runde zwei zusätzliche Aktionskarten und wähle, welche du verwenden willst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Lieblingswaffe": {
-            "name": "Lieblingswaffe",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Kämpfen oder Schießen W8"
-            ],
-            "beschreibung": "+1 auf Athletik (Werfen), Kämpfen oder Schießen mit einer bestimmten Waffe; +1 Parade, wenn die Waffe bereit ist.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Absolute Lieblingswaffe": {
-            "name": "Absolute Lieblingswaffe",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Lieblingswaffe"
-            ],
-            "beschreibung": "Der Bonus auf Angriff und Parade steigt auf +2.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Mächtiger Hieb": {
-            "name": "Mächtiger Hieb",
-            "kategorie": "Kampf",
-            "rang": "WC",
-            "voraussetzungen": [
-                "A",
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden des ersten erfolgreichen Kämpfen-Angriffs in dieser Runde.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meisterschütze": {
-            "name": "Meisterschütze",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Athletik oder Schießen W8"
-            ],
-            "beschreibung": "Bei erster Aktion +1 Bonus oder ignoriere bis zu 2 Punkte Abzüge auf Athletik (Werfen) oder Schießen, wenn du dich nicht bewegst und nicht mehr als FR 1 verwendest.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Parkour": {
-            "name": "Parkour",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Ignoriere Schwieriges Gelände und addiere +2 auf Athletikproben in Verfolgungsjagden zu Fuß.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Raufbold": {
-            "name": "Raufbold",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W8",
-                "KON W8"
-            ],
-            "beschreibung": "Robustheit +1, addiere W4 zum Schaden von Fäusten oder erhöhe Würfeltyp bei Kombination mit Kampfkünstler, Klauen oder ähnlichen Fähigkeiten.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schläger": {
-            "name": "Schläger",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Raufbold"
-            ],
-            "beschreibung": "Erhöhe unbewaffneten Schaden um einen Würfeltyp und Robustheit noch einmal um +1.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Riposte": {
-            "name": "Riposte",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Freier Angriff gegen einen Feind, der eine Kämpfenprobe nicht geschafft hat.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Geschickte Riposte": {
-            "name": "Geschickte Riposte",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Riposte"
-            ],
-            "beschreibung": "Wie Riposte, jedoch bei bis zu drei Angriffen pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Rückzug": {
-            "name": "Rückzug",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Ein angrenzender Gegner erhält keinen freien Angriff, wenn du dich aus dem Nahkampf zurückziehst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wendiger Rückzug": {
-            "name": "Wendiger Rückzug",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Rückzug"
-            ],
-            "beschreibung": "Drei angrenzende Gegner erhalten keine freien Angriffe, wenn du dich aus dem Nahkampf zurückziehst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ruhige Hände": {
-            "name": "Ruhige Hände",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Ignoriere den Abzug für Unsicheren Grund; verringere Abzüge für Sprinten auf –1.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Rundumschlag": {
-            "name": "Rundumschlag",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "STÄ W8",
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Kämpfen-Wurf mit –2 gegen alle Ziele in der Reichweite der Waffe, nicht öfter als einmal pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kontrollierter Rundumschlag": {
-            "name": "Kontrollierter Rundumschlag",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Rundumschlag"
-            ],
-            "beschreibung": "Wie oben, aber ohne den Abzug von –2.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schmerzresistenz": {
-            "name": "Schmerzresistenz",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "KON W8"
-            ],
-            "beschreibung": "Ignoriere eine Stufe Wundabzüge.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Stärkere Schmerzresistenz": {
-            "name": "Stärkere Schmerzresistenz",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "Schmerzresistenz"
-            ],
-            "beschreibung": "Ignoriere bis zu zwei Stufen Wundabzüge.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schneller Angriff": {
-            "name": "Schneller Angriff",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Kämpfen W8"
-            ],
-            "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei einem Nahkampfangriff pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Blitzschneller Angriff": {
-            "name": "Blitzschneller Angriff",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schneller Angriff"
-            ],
-            "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei bis zu zwei Nahkampfangriffen pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnellfeuer": {
-            "name": "Schnellfeuer",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Schießen W6"
-            ],
-            "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Verbessertes Schnellfeuer": {
-            "name": "Verbessertes Schnellfeuer",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schnellfeuer"
-            ],
-            "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schwer zu töten": {
-            "name": "Schwer zu töten",
-            "kategorie": "Kampf",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Ignoriere Wundabzüge, wenn du Konstitutionsproben machst, um Verbluten zu verhindern.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wirklich schwer zu töten": {
-            "name": "Wirklich schwer zu töten",
-            "kategorie": "Kampf",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schwer zu töten"
-            ],
-            "beschreibung": "Wirf einen Würfel, wenn der Charakter umkommt. Auch wenn er Ausgeschaltet ist, überlebt er irgendwie.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Volles Rohr!": {
-            "name": "Volles Rohr!",
-            "kategorie": "Kampf",
-            "rang": "F",
-            "voraussetzungen": [
-                "Schießen W8"
-            ],
-            "beschreibung": "Sofern du dich in deinem Zug nicht bewegst, ignoriere den Rückstoß-Malus, wenn du Waffen mit einer FR von 2 oder mehr verwendest.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Volltreffer": {
-            "name": "Volltreffer",
-            "kategorie": "Kampf",
-            "rang": "WC",
-            "voraussetzungen": [
-                "A",
-                "Athletik oder Schießen W8"
-            ],
-            "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden deines ersten erfolgreichen Angriffs mit Athletik (Werfen) oder Schießen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Anführer": {
-            "name": "Anführer",
-            "kategorie": "Anführer",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "+1 auf Erholungsproben gegen Angeschlagen und Betäubt von Statisten im Befehlsradius.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Großer Anführer": {
-            "name": "Großer Anführer",
-            "kategorie": "Anführer",
-            "rang": "F",
-            "voraussetzungen": [
-                "Anführer"
-            ],
-            "beschreibung": "Erhöhe Befehlsradius auf 10“ (20 m).",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Anheizen": {
-            "name": "Anheizen",
-            "kategorie": "Anführer",
-            "rang": "V",
-            "voraussetzungen": [
-                "WIL W8",
-                "Anführer"
-            ],
-            "beschreibung": "+1 auf Kämpfen-Schadenswürfe von Statisten im Befehlsradius.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Geborener Anführer": {
-            "name": "Geborener Anführer",
-            "kategorie": "Anführer",
-            "rang": "F",
-            "voraussetzungen": [
-                "WIL W8",
-                "Anführer"
-            ],
-            "beschreibung": "Anführertalente gelten nun auch für Wildcards.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Haltet die Stellung!": {
-            "name": "Haltet die Stellung!",
-            "kategorie": "Anführer",
-            "rang": "F",
-            "voraussetzungen": [
-                "VER W8",
-                "Anführer"
-            ],
-            "beschreibung": "+1 auf Robustheit der Statisten im Befehlsradius.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Inspirieren": {
-            "name": "Inspirieren",
-            "kategorie": "Anführer",
-            "rang": "F",
-            "voraussetzungen": [
-                "Anführer"
-            ],
-            "beschreibung": "Einmal pro Zug kann der Held auf Kriegskunst würfeln, um alle Statisten im Befehlsradius bei einer Art von Eigenschaftsprobe zu unterstützen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Taktiker": {
-            "name": "Taktiker",
-            "kategorie": "Anführer",
-            "rang": "F",
-            "voraussetzungen": [
-                "VER W8",
-                "Anführer",
-                "Kriegskunst W6"
-            ],
-            "beschreibung": "Ziehe eine zusätzliche Aktionskarte pro Zug und weise sie einem verbündeten Statisten im Befehlsradius zu.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meistertaktiker": {
-            "name": "Meistertaktiker",
-            "kategorie": "Anführer",
-            "rang": "V",
-            "voraussetzungen": [
-                "Taktiker"
-            ],
-            "beschreibung": "Ziehe und verteile zwei zusätzliche Aktionskarten anstelle von einer.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Energieschub": {
-            "name": "Energieschub",
-            "kategorie": "Macht",
-            "rang": "WC",
-            "voraussetzungen": [
-                "A",
-                "Glaube oder Zaubern W8",
-                "AH"
-            ],
-            "beschreibung": "Erhalte 10 Machtpunkte zurück, wenn du im Kampf einen Joker ziehst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Heiliger/Unheiliger Krieger": {
-            "name": "Heiliger/Unheiliger Krieger",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Wunder)",
-                "Glaube W6"
-            ],
-            "beschreibung": "Addiere +1 bis +4 auf Schaden wegstecken für jeden Machtpunkt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kanalisieren": {
-            "name": "Kanalisieren",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH"
-            ],
-            "beschreibung": "Verringere Machtpunktekosten um –1 nach einer Steigerung beim Aktivierungswurf.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Konzentration": {
-            "name": "Konzentration",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH"
-            ],
-            "beschreibung": "Wirkungsdauer von Mächten wird verdoppelt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Machtpunkte": {
-            "name": "Machtpunkte",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH"
-            ],
-            "beschreibung": "Erhalte 5 zusätzliche Machtpunkte, nur einmal pro Rang.",
-            "neue_maechte": 0,
-            "machtpunkte": 5,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Neue Mächte": {
-            "name": "Neue Mächte",
-            "kategorie": "Macht",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH"
-            ],
-            "beschreibung": "Dein Charakter kennt zwei neue Mächte.",
-            "neue_maechte": 2,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnelle Machtregeneration": {
-            "name": "Schnelle Machtregeneration",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "WIL W6",
-                "AH"
-            ],
-            "beschreibung": "Regeneriere 10 Machtpunkte pro Stunde.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schnellere Machtregeneration": {
-            "name": "Schnellere Machtregeneration",
-            "kategorie": "Macht",
-            "rang": "V",
-            "voraussetzungen": [
-                "Schnelle Machtregeneration"
-            ],
-            "beschreibung": "Regeneriere 20 Machtpunkte pro Stunde.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Seelenentzug": {
-            "name": "Seelenentzug",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH",
-                "Glaube oder Zaubern W10"
-            ],
-            "beschreibung": "Erhalte 5 Machtpunkte für eine Stufe Erschöpfung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Zusätzliche Anstrengung": {
-            "name": "Zusätzliche Anstrengung",
-            "kategorie": "Macht",
-            "rang": "F",
-            "voraussetzungen": [
-                "AH (Begabt)",
-                "Fokus W6"
-            ],
-            "beschreibung": "Erhöhe Fokus um +1 für 1 Machtpunkt oder +2 für 3 Machtpunkte.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Akrobat": {
-            "name": "Akrobat",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8",
-                "Athletik W8"
-            ],
-            "beschreibung": "Wurfwiederholung bei akrobatischen Athletik-Aktionen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kampfakrobat": {
-            "name": "Kampfakrobat",
-            "kategorie": "Experte",
-            "rang": "F",
-            "voraussetzungen": [
-                "Akrobat"
-            ],
-            "beschreibung": "–1 für Gegner zum Treffen mit Fernkampf- und Nahkampfangriffen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Alleskönner": {
-            "name": "Alleskönner",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W10"
-            ],
-            "beschreibung": "Du erhältst W4 in einer Fertigkeit (oder W6 bei einer Steigerung), bis du sie ersetzt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ass am Steuer": {
-            "name": "Ass am Steuer",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8"
-            ],
-            "beschreibung": "Charakter kann Bennys ausgeben, um für sein Fahrzeug Schaden wegstecken anzuwenden und ignoriert bis zu 2 Punkte Abzüge.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Dieb": {
-            "name": "Dieb",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "GES W8",
-                "Heimlichkeit W6",
-                "Diebeskunst W6"
-            ],
-            "beschreibung": "+1 Diebeskunst, Athletik zum Klettern, Heimlichkeit in urbanen Umgebungen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "McGyver": {
-            "name": "McGyver",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6",
-                "Reparieren W8",
-                "Wahrnehmung W8"
-            ],
-            "beschreibung": "Du kannst schnell improvisierte Gerätschaften aus Schrott erfinden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Naturbursche": {
-            "name": "Naturbursche",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "Überleben W8"
-            ],
-            "beschreibung": "+2 Überleben und Heimlichkeit in der Wildnis.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Soldat": {
-            "name": "Soldat",
-            "kategorie": "Experte",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W6",
-                "KON W6"
-            ],
-            "beschreibung": "Stärke ist einen Würfeltyp höher für Belastung und Mindeststärke. Wiederhole Konstitutionsproben beim Widerstand gegen Umweltgefahren.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Aufwiegler": {
-            "name": "Aufwiegler",
-            "kategorie": "Sozial",
-            "rang": "F",
-            "voraussetzungen": [
-                "Heimlichkeit W8"
-            ],
-            "beschreibung": "Einmal pro Zug kannst du alle Feinde in einer mittleren Flächenschablone mit einer Einschüchtern- oder Provozieren-Herausforderung beeinflussen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bedrohlich": {
-            "name": "Bedrohlich",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "+2 auf Einschüchtern.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Beziehungen": {
-            "name": "Beziehungen",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Kontakte bieten einmal pro Sitzung Unterstützung oder andere Gefallen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Ermutigen": {
-            "name": "Ermutigen",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Kann den Zustand Abgelenkt oder Verwundbar nach Herausfordern aufheben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Erniedrigen": {
-            "name": "Erniedrigen",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "Provozieren W8"
-            ],
-            "beschreibung": "Freie Wiederholung bei Provozieren.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Erzürnen": {
-            "name": "Erzürnen",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "Provozieren W6"
-            ],
-            "beschreibung": "Kann Feinde mit einer Steigerung bei einer Provozierenprobe „erzürnen“.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Gassenwissen": {
-            "name": "Gassenwissen",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "VER W6"
-            ],
-            "beschreibung": "+2 auf Proben mit Allgemeinwissen und Informationsbeschaffung in kriminellen Kreisen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Konter": {
-            "name": "Konter",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "Provozieren W6"
-            ],
-            "beschreibung": "Eine Steigerung beim Widerstand gegen Provozieren oder Einschüchtern verursacht beim Feind Abgelenkt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Rampensau": {
-            "name": "Rampensau",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Einmal pro Zug wirf einen zweiten Würfel, wenn du mit Darbietung oder Überreden unterstützt und wende das Ergebnis auf einen Verbündeten an.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Echte Rampensau": {
-            "name": "Echte Rampensau",
-            "kategorie": "Sozial",
-            "rang": "F",
-            "voraussetzungen": [
-                "Rampensau"
-            ],
-            "beschreibung": "Wie oben, aber bis zu zweimal pro Zug.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Selbstlos": {
-            "name": "Selbstlos",
-            "kategorie": "Sozial",
-            "rang": "WC",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Der Held kann anderen seine Bennys geben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Starker Wille": {
-            "name": "Starker Wille",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "+2 um Herausfordern mit Verstand oder Willenskraft zu widerstehen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Verlässlich": {
-            "name": "Verlässlich",
-            "kategorie": "Sozial",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Freie Wiederholung bei Unterstützung.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Auserwählter": {
-            "name": "Auserwählter",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8",
-                "Kämpfen W6"
-            ],
-            "beschreibung": "+2 Schaden gegen übernatürlich böse (oder gute) Kreaturen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Heiler": {
-            "name": "Heiler",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "+2 auf Heilungsproben, magisch oder anderweitig.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Sammler": {
-            "name": "Sammler",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [
-                "Glück"
-            ],
-            "beschreibung": "Kann einmal pro Begegnung einen benötigten Gegenstand finden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Sechster Sinn": {
-            "name": "Sechster Sinn",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Wahrnehmungsprobe mit +2 zum Spüren von Hinterhalten oder ähnlichen Ereignissen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Tierempathie": {
-            "name": "Tierempathie",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [],
-            "beschreibung": "Der Held kann Bennys für Tiere unter seiner Kontrolle ausgeben.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Tiermeister": {
-            "name": "Tiermeister",
-            "kategorie": "Übersinnlich",
-            "rang": "A",
-            "voraussetzungen": [
-                "WIL W8"
-            ],
-            "beschreibung": "Tiere mögen deinen Helden und er hat eine Art von Haustier.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Gefolgsleute": {
-            "name": "Gefolgsleute",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "WC"
-            ],
-            "beschreibung": "Der Held hat fünf Gefolgsleute.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Handlanger": {
-            "name": "Handlanger",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "WC"
-            ],
-            "beschreibung": "Der Charakter erhält einen Wildcard-Handlanger.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Profi": {
-            "name": "Profi",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [],
-            "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Experte": {
-            "name": "Experte",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "Profi"
-            ],
-            "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen weiteren Schritt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meister": {
-            "name": "Meister",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "Experte"
-            ],
-            "beschreibung": "Der Wildcard-Würfel des Charakters für die Eigenschaft ist ein W10.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Waffenmeister": {
-            "name": "Waffenmeister",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "Kämpfen W12"
-            ],
-            "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W8.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Meister aller Waffen": {
-            "name": "Meister aller Waffen",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "Waffenmeister"
-            ],
-            "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W10.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Zäh wie Leder": {
-            "name": "Zäh wie Leder",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "Konstitution W8"
-            ],
-            "beschreibung": "Der Held kann vier Wunden einstecken, ehe er Ausgeschaltet ist.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Zäher als Leder": {
-            "name": "Zäher als Leder",
-            "kategorie": "Legendär",
-            "rang": "L",
-            "voraussetzungen": [
-                "Zäh wie Leder",
-                "KON W12"
-            ],
-            "beschreibung": "Der Held kann fünf Wunden einstecken, ehe er Ausgeschaltet ist.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Behände": {
-            "name": "Behände",
-            "kategorie": "Barbar",
-            "rang": "A",
-            "voraussetzungen": [
-                "Barbar"
-            ],
-            "beschreibung": "Bewegungsweite +2.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kampfrausch": {
-            "name": "Kampfrausch",
-            "kategorie": "Barbar",
-            "rang": "A",
-            "voraussetzungen": [
-                "Barbar"
-            ],
-            "beschreibung": "Der Barbar kann freiwillig in einen Kampfrausch verfallen. Nach Angeschlagen oder Wunde: Rücksichtslose Angriffe erzwungen, +1 Würfeltyp Stärke, +2 Robustheit, ignoriere eine Stufe Wundabzüge. Endet nach 5 Runden mit Erschöpfung oder Verstandsprobe mit -2.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Scharfzüngig": {
-            "name": "Scharfzüngig",
-            "kategorie": "Barde",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Barde)"
-            ],
-            "beschreibung": "Der Barde kann Darbietung statt Provozieren verwenden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Bindung mit der Natur": {
-            "name": "Bindung mit der Natur",
-            "kategorie": "Druide",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Druide)"
-            ],
-            "beschreibung": "Der Druide kann ein Tier beschwören, das als sein Begleiter dient.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Naturgespür": {
-            "name": "Naturgespür",
-            "kategorie": "Druide",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Druide)"
-            ],
-            "beschreibung": "-2 auf Überreden und Einschüchtern in der Stadt, +2 in der Wildnis.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kriegerische Anpassungsfähigkeit": {
-            "name": "Kriegerische Anpassungsfähigkeit",
-            "kategorie": "Kämpfer",
-            "rang": "A",
-            "voraussetzungen": [
-                "Kämpfer"
-            ],
-            "beschreibung": "Einmal pro Begegnung kann der Kämpfer als begrenzte freie Aktion die Vorteile eines Kampftalents erhalten. Er muss alle Voraussetzungen erfüllen, und die Vorteile enden nach fünf Runden.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Energie fokussieren": {
-            "name": "Energie fokussieren",
-            "kategorie": "Kleriker",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Kleriker)"
-            ],
-            "beschreibung": "Der Kleriker kann die Macht Heilung auf eine Entfernung gleich seiner Willenskraft wirken. Er erhält außerdem den Machtmodifikator Zusätzlicher Empfänger, sodass er für jeweils 1 Machtpunkt nahe Verbündete heilen kann.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Arkane Verbindung": {
-            "name": "Arkane Verbindung",
-            "kategorie": "Magier",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Magier)"
-            ],
-            "beschreibung": "Der Magier wählt eine Arkane Verbindung: einen Gegenstand (+1 auf Zaubern) oder einen Vertrauten (siehe Regeln).",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Schule": {
-            "name": "Schule",
-            "kategorie": "Magier",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Magier)"
-            ],
-            "beschreibung": "Der Magier wählt eine Schule, die bestimmt, auf welche Arten von Mächten er sich spezialisiert.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Betäubende Fäuste": {
-            "name": "Betäubende Fäuste",
-            "kategorie": "Mönch",
-            "rang": "A",
-            "voraussetzungen": [
-                "Mönch"
-            ],
-            "beschreibung": "Bei einer Steigerung beim Kämpfen-Wurf kann der Mönch einen Feind betäuben oder einen Verursacher machen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Beweglichkeit": {
-            "name": "Beweglichkeit",
-            "kategorie": "Mönch",
-            "rang": "A",
-            "voraussetzungen": [
-                "Mönch"
-            ],
-            "beschreibung": "Der Mönch ist schnell und wendig und erhält +1 auf Sprint und Ausweichen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Kämpferische Disziplin": {
-            "name": "Kämpferische Disziplin",
-            "kategorie": "Mönch",
-            "rang": "A",
-            "voraussetzungen": [
-                "Mönch"
-            ],
-            "beschreibung": "Der Mönch erhält +1 Robustheit, wenn er keine Rüstung trägt.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Waffenloser Schlag": {
-            "name": "Waffenloser Schlag",
-            "kategorie": "Mönch",
-            "rang": "A",
-            "voraussetzungen": [
-                "Mönch"
-            ],
-            "beschreibung": "Der Mönch erhält +1 auf Kampfwürfe und verursacht STÄ+W4 Schaden bei waffenlosen Angriffen. Dieser Schadenswürfel steigt mit dem Rang.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Böses Entdecken": {
-            "name": "Böses Entdecken",
-            "kategorie": "Paladin",
-            "rang": "A",
-            "voraussetzungen": [
-                "Paladin"
-            ],
-            "beschreibung": "Als freie Aktion kann der Paladin eine Wahrnehmungsprobe ablegen, um böse übernatürliche Kreaturen oder Charaktere in einer Entfernung von 5'' (10 Metern) zu entdecken.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Böses Niederstrecken": {
-            "name": "Böses Niederstrecken",
-            "kategorie": "Paladin",
-            "rang": "A",
-            "voraussetzungen": [
-                "Paladin"
-            ],
-            "beschreibung": "Einmal pro Begegnung erhält der Paladin eine freie Wiederholung bei allen Angriffswürfen gegen einen gewählten bösen Gegner.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Hinterhältiger Angriff": {
-            "name": "Hinterhältiger Angriff",
-            "kategorie": "Schurke",
-            "rang": "A",
-            "voraussetzungen": [
-                "Schurke"
-            ],
-            "beschreibung": "Der Schurke addiert +W6 auf den Schaden, wenn er einen Überraschungsangriff gegen ein Ziel durchführen kann und das Opfer verwundbar ist. Dies gilt für Angriffe mit Athletik (Werfen), Kämpfen oder Schießen.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Wildnis durchqueren": {
-            "name": "Wildnis durchqueren",
-            "kategorie": "Waldläufer",
-            "rang": "A",
-            "voraussetzungen": [
-                "Waldläufer"
-            ],
-            "beschreibung": "Der Waldläufer ignoriert Abzüge für Schwieriges Gelände in der Wildnis.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
-        },
-        "Blutlinie": {
-            "name": "Blutlinie",
-            "kategorie": "Zauberer",
-            "rang": "A",
-            "voraussetzungen": [
-                "AH (Zauberer)"
-            ],
-            "beschreibung": "Der Zauberer muss eine Blutlinie wählen (siehe Seite 69). Bei der Beschreibung jeder Blutlinie findest du auch die zusätzliche Spezialfähigkeit, die du erhältst, wenn du das Talent Mächtige Blutlinie wählst.",
-            "neue_maechte": 0,
-            "machtpunkte": 0,
-            "ausgewaehlt": false,
-            "aktiv": true
+    "Halbork": {
+      "name": "Halbork",
+      "handicaps": [
+        "Außenseiter (leicht, -2 auf Überredenproben, werden oft abgelehnt oder verspottet)"
+      ],
+      "talente": [],
+      "besonderheiten": [
+        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+        "Einschüchternd (Beginnt mit W4 in Einschüchtern, Maximum W12+1)",
+        "Orkische Wildheit (+1 Robustheit)",
+        "Stark (Stärke W6 statt W4, Maximum W12+1)"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Orkisch"
+      ],
+      "altersspanne": "Erwachsen mit 15, Alt mit 45, maximales Alter 60–80",
+      "groesse_maennlich": "1,50-2,05m, 74-144kg (Durchschnitt 1,80m, 109kg)",
+      "groesse_weiblich": "1,40-1,95m, 56-126kg (Durchschnitt 1,70m, 91kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Stärke": 2
+        },
+        "robustheit_bonus": 1,
+        "bewegungsweite_bonus": 0,
+        "fertigkeits_startboni": {},
+        "auto_talente": [],
+        "auto_handicaps": [
+          "Außenseiter_leicht"
+        ],
+        "spezielle_effekte": {
+          "dunkelsicht": true
+        },
+        "wahlmoeglichkeiten": {}
+      }
+    },
+    "Mensch": {
+      "name": "Mensch",
+      "handicaps": [],
+      "talente": [],
+      "besonderheiten": [
+        "Anpassungsfähigkeit (Freies Talent und W6 in einem Attribut statt W4, erhöht Maximum nicht)"
+      ],
+      "sprachen": [
+        "Gemeinsprache"
+      ],
+      "altersspanne": "Erwachsen mit 17, Alt mit 53, maximales Alter 70–110",
+      "groesse_maennlich": "1,50-1,95m, 54-100kg (Durchschnitt 1,70m, 79kg)",
+      "groesse_weiblich": "1,50-1,85m, 43-84kg (Durchschnitt 1,60m, 64kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {},
+        "robustheit_bonus": 0,
+        "bewegungsweite_bonus": 0,
+        "fertigkeits_startboni": {},
+        "auto_talente": [],
+        "spezielle_effekte": {},
+        "wahlmoeglichkeiten": {
+          "freies_talent": true,
+          "freies_attribut": true
         }
+      }
     },
-    "handicaps": {
-        "Alt": {
-            "name": "Alt",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–1 auf Bewegungsweite, Sprint-Würfel, Geschicklichkeit, Stärke und Konstitution. Held erhält 5 zusätzliche Fertigkeitspunkte.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Analphabet": {
-            "name": "Analphabet",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter kann nicht lesen oder schreiben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Angetrieben_leicht": {
-            "name": "Angetrieben",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Angetrieben_schwer": {
-            "name": "Angetrieben",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Angewohnheit_leicht": {
-            "name": "Angewohnheit",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Angewohnheit_schwer": {
-            "name": "Angewohnheit",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Arm": {
-            "name": "Arm",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Halbiere das Startkapital, und der Charakter ist immer pleite.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Arrogant": {
-            "name": "Arrogant",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Dominiert gerne seine Gegner, fordert den mächtigsten Feind im Kampf heraus.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Außenseiter_leicht": {
-            "name": "Außenseiter",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Außenseiter_schwer": {
-            "name": "Außenseiter",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab. Bei einem schweren Handicap hat er keine Rechte oder leidet unter anderen schweren Konsequenzen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Beschämt_leicht": {
-            "name": "Beschämt",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Beschämt_schwer": {
-            "name": "Beschämt",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Blind": {
-            "name": "Blind",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–6 auf alle Aufgaben, die Sicht erfordern (aber ein freies Talent zum Ausgleich).",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Blutrünstig": {
-            "name": "Blutrünstig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Nimmt niemals Gefangene.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Dünnhäutig_leicht": {
-            "name": "Dünnhäutig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –2, wenn er Provozieren-Angriffen widerstehen will.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Dünnhäutig_schwer": {
-            "name": "Dünnhäutig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –4, wenn er Provozieren-Angriffen widerstehen will.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Ehrenkodex": {
-            "name": "Ehrenkodex",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter hält sein Wort und benimmt sich wie ein Gentleman.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Eifersüchtig_leicht": {
-            "name": "Eifersüchtig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter will das, was andere haben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Eifersüchtig_schwer": {
-            "name": "Eifersüchtig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter will das, was andere haben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Einarmig": {
-            "name": "Einarmig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–4 auf Aufgaben (wie Athletik), die beide Hände erfordern.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Einäugig": {
-            "name": "Einäugig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–2 auf Aktionen auf 5ʺ (10 Meter) oder mehr Entfernung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Feind_leicht": {
-            "name": "Feind",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Feind_schwer": {
-            "name": "Feind",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Fettleibig": {
-            "name": "Fettleibig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Größe +1, Bewegungsweite –1, Sprintwürfel W4. Behandle Stärke als einen Würfeltyp niedriger, wenn es um Mindeststärke geht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Feige": {
-            "name": "Feige",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–2 auf Furchtproben und beim Widerstand gegen Einschüchtern.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Fies": {
-            "name": "Fies",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–1 auf Überredenproben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Geheimnis_leicht": {
-            "name": "Geheimnis",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Held hat ein dunkles Geheimnis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Geheimnis_schwer": {
-            "name": "Geheimnis",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Held hat ein dunkles Geheimnis.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gesucht_leicht": {
-            "name": "Gesucht",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gesucht_schwer": {
-            "name": "Gesucht",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gierig_leicht": {
-            "name": "Gierig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gierig_schwer": {
-            "name": "Gierig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Große Klappe": {
-            "name": "Große Klappe",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Kann kein Geheimnis bewahren, und verrät ständig private Informationen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Hässlich_leicht": {
-            "name": "Hässlich",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –1 von Überredenproben ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Hässlich_schwer": {
-            "name": "Hässlich",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –2 von Überredenproben ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Heldenhaft": {
-            "name": "Heldenhaft",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter hilft immer anderen, die in Not sind.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Impulsiv": {
-            "name": "Impulsiv",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Held springt, ehe er schaut.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Jung_leicht": {
-            "name": "Jung",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "4 Attributspunkte, 10 Fertigkeitspunkte, einen zusätzlichen Benny pro Sitzung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Jung_schwer": {
-            "name": "Jung",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "3 Attributspunkte, 10 Fertigkeitspunkte, zwei zusätzliche Bennys pro Sitzung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Klein": {
-            "name": "Klein",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Größe und Robustheit sinken um 1. Größe kann nicht unter –1 liegen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Kränklich": {
-            "name": "Kränklich",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–2 Konstitution beim Widerstand gegen Erschöpfung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Langsam_leicht": {
-            "name": "Langsam",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Bewegungsweite –1, verringere den Sprintwürfel um eine Stufe.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Langsam_schwer": {
-            "name": "Langsam",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Bewegungsweite –2, –2 auf Athletikproben und Würfe, um Athletik zu widerstehen, kann nicht das Talent Flink wählen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Lebensaufgabe": {
-            "name": "Lebensaufgabe",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Held will sterben, nachdem er eine epische Aufgabe abgeschlossen hat.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Loyal": {
-            "name": "Loyal",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Held ist seinen Freunden und Verbündeten gegenüber loyal.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Misstrauisch_leicht": {
-            "name": "Misstrauisch",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter ist paranoid.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Misstrauisch_schwer": {
-            "name": "Misstrauisch",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter ist paranoid und Verbündete, die ihn unterstützen wollen, ziehen –2 von ihren Würfen ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Neugierig": {
-            "name": "Neugierig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter will immer alles wissen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Nichtschwimmer": {
-            "name": "Nichtschwimmer",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–2 auf Proben mit Athletik (Schwimmen); jedes Zoll Bewegung im Wasser kostet 3ʺ Bewegungsweite.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Pazifist_leicht": {
-            "name": "Pazifist",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Kämpft nur in Selbstverteidigung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Pazifist_schwer": {
-            "name": "Pazifist",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Kämpft gar nicht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Pech": {
-            "name": "Pech",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter beginnt jede Spielsitzung mit einem Benny weniger.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Phobie_leicht": {
-            "name": "Phobie",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat vor etwas Angst und zieht –1 von allen Eigenschaftsproben in dessen Gegenwart ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Phobie_schwer": {
-            "name": "Phobie",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter hat vor etwas Angst und zieht –2 von allen Eigenschaftsproben in dessen Gegenwart ab.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rachsüchtig_leicht": {
-            "name": "Rachsüchtig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rachsüchtig_schwer": {
-            "name": "Rachsüchtig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen. Bei einem schweren Handicap greift er auch zu körperlicher Gewalt.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Sanftmütig": {
-            "name": "Sanftmütig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–2 auf Einschüchternproben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schlechte Augen_leicht": {
-            "name": "Schlechte Augen",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–1 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schlechte Augen_schwer": {
-            "name": "Schlechte Augen",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–2 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwerhörig_leicht": {
-            "name": "Schwerhörig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–4 auf Wahrnehmung bei Geräuschen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwerhörig_schwer": {
-            "name": "Schwerhörig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Automatischer Fehlschlag bei vollständiger Taubheit.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwerzüngig": {
-            "name": "Schwerzüngig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter sagt oft das Falsche oder bekommt seine Worte nicht heraus; –1 auf Einschüchtern, Überreden und Provozieren.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwur_leicht": {
-            "name": "Schwur",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schwur_schwer": {
-            "name": "Schwur",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Skrupellos_leicht": {
-            "name": "Skrupellos",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Skrupellos_schwer": {
-            "name": "Skrupellos",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Stumm": {
-            "name": "Stumm",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter kann nicht sprechen.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Stur": {
-            "name": "Stur",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter will seinen Willen durchsetzen und gibt selten Fehler zu.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Tick": {
-            "name": "Tick",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat eine kleine, aber hartnäckige Marotte, die anderen oft auf die Nerven geht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Tollpatschig": {
-            "name": "Tollpatschig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–2 auf Proben mit Athletik und Heimlichkeit.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Übermütig": {
-            "name": "Übermütig",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Held glaubt, dass er alles tun kann.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verpeilt": {
-            "name": "Verpeilt",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "–1 auf Proben mit Allgemeinwissen und Wahrnehmung.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verpflichtung_leicht": {
-            "name": "Verpflichtung",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 20 Stunden.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verpflichtung_schwer": {
-            "name": "Verpflichtung",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 40 Stunden.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Vorsichtig": {
-            "name": "Vorsichtig",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter schmiedet aufwendige Pläne und/oder ist übermäßig vorsichtig.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Wahnvorstellungen_leicht": {
-            "name": "Wahnvorstellungen",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm manchmal Schwierigkeiten macht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Wahnvorstellungen_schwer": {
-            "name": "Wahnvorstellungen",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm oft Schwierigkeiten macht.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Zögerlich": {
-            "name": "Zögerlich",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "Ziehe zwei Aktionskarten und nimm die schlechtere (außer Joker, die darfst du behalten).",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Zwei linke Hände": {
-            "name": "Zwei linke Hände",
-            "stufe": "leicht",
-            "punkte": 1,
-            "beschreibung": "–2 bei der Verwendung von mechanischen oder elektrischen Geräten.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rüstungsbeschränkung_mittelschwer": {
-            "name": "Rüstungsbeschränkung (mittelschwer)",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er schwere Rüstung trägt oder einen schweren Schild verwendet.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rüstungsbeschränkung_leicht": {
-            "name": "Rüstungsbeschränkung (leicht)",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er mittelschwere oder schwere Rüstung trägt oder mittlere/schwere Schilde verwendet.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Rüstungsbeschränkung_jede": {
-            "name": "Rüstungsbeschränkung (jede)",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter darf keine Rüstung tragen und keine Schilde verwenden.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Behindernde Rüstung_leicht": {
-            "name": "Behindernde Rüstung (leicht)",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er leichte oder schwerere Rüstung trägt.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Behindernde Rüstung_jede": {
-            "name": "Behindernde Rüstung (jede)",
-            "stufe": "schwer",
-            "punkte": 2,
-            "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er jede Art von Rüstung trägt.",
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        }
+    "Zwerg": {
+      "name": "Zwerg",
+      "handicaps": [
+        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
+      ],
+      "talente": [],
+      "besonderheiten": [
+        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+        "Eiserne Konstitution (+1 beim Widerstand gegen Gift, +1 zum Widerstand oder zur Erholung von Mächten)",
+        "Steingespür (+2 auf Wahrnehmungsproben bei ungewöhnlich bearbeitetem Stein innerhalb von 3m)",
+        "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1, Stärke um einen Würfel höher für Belastung und Mindeststärke)"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Zwergisch"
+      ],
+      "altersspanne": "Erwachsen mit 45, Alt mit 188, maximales Alter 250–450",
+      "groesse_maennlich": "1,20-1,35m, 74-93kg (Durchschnitt 1,30m, 84kg)",
+      "groesse_weiblich": "1,15-1,30m, 61-80kg (Durchschnitt 1,20m, 75kg)",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Konstitution": 2
+        },
+        "robustheit_bonus": 0,
+        "bewegungsweite_bonus": -1,
+        "fertigkeits_startboni": {},
+        "auto_talente": [],
+        "auto_handicaps": [
+          "Langsam_leicht"
+        ],
+        "spezielle_effekte": {
+          "dunkelsicht": true,
+          "eiserne_konstitution": true,
+          "steingespür": true,
+          "staerke_bonus_traglast": true
+        },
+        "wahlmoeglichkeiten": {}
+      }
     },
-    "maechte": {
-        "Abwehren": {
-            "name": "Abwehren",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "–2/–4 bei Angriffen auf Empfänger",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Arkaner Schutz": {
-            "name": "Arkaner Schutz",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Gegnerische Wirker ziehen –2 (–4 mit Steigerung) ab, wenn sie den Charakter mit Mächten angreifen; verringert Schaden um die gleiche Summe",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Arkanes entdecken/verbergen": {
-            "name": "Arkanes entdecken/verbergen",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5/1h",
-            "beschreibung": "Entdeckt Magie für Wirkungsdauer 5 oder verbirgt sie für 1 Stunde",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Aufheben": {
-            "name": "Aufheben",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Negiert magische Effekte",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Aufspüren": {
-            "name": "Aufspüren",
-            "rang": "A",
-            "machtpunkte": 3,
-            "reichweite": "Selbst",
-            "dauer": "10 Minuten",
-            "beschreibung": "Findet ein Objekt",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Ausspähung": {
-            "name": "Ausspähung",
-            "rang": "F",
-            "machtpunkte": 3,
-            "reichweite": "Selbst",
-            "dauer": "5",
-            "beschreibung": "Wirker kann ein Ziel und seine Umgebung auf Entfernung sehen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Barriere": {
-            "name": "Barriere",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Erschafft Barriere mit 5ʺ (10 Meter) Länge, 1ʺ (2 Meter) Höhe und Härte 10 (12 mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Betäuben": {
-            "name": "Betäuben",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Ziel ist Betäubt",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Bindender Ruf": {
-            "name": "Bindender Ruf",
-            "rang": "V",
-            "machtpunkte": 8,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Beschwört und bindet eine Kreatur von einer anderen Ebene",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Blenden": {
-            "name": "Blenden",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Verursacht Abzug von –2/–4 bei Opfern",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Böswillige Verwandlung": {
-            "name": "Böswillige Verwandlung",
-            "rang": "V",
-            "machtpunkte": 3,
-            "reichweite": "Ver",
-            "dauer": "5",
-            "beschreibung": "Tier von Größe –2 bis 3 wird in eine relativ harmlose Kreatur verwandelt",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Chaos": {
-            "name": "Chaos",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Ziele in MFS oder Kegel sind Abgelenkt und könnten geschleudert werden",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Dunkelsicht": {
-            "name": "Dunkelsicht",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver",
-            "dauer": "1 Stunde",
-            "beschreibung": "Ignoriere bis zu 4 Punkte Beleuchtungsabzüge, 6 bei Steigerung",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Ebenenwechsel": {
-            "name": "Ebenenwechsel",
-            "rang": "V",
-            "machtpunkte": 5,
-            "reichweite": "Ver",
-            "dauer": "5",
-            "beschreibung": "Erlaubt Reisen zu anderen Existenzebenen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Eigenschaft erhöhen/senken": {
-            "name": "Eigenschaft erhöhen/senken",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5/Sofort",
-            "beschreibung": "Erhöht oder senkt Fertigkeit oder Attribut",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Elementarmanipulation": {
-            "name": "Elementarmanipulation",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Erlaubt einfache Manipulation der grundlegenden Elemente",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Empathie": {
-            "name": "Empathie",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Vergleichender Wurf gegen Willenskraft, für +1/+2 auf Darbietung, Einschüchtern, Provozieren und Überreden gegen das Ziel",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Fernsicht": {
-            "name": "Fernsicht",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Sieht Details auf größere Entfernung; halbiert Entfernungsabzüge bei Steigerung",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Flächenschlag": {
-            "name": "Flächenschlag",
-            "rang": "F",
-            "machtpunkte": 3,
-            "reichweite": "Ver×2",
-            "dauer": "Sofort",
-            "beschreibung": "2W6 Schaden in mittlerer Flächenschablone",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Fliegen": {
-            "name": "Fliegen",
-            "rang": "V",
-            "machtpunkte": 3,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Ziel fliegt mit Bewegungsweite 12",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Fluch": {
-            "name": "Fluch",
-            "rang": "F",
-            "machtpunkte": 5,
-            "reichweite": "Berührung",
-            "dauer": "Speziell",
-            "beschreibung": "Legt Fluch auf Ziel",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Furcht": {
-            "name": "Furcht",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Verursacht Furchtproben",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gedankenleere": {
-            "name": "Gedankenleere",
-            "rang": "V",
-            "machtpunkte": 3,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Entfernt oder verändert Erinnerungen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gedankenlesen": {
-            "name": "Gedankenlesen",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Vergleichender Wurf gegen Verstand zum Gedankenlesen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gedankenverbindung": {
-            "name": "Gedankenverbindung",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 30m",
-            "dauer": "5",
-            "beschreibung": "Geistige Verbindung auf 1,5 Kilometer (8 mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gegenstand beschwören": {
-            "name": "Gegenstand beschwören",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "1 Stunde",
-            "beschreibung": "Beschwört Gegenstand, 1 Pfund pro 2 Machtpunkte",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Geräusch/Stille": {
-            "name": "Geräusch/Stille",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver×5/Ver",
-            "dauer": "5/Sofort",
-            "beschreibung": "Erzeugt oder dämpft Geräusche",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Geschoss": {
-            "name": "Geschoss",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver×2",
-            "dauer": "Sofort",
-            "beschreibung": "2W6 Fernkampfangriff",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gestaltwandeln": {
-            "name": "Gestaltwandeln",
-            "rang": "A",
-            "machtpunkte": 3,
-            "reichweite": "Selbst",
-            "dauer": "5",
-            "beschreibung": "Wirker nimmt die Gestalt verschiedener Wesen an",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Graben": {
-            "name": "Graben",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Ziel gräbt sich durch die Erde",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Heiligtum": {
-            "name": "Heiligtum",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Berührung",
-            "dauer": "5",
-            "beschreibung": "Feinde müssen Willenskraftprobe machen, um angreifen zu können",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Heilung": {
-            "name": "Heilung",
-            "rang": "A",
-            "machtpunkte": 3,
-            "reichweite": "Berührung",
-            "dauer": "Sofort",
-            "beschreibung": "Stellt Wunden wieder her, die weniger als eine Stunde alt sind",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Illusion": {
-            "name": "Illusion",
-            "rang": "A",
-            "machtpunkte": 3,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Erschafft eine visuelle Szene oder Abbildung von so gut wie allem, was der Wirker sich vorstellen kann",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Kriegersegen": {
-            "name": "Kriegersegen",
-            "rang": "F",
-            "machtpunkte": 4,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Gewährt Ziel ein Kampftalent",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Licht/Dunkelheit": {
-            "name": "Licht/Dunkelheit",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 10m",
-            "dauer": "5",
-            "beschreibung": "Erschafft oder verbannt Beleuchtung",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Linderung": {
-            "name": "Linderung",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver",
-            "dauer": "Sofort/1h",
-            "beschreibung": "Entfernt Zustände Angeschlagen, Abgelenkt oder Verwundbar (2 mit Steigerung) oder ignoriert 1 Punkt Wund- und Erschöpfungsabzüge (2 mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Machtpunkte entziehen": {
-            "name": "Machtpunkte entziehen",
-            "rang": "V",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Entzieht Gegner W6 Machtpunkte bei erfolgreichem vergleichendem Wurf",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Magisches Glas": {
-            "name": "Magisches Glas",
-            "rang": "H",
-            "machtpunkte": 5,
-            "reichweite": "Ver",
-            "dauer": "5 Stunden",
-            "beschreibung": "Überträgt die Seele des Wirkers in ein verzaubertes Gefäß (Kristall oder Edelstein). Der Wirker kann zwischen Gefäß und Körper wechseln (Körper wirkt leblos) und versuchen, andere Körper zu besetzen (vergleichender Wurf arkane Fertigkeit vs. Geist). Bei Erfolg wird die Seele des Opfers im Gefäß gefangen. Verstand, Willenskraft, Gesinnung und Vorteile des Wirkers bleiben erhalten; Körperattribute und Wunden stammen vom Wirt.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Marionette": {
-            "name": "Marionette",
-            "rang": "V",
-            "machtpunkte": 3,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Ziel zu kontrollieren",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Objekt auslesen": {
-            "name": "Objekt auslesen",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Berührung",
-            "dauer": "Speziell",
-            "beschreibung": "Offenbart vage Erinnerungen der Geschichte des Ziels (mehr Details mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schadensfeld": {
-            "name": "Schadensfeld",
-            "rang": "F",
-            "machtpunkte": 4,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Erschafft Aura, die 2W4 Schaden verursacht",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schlummer": {
-            "name": "Schlummer",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "1 Stunde",
-            "beschreibung": "Lässt Opfer einschlafen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schutz": {
-            "name": "Schutz",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Gewährt Panzerung +2 bei Erfolg, Robustheit +2 bei Steigerung",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Schutz vor Naturgewalten": {
-            "name": "Schutz vor Naturgewalten",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "1 Stunde",
-            "beschreibung": "Beschützt Ziel vor schädlichen Umwelteinflüssen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Sprachen sprechen": {
-            "name": "Sprachen sprechen",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 10m",
-            "dauer": "5",
-            "beschreibung": "Wirker kann Sprachen sprechen und verstehen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Strahl": {
-            "name": "Strahl",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Kegel",
-            "dauer": "Sofort",
-            "beschreibung": "Kegelförmiger Angriff mit 2W6 Schaden",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Telekinese": {
-            "name": "Telekinese",
-            "rang": "F",
-            "machtpunkte": 5,
-            "reichweite": "Ver×2",
-            "dauer": "5",
-            "beschreibung": "Bewegt Gegenstände mit Stärke W10 (W12 mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Teleportation": {
-            "name": "Teleportation",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Charakter teleportiert sich bis zu 12ʺ weit",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Tierfreund": {
-            "name": "Tierfreund",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Ver 10m",
-            "dauer": "5",
-            "beschreibung": "Kontrolliert Tiere",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Trägheit/Beschleunigung": {
-            "name": "Trägheit/Beschleunigung",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort/5",
-            "beschreibung": "Erhöht oder verlangsamt Bewegung",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Unberührbarkeit": {
-            "name": "Unberührbarkeit",
-            "rang": "V",
-            "machtpunkte": 5,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Ziel wird körperlos",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Unsichtbarkeit": {
-            "name": "Unsichtbarkeit",
-            "rang": "F",
-            "machtpunkte": 5,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Ziel wird unsichtbar (–4/–6, um es zu beeinflussen)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verbannen": {
-            "name": "Verbannen",
-            "rang": "V",
-            "machtpunkte": 3,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Wesenheiten zu verbannen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verbündeten beschwören": {
-            "name": "Verbündeten beschwören",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Beschwört verschiedene Verbündete",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verkleiden": {
-            "name": "Verkleiden",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver 10m",
-            "dauer": "5",
-            "beschreibung": "Ziel sieht aus wie jemand anders",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verstricken": {
-            "name": "Verstricken",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Feind wird Gebunden oder Festgehalten",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verwirrung": {
-            "name": "Verwirrung",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver",
-            "dauer": "Speziell",
-            "beschreibung": "Macht Ziel Abgelenkt und Verwundbar",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Wachsen/Schrumpfen": {
-            "name": "Wachsen/Schrumpfen",
-            "rang": "F",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Erhöht oder verringert Größe",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Waffe verbessern": {
-            "name": "Waffe verbessern",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Erhöht Schaden einer Waffe um +2/+4",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Wandkrabbler": {
-            "name": "Wandkrabbler",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Ver 5",
-            "dauer": "5",
-            "beschreibung": "Charakter kann mit halber Bewegungsweite an Wänden laufen (volle Bewegungsweite mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Wiederauferstehung": {
-            "name": "Wiederauferstehung",
-            "rang": "H",
-            "machtpunkte": 20,
-            "reichweite": "Berührung",
-            "dauer": "Sofort",
-            "beschreibung": "Erweckt die Toten zum Leben",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Wunsch": {
-            "name": "Wunsch",
-            "rang": "L",
-            "machtpunkte": 20,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Wähle eines von mehreren realitätsverändernden Ereignissen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Zeitstopp": {
-            "name": "Zeitstopp",
-            "rang": "H",
-            "machtpunkte": 8,
-            "reichweite": "Ver",
-            "dauer": "Sofort",
-            "beschreibung": "Wirker erhält einen zusätzlichen Zug (bis zu 4 Aktionen mit Steigerung)",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Zombie": {
-            "name": "Zombie",
-            "rang": "V",
-            "machtpunkte": 3,
-            "reichweite": "Ver",
-            "dauer": "1 Stunde",
-            "beschreibung": "Erhebt und kontrolliert Untote",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Zwiesprache": {
-            "name": "Zwiesprache",
-            "rang": "F",
-            "machtpunkte": 5,
-            "reichweite": "Selbst",
-            "dauer": "5 Minuten",
-            "beschreibung": "Wirker kann anderweltlichen Wesenheit Fragen stellen",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Gegenstand Beschwören": {
-            "name": "Gegenstand Beschwören",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Verstand",
-            "dauer": "Eine Stunde",
-            "beschreibung": "Erschafft einen Gegenstand bis 0,5 kg pro 2 Machtpunkte.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Monster Beschwören": {
-            "name": "Monster Beschwören",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Verstand",
-            "dauer": "5",
-            "beschreibung": "Beschwört ein mächtiges Monster.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Mystisches Eingreifen": {
-            "name": "Mystisches Eingreifen",
-            "rang": "Legendär",
-            "machtpunkte": 20,
-            "reichweite": "Speziell",
-            "dauer": "Speziell",
-            "beschreibung": "Bittet um Hilfe von größeren Mächten.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Segen": {
-            "name": "Segen",
-            "rang": "F",
-            "machtpunkte": 10,
-            "reichweite": "Eine Stadt/Gemeinde",
-            "dauer": "Ein Jahr",
-            "beschreibung": "Segnet Gemeinschaften und Ressourcen.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Tier Beschwören": {
-            "name": "Tier Beschwören",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Verstand",
-            "dauer": "5",
-            "beschreibung": "Beschwört Tiere zur Unterstützung.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Untoten Beschwören": {
-            "name": "Untoten Beschwören",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Verstand",
-            "dauer": "5",
-            "beschreibung": "Beschwört einfache Untote.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Verriegeln/Entriegeln": {
-            "name": "Verriegeln/Entriegeln",
-            "rang": "A",
-            "machtpunkte": 1,
-            "reichweite": "Verstand",
-            "dauer": "Permanent (Verriegeln); Sofort (Entriegeln)",
-            "beschreibung": "Verriegelt oder entriegelt magisch.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        },
-        "Zuflucht": {
-            "name": "Zuflucht",
-            "rang": "A",
-            "machtpunkte": 2,
-            "reichweite": "Berührung",
-            "dauer": "5",
-            "beschreibung": "Schützt vor Angriffen und Flächeneffekten; erfordert Willenskraftprobe bei bösen Kreaturen.",
-            "voraussetzungen": [],
-            "ausgewaehlt": false,
-            "aktiv": true,
-            "custom": false
-        }
+    "Ifrits": {
+      "name": "Ifrits",
+      "handicaps": [],
+      "talente": [],
+      "besonderheiten": [
+        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+        "Elementarzauberei (Ifrit-Zauberer mit dem Talent Elementarblut [Feuer] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+        "Angeborene Macht: Ausbruch / Brennende Hände (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
+        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+        "Alternativfähigkeit – Wüstenspiegelung: +1 auf Proben gegen Hunger und Durst; ersetzt Elementarzauberei",
+        "Alternativfähigkeit – Efrit-Magie: Angeborene Macht wird Wachsen/Schrumpfen (selbst, zwei Größenstufen) statt Ausbruch; modifiziert Angeborene Macht",
+        "Alternativfähigkeit – Feuer im Blut: Schnelle Regeneration für 2 Runden wenn durch Feuer Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Beweglich"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Ignanisch"
+      ],
+      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); oft spitze Ohren, rote oder gefleckte Hörner, flammenartiges Haar",
+      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit messingfarbener Haut oder anthrazitfarbenen Schuppen",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Geschicklichkeit": 2
+        },
+        "robustheit_bonus": 0,
+        "bewegungsweite_bonus": 0,
+        "fertigkeits_startboni": {},
+        "auto_talente": [],
+        "auto_handicaps": [],
+        "spezielle_effekte": {
+          "dunkelsicht": true,
+          "elementarzauberei_feuer": true,
+          "angeborene_macht_feuer": true,
+          "heimischer_aussenseiter": true
+        },
+        "wahlmoeglichkeiten": {}
+      }
     },
-    "ausruestung": {
-        "Angelhaken": {
-            "name": "Angelhaken",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Beutel, Gürtel": {
-            "name": "Beutel, Gürtel",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Fackel": {
-            "name": "Fackel",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.01,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Licht für 1 Stunde, 4'' Radius.",
-            "aktiv": true
-        },
-        "Feuerholz (pro Tag)": {
-            "name": "Feuerholz (pro Tag)",
-            "kategorie": "Allgemein",
-            "gewicht": 10,
-            "kosten": 0.01,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Feuerstein und Stahl": {
-            "name": "Feuerstein und Stahl",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Fischernetz (2,5 Quadratmeter)": {
-            "name": "Fischernetz (2,5 Quadratmeter)",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 4,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Flasche oder Krug, Keramik (leer)": {
-            "name": "Flasche oder Krug, Keramik (leer)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.03,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Flasche, Glas (leer)": {
-            "name": "Flasche, Glas (leer)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Flaschenzug": {
-            "name": "Flaschenzug",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Handschellen": {
-            "name": "Handschellen",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Behälter, Karte oder Schriftrolle": {
-            "name": "Behälter, Karte oder Schriftrolle",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Kerze": {
-            "name": "Kerze",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.01,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Brennt eine Stunde, spendet Licht in 2'' Radius.",
-            "aktiv": true
-        },
-        "Kette": {
-            "name": "Kette",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 30,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Krähenfüße": {
-            "name": "Krähenfüße",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Ein Beutel deckt eine kleine Flächenschablone ab, zwei eine mittlere und drei eine große. Zählt als Schwieriges Gelände; jeder der sich durch das Gebiet bewegt, muss Athletik würfeln, um nicht Angeschlagen zu werden. Ein Kritischer Fehlschlag verursacht eine Wunde an den Füßen (–2 Bewegungsweite bis geheilt).",
-            "aktiv": true
-        },
-        "Kreide": {
-            "name": "Kreide",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.01,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Lampe, klein": {
-            "name": "Lampe, klein",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "3'' Radius",
-            "aktiv": true
-        },
-        "Laterne, Blend-": {
-            "name": "Laterne, Blend-",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 12,
-            "setting": "savage_pathfinder",
-            "beschreibung": "10'' Kegel",
-            "aktiv": true
-        },
-        "Laterne, abdeckbar": {
-            "name": "Laterne, abdeckbar",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 7,
-            "setting": "savage_pathfinder",
-            "beschreibung": "6'' Radius",
-            "aktiv": true
-        },
-        "Nähnadel": {
-            "name": "Nähnadel",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Öl (für Laterne; halber Liter)": {
-            "name": "Öl (für Laterne; halber Liter)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
-            "aktiv": true
-        },
-        "Papier": {
-            "name": "Papier",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.4,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Pergament": {
-            "name": "Pergament",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Pfeife, Keramik": {
-            "name": "Pfeife, Keramik",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Phiole, klein": {
-            "name": "Phiole, klein",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Rucksack (leer)": {
-            "name": "Rucksack (leer)",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Halbiert das effektive Gewicht des Inhalts.",
-            "aktiv": true
-        },
-        "Sack (leer)": {
-            "name": "Sack (leer)",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Sanduhr": {
-            "name": "Sanduhr",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 25,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Schaufel": {
-            "name": "Schaufel",
-            "kategorie": "Allgemein",
-            "gewicht": 4,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Schlafsack": {
-            "name": "Schlafsack",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Schleifstein": {
-            "name": "Schleifstein",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.02,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Seife": {
-            "name": "Seife",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Seil, Hanf (10''/20 Meter)": {
-            "name": "Seil, Hanf (10''/20 Meter)",
-            "kategorie": "Allgemein",
-            "gewicht": 5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
-            "aktiv": true
-        },
-        "Seil, Seide (10''/20 Meter)": {
-            "name": "Seil, Seide (10''/20 Meter)",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Segeltuch (Quadratmeter)": {
-            "name": "Segeltuch (Quadratmeter)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Siegelwachs, Stange": {
-            "name": "Siegelwachs, Stange",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Spiegel, klein, Stahl": {
-            "name": "Spiegel, klein, Stahl",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Stachel (Kletterhaken)": {
-            "name": "Stachel (Kletterhaken)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 0.05,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Stange, 4 Meter": {
-            "name": "Stange, 4 Meter",
-            "kategorie": "Allgemein",
-            "gewicht": 4,
-            "kosten": 0.25,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Brechstange": {
-            "name": "Brechstange",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Tintenstift (Schreibfeder)": {
-            "name": "Tintenstift (Schreibfeder)",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Topf, Eisen": {
-            "name": "Topf, Eisen",
-            "kategorie": "Allgemein",
-            "gewicht": 2,
-            "kosten": 0.8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Trinkkrug, Keramik": {
-            "name": "Trinkkrug, Keramik",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.02,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Truhe (klein, leer)": {
-            "name": "Truhe (klein, leer)",
-            "kategorie": "Allgemein",
-            "gewicht": 6,
-            "kosten": 25,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wasserschlauch": {
-            "name": "Wasserschlauch",
-            "kategorie": "Allgemein",
-            "gewicht": 2,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Gewicht ist mit Inhalt",
-            "aktiv": true
-        },
-        "Wolldecke": {
-            "name": "Wolldecke",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wurfhaken": {
-            "name": "Wurfhaken",
-            "kategorie": "Allgemein",
-            "gewicht": 2,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Zelt, Tuch (2 Personen)": {
-            "name": "Zelt, Tuch (2 Personen)",
-            "kategorie": "Allgemein",
-            "gewicht": 10,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Bankett (pro Person)": {
-            "name": "Bankett (pro Person)",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Bier, 4 Liter": {
-            "name": "Bier, 4 Liter",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 4,
-            "kosten": 0.2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Bier, Krug": {
-            "name": "Bier, Krug",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0.5,
-            "kosten": 0.04,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Brot, Leib": {
-            "name": "Brot, Leib",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0.25,
-            "kosten": 0.02,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Käse, Klotz": {
-            "name": "Käse, Klotz",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Reiseproviant (pro Tag)": {
-            "name": "Reiseproviant (pro Tag)",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0.5,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Mahlzeit, schlicht (pro Tag)": {
-            "name": "Mahlzeit, schlicht (pro Tag)",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Mahlzeit, gewöhnlich (pro Tag)": {
-            "name": "Mahlzeit, gewöhnlich (pro Tag)",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0,
-            "kosten": 0.3,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Mahlzeit, gut (pro Tag)": {
-            "name": "Mahlzeit, gut (pro Tag)",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Tierfutter (pro Tag)": {
-            "name": "Tierfutter (pro Tag)",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 4,
-            "kosten": 0.05,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Trockenfrüchte, Beutel": {
-            "name": "Trockenfrüchte, Beutel",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0.5,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wein, 4 Liter": {
-            "name": "Wein, 4 Liter",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 4,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wein, Becher": {
-            "name": "Wein, Becher",
-            "kategorie": "Essen & Trinken",
-            "gewicht": 0.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Adeligenkleindung": {
-            "name": "Adeligenkleindung",
-            "kategorie": "Kleidung",
-            "gewicht": 5,
-            "kosten": 75,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Händlerkleidung": {
-            "name": "Händlerkleidung",
-            "kategorie": "Kleidung",
-            "gewicht": 2,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Handwerkerkleidung": {
-            "name": "Handwerkerkleidung",
-            "kategorie": "Kleidung",
-            "gewicht": 2,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Kaltwetterkleidung": {
-            "name": "Kaltwetterkleidung",
-            "kategorie": "Kleidung",
-            "gewicht": 3.5,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schützt vor Kälte",
-            "aktiv": true
-        },
-        "Königliche Kleidung": {
-            "name": "Königliche Kleidung",
-            "kategorie": "Kleidung",
-            "gewicht": 7.5,
-            "kosten": 100,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Reisekleidung": {
-            "name": "Reisekleidung",
-            "kategorie": "Kleidung",
-            "gewicht": 2.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Esel oder Maultier": {
-            "name": "Esel oder Maultier",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Hund, Wachhund": {
-            "name": "Hund, Wachhund",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0,
-            "kosten": 25,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Pferd, leicht": {
-            "name": "Pferd, leicht",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0,
-            "kosten": 75,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Siehe Seite 248",
-            "aktiv": true
-        },
-        "Pferd, schwer": {
-            "name": "Pferd, schwer",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0,
-            "kosten": 300,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Siehe Seite 248",
-            "aktiv": true
-        },
-        "Pony, leicht": {
-            "name": "Pony, leicht",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0,
-            "kosten": 30,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Siehe Seite 248",
-            "aktiv": true
-        },
-        "Pony, schwer": {
-            "name": "Pony, schwer",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0,
-            "kosten": 45,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Siehe Seite 248",
-            "aktiv": true
-        },
-        "Sattel, Kriegssattel": {
-            "name": "Sattel, Kriegssattel",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 15,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Freie Wiederholung bei Reitenproben, um im Sattel zu bleiben",
-            "aktiv": true
-        },
-        "Sattel, Reitsattel": {
-            "name": "Sattel, Reitsattel",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 12.5,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Satteltaschen, leer": {
-            "name": "Satteltaschen, leer",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 4,
-            "kosten": 4,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Zaumzeug und Zügel": {
-            "name": "Zaumzeug und Zügel",
-            "kategorie": "Tiere & Ausrüstung",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Herberge, schlicht (pro Tag)": {
-            "name": "Herberge, schlicht (pro Tag)",
-            "kategorie": "Unterkunft",
-            "gewicht": 0,
-            "kosten": 0.2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Herberge, gewöhnlich (pro Tag)": {
-            "name": "Herberge, gewöhnlich (pro Tag)",
-            "kategorie": "Unterkunft",
-            "gewicht": 0,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Herberge, gut (pro Tag)": {
-            "name": "Herberge, gut (pro Tag)",
-            "kategorie": "Unterkunft",
-            "gewicht": 0,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Stall (pro Tag)": {
-            "name": "Stall (pro Tag)",
-            "kategorie": "Unterkunft",
-            "gewicht": 0,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Abenteurerausrüstung": {
-            "name": "Abenteurerausrüstung",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 2.5,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Blendlaterne, Feuerstein und Stahl, Hanfseil, Kerze, kleiner Spiegel, Kreide, Mahlzeiten für 1 Woche, Rucksack, Öl, Schaufel, Schlafsack, Schleifstein, Seife, Wasserschlauch, Wurfhaken, Zusatzkleidung, 3 x Fackeln",
-            "aktiv": true
-        },
-        "Diebeswerkzeug": {
-            "name": "Diebeswerkzeug",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.25,
-            "kosten": 30,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Dietriche und Nadeln, Handschuhe, Ölflaschen, Schmiere, Seidenseil, –2 auf Diebeskunst ohne.",
-            "aktiv": true
-        },
-        "Fernrohr": {
-            "name": "Fernrohr",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.5,
-            "kosten": 1000,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Wahrnehmung +2 auf Entfernung",
-            "aktiv": true
-        },
-        "Hammer": {
-            "name": "Hammer",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.25,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Werkzeug eines Handwerkers": {
-            "name": "Werkzeug eines Handwerkers",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 1.25,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Heilertasche": {
-            "name": "Heilertasche",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.25,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Rudimentäre medizinische Ausrüstung, inklusive Salben und Verbänden, –1 auf Heilen ohne.",
-            "aktiv": true
-        },
-        "Heiliges Symbol, Holz": {
-            "name": "Heiliges Symbol, Holz",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Heiliges Symbol, Silber": {
-            "name": "Heiliges Symbol, Silber",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.5,
-            "kosten": 25,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Kaufmannswaage": {
-            "name": "Kaufmannswaage",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.25,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Kletterausrüstung": {
-            "name": "Kletterausrüstung",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 2.5,
-            "kosten": 80,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Hammer, Kletterhaken, Seil, Steigeisen und andere Ausrüstung zum Klettern. Diese Ausrüstung erlaubt es dem Anwender, bis zu 2 Punkte Abzüge beim Klettern zu ignorieren.",
-            "aktiv": true
-        },
-        "Musikinstrument": {
-            "name": "Musikinstrument",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.75,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Spitzhacke": {
-            "name": "Spitzhacke",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 1.25,
-            "kosten": 3,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Vergrößerungsglas": {
-            "name": "Vergrößerungsglas",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0,
-            "kosten": 100,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Verkleidungsausrüstung": {
-            "name": "Verkleidungsausrüstung",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 2,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schminke, Prothesen und falsches Haar. Gewährt eine freie Wiederholung bei Darbietungsproben bei Verwendung einer Verkleidung.",
-            "aktiv": true
-        },
-        "Vorschlaghammer": {
-            "name": "Vorschlaghammer",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 2.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Zauberbuch, Magier (leer)": {
-            "name": "Zauberbuch, Magier (leer)",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.75,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Zauberkomponentenbeutel": {
-            "name": "Zauberkomponentenbeutel",
-            "kategorie": "Werkzeuge & Ausrüstungssets",
-            "gewicht": 0.5,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Alchemistentasche": {
-            "name": "Alchemistentasche",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 25,
-            "setting": "fantasy",
-            "beschreibung": "Tragbares Labor mit Werkzeugen und Kräutern.",
-            "aktiv": true
-        },
-        "Artefakterschaffertasche": {
-            "name": "Artefakterschaffertasche",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 100,
-            "setting": "fantasy",
-            "beschreibung": "Werkzeuge zum Verzaubern von magischen Gegenständen.",
-            "aktiv": true
-        },
-        "Bandolier": {
-            "name": "Bandolier",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 0.5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Behälter für Karte oder Schriftrolle": {
-            "name": "Behälter für Karte oder Schriftrolle",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Buch": {
-            "name": "Buch",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 50,
-            "setting": "fantasy",
-            "beschreibung": "Ermöglicht Rechercheproben.",
-            "aktiv": true
-        },
-        "Diebeswerkzeuge": {
-            "name": "Diebeswerkzeuge",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 30,
-            "setting": "fantasy",
-            "beschreibung": "-2 auf Diebeskunst ohne Werkzeuge.",
-            "aktiv": true
-        },
-        "Fallenherstellungsset": {
-            "name": "Fallenherstellungsset",
-            "kategorie": "Allgemein",
-            "gewicht": 5,
-            "kosten": 150,
-            "setting": "fantasy",
-            "beschreibung": "-2 auf Reparieren ohne Set.",
-            "aktiv": true
-        },
-        "Fass": {
-            "name": "Fass",
-            "kategorie": "Allgemein",
-            "gewicht": 15,
-            "kosten": 2,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Feder": {
-            "name": "Feder",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Feldflasche (Metall)": {
-            "name": "Feldflasche (Metall)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Fernglas": {
-            "name": "Fernglas",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1000,
-            "setting": "fantasy",
-            "beschreibung": "Wahrnehmung +2, um entfernte Objekte zu erkennen.",
-            "aktiv": true
-        },
-        "Flasche": {
-            "name": "Flasche",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Flickzeug": {
-            "name": "Flickzeug",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Glocke": {
-            "name": "Glocke",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Gürteltasche": {
-            "name": "Gürteltasche",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Karren": {
-            "name": "Karren",
-            "kategorie": "Allgemein",
-            "gewicht": 40,
-            "kosten": 15,
-            "setting": "fantasy",
-            "beschreibung": "150 kg Ladevermögen.",
-            "aktiv": true
-        },
-        "Kette (10 Meter)": {
-            "name": "Kette (10 Meter)",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 30,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Kiste": {
-            "name": "Kiste",
-            "kategorie": "Allgemein",
-            "gewicht": 5,
-            "kosten": 5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Laterne": {
-            "name": "Laterne",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 12,
-            "setting": "fantasy",
-            "beschreibung": "Licht für 3 Stunden, 4'' Radius.",
-            "aktiv": true
-        },
-        "Öl (0,5 l)": {
-            "name": "Öl (0,5 l)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
-            "aktiv": true
-        },
-        "Pergament (pro Blatt)": {
-            "name": "Pergament (pro Blatt)",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Ruderboot": {
-            "name": "Ruderboot",
-            "kategorie": "Allgemein",
-            "gewicht": 50,
-            "kosten": 50,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Sack, klein": {
-            "name": "Sack, klein",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Seil, Hanf (20 Meter)": {
-            "name": "Seil, Hanf (20 Meter)",
-            "kategorie": "Allgemein",
-            "gewicht": 5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
-            "aktiv": true
-        },
-        "Stab (3,5 m)": {
-            "name": "Stab (3,5 m)",
-            "kategorie": "Allgemein",
-            "gewicht": 4,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Tagebuch, leer": {
-            "name": "Tagebuch, leer",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Tinte (Fläschchen)": {
-            "name": "Tinte (Fläschchen)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Krug, Keramik": {
-            "name": "Krug, Keramik",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Heiliges Symbol, Gold": {
-            "name": "Heiliges Symbol, Gold",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 100,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Schubkarre": {
-            "name": "Schubkarre",
-            "kategorie": "Allgemein",
-            "gewicht": 10,
-            "kosten": 10,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Schwertscheide": {
-            "name": "Schwertscheide",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 8,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Siegelwachs, Stab": {
-            "name": "Siegelwachs, Stab",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Kreide (Schachtel mit 12 Stück)": {
-            "name": "Kreide (Schachtel mit 12 Stück)",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Leinwand (m2)": {
-            "name": "Leinwand (m2)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Reitbedarf": {
-            "name": "Reitbedarf",
-            "kategorie": "Allgemein",
-            "gewicht": 12.5,
-            "kosten": 15,
-            "setting": "fantasy",
-            "beschreibung": "Sattel, Zaumzeug und Zügel. -2 auf Reiten ohne Ausrüstung.",
-            "aktiv": true
-        },
-        "Schaufel, klein": {
-            "name": "Schaufel, klein",
-            "kategorie": "Allgemein",
-            "gewicht": 2,
-            "kosten": 2,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Steigeisen/Kletterhaken (10)": {
-            "name": "Steigeisen/Kletterhaken (10)",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Bier, Becher": {
-            "name": "Bier, Becher",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Futter, Tier (1 Tag)": {
-            "name": "Futter, Tier (1 Tag)",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 2,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Grundrationen (1 Tag)": {
-            "name": "Grundrationen (1 Tag)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Mahlzeit, billig": {
-            "name": "Mahlzeit, billig",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Mahlzeit, durchschnittlich": {
-            "name": "Mahlzeit, durchschnittlich",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 0.5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Mahlzeit, gut": {
-            "name": "Mahlzeit, gut",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Rationen, edel (1 Tag)": {
-            "name": "Rationen, edel (1 Tag)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wasser, 1 Liter (1 Tag)": {
-            "name": "Wasser, 1 Liter (1 Tag)",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 0.25,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wein, Flasche": {
-            "name": "Wein, Flasche",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Wein, Glas": {
-            "name": "Wein, Glas",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 0.5,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Feine Kleidung": {
-            "name": "Feine Kleidung",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 100,
-            "setting": "fantasy",
-            "beschreibung": "+1 auf Überreden in Statussituationen.",
-            "aktiv": true
-        },
-        "Formelle Kleidung": {
-            "name": "Formelle Kleidung",
-            "kategorie": "Allgemein",
-            "gewicht": 2.5,
-            "kosten": 75,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Gewöhnliche Kleidung": {
-            "name": "Gewöhnliche Kleidung",
-            "kategorie": "Allgemein",
-            "gewicht": 1,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Stiefel, schwer": {
-            "name": "Stiefel, schwer",
-            "kategorie": "Allgemein",
-            "gewicht": 2,
-            "kosten": 2,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Umhang, leicht (mit Kapuze)": {
-            "name": "Umhang, leicht (mit Kapuze)",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 2,
-            "setting": "fantasy",
-            "beschreibung": "",
-            "aktiv": true
-        },
-        "Winterkleidung": {
-            "name": "Winterkleidung",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 8,
-            "setting": "fantasy",
-            "beschreibung": "Schützt vor Kälte (siehe SWAE, S. 118).",
-            "aktiv": true
-        },
-        "Abenteurerpaket": {
-            "name": "Abenteurerpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 11.5,
-            "kosten": 45,
-            "setting": "fantasy",
-            "beschreibung": "Rucksack, Schlafsack, Kerze, Kreide, gewöhnliche Kleidung, Feuerstein und Stahl, Wurfhaken, Laterne, Spiegel, Seil, Öl, Schaufel, Seife, 3 Fackeln, Wasserschlauch, Schleifstein, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Alchemistenpaket": {
-            "name": "Alchemistenpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 15.5,
-            "kosten": 50,
-            "setting": "fantasy",
-            "beschreibung": "Alchemistentasche, Rucksack, Feuerstein und Stahl, Schlafsack, Spiegel, Gürteltasche, Öl, Seil, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Diebespaket": {
-            "name": "Diebespaket",
-            "kategorie": "Allgemein",
-            "gewicht": 9.5,
-            "kosten": 65,
-            "setting": "fantasy",
-            "beschreibung": "Diebeswerkzeug, Rucksack, Spiegel, Feuerstein und Stahl, Gürteltasche, Wurfhaken, Seil, Krähenfüße, Sack (klein), Öl, Laterne, Wasserschlauch, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Gewölbeforscherpaket": {
-            "name": "Gewölbeforscherpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 15.5,
-            "kosten": 50,
-            "setting": "fantasy",
-            "beschreibung": "Seil, Wurfhaken, Rucksack, Feuerstein und Stahl, Hammer, Schlafsack, Brechstange, Laterne, Öl, Steigeisen, Schaufel, Wasserschläuche, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Klerikerpaket": {
-            "name": "Klerikerpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 6,
-            "kosten": 100,
-            "setting": "fantasy",
-            "beschreibung": "Heiliges Symbol, Schlafsack, Feuerstein und Stahl, Kerze, Heilertasche, Laterne, Öl, Pergament, Tinte, Feder, Rucksack, Wasserschlauch, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Magierpaket": {
-            "name": "Magierpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 8,
-            "kosten": 80,
-            "setting": "fantasy",
-            "beschreibung": "Zauberbuch, Rucksack, Schlafsack, Lampe, Feuerstein und Stahl, Tinte, Feder, Öl, Umhang, Buch, Wasserschlauch, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Söldnerpaket": {
-            "name": "Söldnerpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 12,
-            "kosten": 45,
-            "setting": "fantasy",
-            "beschreibung": "Schlafsack, Rucksack, Krähenfüße, Laterne, 1,5 l Öl, Bier (5 l), Feuerstein und Stahl, Krug, Seil, Handschellen, Wasserschlauch, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Unterhalterpaket": {
-            "name": "Unterhalterpaket",
-            "kategorie": "Allgemein",
-            "gewicht": 8,
-            "kosten": 120,
-            "setting": "fantasy",
-            "beschreibung": "Musikinstrument, Rucksack, Schlafsack, Spiegel, Tagebuch, Tinte und Federkiel, Feuerstein und Stahl, Mantel (leicht, mit Kapuze), formelle Kleidung, Verpflegung für 1 Woche, Flickzeug, Flasche Wein.",
-            "aktiv": true
-        },
-        "Wildnispaket": {
-            "name": "Wildnispaket",
-            "kategorie": "Allgemein",
-            "gewicht": 12,
-            "kosten": 36,
-            "setting": "fantasy",
-            "beschreibung": "Zelt (2 Personen), Rucksack, Seil, Schlafsack, Winterkleidung, Stiefel (schwer), Feuerstein und Stahl, Schaufel (klein), Umhang mit Kapuze, Wasserschlauch, Verpflegung für 1 Woche.",
-            "aktiv": true
-        },
-        "Blasrohrpfeile (20)": {
-            "name": "Blasrohrpfeile (20)",
-            "kategorie": "Allgemein",
-            "gewicht": 0,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "Nur für den Gebrauch mit dem Blasrohr. Enthält 20 Pfeile.",
-            "aktiv": true
-        },
-        "Brandpfeile (20)": {
-            "name": "Brandpfeile/-bolzen (20)",
-            "kategorie": "Allgemein",
-            "gewicht": 1.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "Halbe normale Reichweite, +1W6 Schaden, kann brennbare Gegenstände entzünden. Pro Stück.",
-            "aktiv": true
-        },
-        "Schießpulver (10)": {
-            "name": "Schießpulver (10)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "Für Schwarzpulverwaffen. Enthält 10 Schuss.",
-            "aktiv": true
-        },
-        "Schleudersteine (20)": {
-            "name": "Schleudersteine (20)",
-            "kategorie": "Allgemein",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "fantasy",
-            "beschreibung": "Polierte Steine für Schleudern. Enthält 20 Steine.",
-            "aktiv": true
-        },
-        "Beinlinge": {
-            "name": "Beinlinge",
-            "kategorie": "Rüstung",
-            "gewicht": 2.5,
-            "kosten": 5,
-            "setting": "mittelalterlich",
-            "beschreibung": "Leichte Stoffbeinlinge",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 1,
-            "kopf": 0,
-            "mindeststaerke": "W4"
-        },
-        "Robe mit Kapuze": {
-            "name": "Robe mit Kapuze",
-            "kategorie": "Rüstung",
-            "gewicht": 4,
-            "kosten": 10,
-            "setting": "mittelalterlich",
-            "beschreibung": "Robe mit Kapuze schützt Torso, Arme und Kopf",
-            "aktiv": true,
-            "torso": 1,
-            "arme": 1,
-            "beine": 0,
-            "kopf": 1,
-            "mindeststaerke": "W4"
-        },
-        "Tunika": {
-            "name": "Tunika",
-            "kategorie": "Rüstung",
-            "gewicht": 2.5,
-            "kosten": 10,
-            "setting": "mittelalterlich",
-            "beschreibung": "Leichte Stofftunika schützt Torso und Arme",
-            "aktiv": true,
-            "torso": 1,
-            "arme": 1,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W4"
-        },
-        "Umhang mit Kapuze": {
-            "name": "Umhang mit Kapuze",
-            "kategorie": "Rüstung",
-            "gewicht": 2.5,
-            "kosten": 5,
-            "setting": "mittelalterlich",
-            "beschreibung": "Leichter Umhang schützt Torso und Kopf",
-            "aktiv": true,
-            "torso": 1,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 1,
-            "mindeststaerke": "W4"
-        },
-        "Bronzearmschienen": {
-            "name": "Bronzearmschienen",
-            "kategorie": "Rüstung",
-            "gewicht": 2.5,
-            "kosten": 100,
-            "setting": "mittelalterlich",
-            "beschreibung": "Mittlere Armschienen aus Bronze",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 3,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W8"
-        },
-        "Bronzebeinschienen": {
-            "name": "Bronzebeinschienen",
-            "kategorie": "Rüstung",
-            "gewicht": 3,
-            "kosten": 200,
-            "setting": "mittelalterlich",
-            "beschreibung": "Mittlere Beinschienen aus Bronze",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 3,
-            "kopf": 0,
-            "mindeststaerke": "W8"
-        },
-        "Bronzebrustpanzer": {
-            "name": "Bronzebrustpanzer",
-            "kategorie": "Rüstung",
-            "gewicht": 6.5,
-            "kosten": 200,
-            "setting": "mittelalterlich",
-            "beschreibung": "Mittlerer Brustpanzer aus Bronze",
-            "aktiv": true,
-            "torso": 3,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W8"
-        },
-        "Schwerer geschlossener Helm": {
-            "name": "Schwerer geschlossener Helm",
-            "kategorie": "Rüstung",
-            "gewicht": 4,
-            "kosten": 300,
-            "setting": "mittelalterlich",
-            "beschreibung": "Schwerer Helm mit geschlossenem Visier",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 4,
-            "mindeststaerke": "W10"
-        },
-        "Kettenhose": {
-            "name": "Kettenhose",
-            "kategorie": "Rüstung",
-            "gewicht": 10,
-            "kosten": 100,
-            "setting": "mittelalterlich",
-            "beschreibung": "Mittlere Kettenhose schützt die Beine",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 3,
-            "kopf": 0,
-            "mindeststaerke": "W8"
-        },
-        "Bronzehelm": {
-            "name": "Bronzehelm",
-            "kategorie": "Rüstung",
-            "gewicht": 3,
-            "kosten": 120,
-            "setting": "mittelalterlich",
-            "beschreibung": "Mittlerer Helm aus Bronze",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 3,
-            "mindeststaerke": "W8"
-        },
-        "Beinlinge aus natürlicher Rüstung": {
-            "name": "Beinlinge aus natürlicher Rüstung",
-            "kategorie": "Rüstung",
-            "gewicht": 3.5,
-            "kosten": 20,
-            "setting": "mittelalterlich",
-            "beschreibung": "Beinlinge aus dicker natürlicher Rüstung",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 2,
-            "kopf": 0,
-            "mindeststaerke": "W6"
-        },
-        "Hemd aus natürlicher Rüstung": {
-            "name": "Hemd aus natürlicher Rüstung",
-            "kategorie": "Rüstung",
-            "gewicht": 5,
-            "kosten": 20,
-            "setting": "mittelalterlich",
-            "beschreibung": "Hemd aus natürlicher Rüstung schützt Torso und Arme",
-            "aktiv": true,
-            "torso": 2,
-            "arme": 2,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W6"
-        },
-        "Kleiner Schild": {
-            "name": "Kleiner Schild",
-            "kategorie": "Schild",
-            "gewicht": 2,
-            "kosten": 5,
-            "setting": "mittelalterlich",
-            "beschreibung": "Kleiner Schild für grundlegenden Schutz.",
-            "aktiv": true,
-            "parade": 1,
-            "deckung": 0,
-            "mindeststaerke": "W6"
-        },
-        "Mittlerer Schild": {
-            "name": "Mittlerer Schild",
-            "kategorie": "Schild",
-            "gewicht": 4,
-            "kosten": 9,
-            "setting": "mittelalterlich",
-            "beschreibung": "Mittlerer Schild für besseren Schutz.",
-            "aktiv": true,
-            "parade": 2,
-            "deckung": -2,
-            "mindeststaerke": "W8"
-        },
-        "Großer Schild": {
-            "name": "Großer Schild",
-            "kategorie": "Schild",
-            "gewicht": 6,
-            "kosten": 20,
-            "setting": "mittelalterlich",
-            "beschreibung": "Großer Schild für maximalen Schutz. Verringert die Bewegungsweite um 1.",
-            "aktiv": true,
-            "parade": 2,
-            "deckung": -4,
-            "mindeststaerke": "W10"
-        },
-        "Chakram": {
-            "name": "Chakram",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "mittelalterlich",
-            "beschreibung": "Parade +1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Dolch": {
-            "name": "Dolch",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "mittelalterlich",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Dreizack": {
-            "name": "Dreizack",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "mittelalterlich",
-            "beschreibung": "Reichweite 1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Haken-Schwert": {
-            "name": "Haken-Schwert",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 20,
-            "setting": "mittelalterlich",
-            "beschreibung": "+1 zum Entwaffnen.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Zweihandschwert": {
-            "name": "Zweihandschwert",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 50,
-            "setting": "mittelalterlich",
-            "beschreibung": "PB 2, Zweihändig.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W10",
-            "eigenschaften": {
-                "Schaden": "Stä+W10",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": 2
-            }
-        },
-        "Spalthammer": {
-            "name": "Spalthammer",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 12,
-            "setting": "mittelalterlich",
-            "beschreibung": "PB 2, Zweihändig, +2 Schaden gegen Gegenstände.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W10",
-            "eigenschaften": {
-                "Schaden": "Stä+W10",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": 2
-            }
-        },
-        "Stab": {
-            "name": "Stab",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 0,
-            "setting": "mittelalterlich",
-            "beschreibung": "Parade +1, Reichweite 1, Zweihändig.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Entermesser": {
-            "name": "Entermesser",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Keule, leicht": {
-            "name": "Keule, leicht",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 1,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Keule, schwer": {
-            "name": "Keule, schwer",
-            "kategorie": "Waffe",
-            "gewicht": 2.5,
-            "kosten": 2,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Menschenfänger": {
-            "name": "Menschenfänger",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 15,
-            "setting": "mittelalterlich",
-            "beschreibung": "Reichweite 2, Zweihändig, kein Bonusschaden bei einer Steigerung, aber das Opfer ist Gebunden",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "2",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Meteorhammer": {
-            "name": "Meteorhammer",
-            "kategorie": "Waffe",
-            "gewicht": 2.5,
-            "kosten": 12,
-            "setting": "mittelalterlich",
-            "beschreibung": "Reichweite 2, ignoriert Schildbonus, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "2",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Speer": {
-            "name": "Speer",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 2,
-            "setting": "mittelalterlich",
-            "beschreibung": "Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Speer, Kurz-": {
-            "name": "Speer, Kurz-",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 1,
-            "setting": "mittelalterlich",
-            "beschreibung": "Einhändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitflegel, Zweihand": {
-            "name": "Streitflegel, Zweihand",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 15,
-            "setting": "mittelalterlich",
-            "beschreibung": "Ignoriert Schildbonus, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitkolben, leicht": {
-            "name": "Streitkolben, leicht",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 5,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitkolben, schwer": {
-            "name": "Streitkolben, schwer",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 12,
-            "setting": "mittelalterlich",
-            "beschreibung": "PB 1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "-",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Handrepetierarmbrust": {
-            "name": "Handrepetierarmbrust",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 160,
-            "setting": "mittelalterlich",
-            "beschreibung": "Kartusche mit 5 Bolzen oder 1 Bolzen. Nachladen 1. Rückstoßabzug.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "2W4",
-                "Reichweite": "5/10/20",
-                "FR": 2,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Donnerbüchse": {
-            "name": "Donnerbüchse",
-            "kategorie": "Waffe",
-            "gewicht": 6,
-            "kosten": 300,
-            "setting": "schwarzpulver",
-            "beschreibung": "Regeln wie Schrotflinte (SWAE S. 106). Nachladen 2.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "1-3W6",
-                "Reichweite": "10/20/40",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Muskete": {
-            "name": "Muskete",
-            "kategorie": "Waffe",
-            "gewicht": 7.5,
-            "kosten": 300,
-            "setting": "schwarzpulver",
-            "beschreibung": "Schwere, lange Feuerwaffe. Nachladen 2.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W8",
-                "Reichweite": "10/20/40",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Armbrust, Leichte Repetier-": {
-            "name": "Armbrust, Leichte Repetier-",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 4,
-            "kosten": 250,
-            "setting": "mittelalterlich",
-            "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen. Verursacht einen Abzug für Rückstoß.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W6",
-                "Reichweite": "10/20/40",
-                "FR": 1,
-                "Schuss": "5 (Kartusche)",
-                "PB": "2"
-            }
-        },
-        "Armbrust, Schwere Repetier-": {
-            "name": "Armbrust, Schwere Repetier-",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 6,
-            "kosten": 400,
-            "setting": "mittelalterlich",
-            "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "2W8",
-                "Reichweite": "15/30/60",
-                "FR": 1,
-                "Schuss": "5 (Kartusche)",
-                "PB": "2"
-            }
-        },
-        "Axt, Hand-": {
-            "name": "Axt, Hand-",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 1.5,
-            "kosten": 6,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "3/6/12",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Bogen, Komposit-": {
-            "name": "Bogen, Komposit-",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 1.5,
-            "kosten": 100,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "12/24/48",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Bogen, Kurz-": {
-            "name": "Bogen, Kurz-",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 1,
-            "kosten": 30,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W6",
-                "Reichweite": "12/24/48",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Wurf-Chakram": {
-            "name": "Wurf-Chakram",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "4/8/16",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Dolch/Messer": {
-            "name": "Dolch/Messer",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "3/6/12",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Wurf-Dreizack": {
-            "name": "Wurf-Dreizack",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "3/6/12",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kurz-/Wurfspeer": {
-            "name": "Kurz-/Wurfspeer",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 1.5,
-            "kosten": 1,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "4/8/16",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Wurf-Speer": {
-            "name": "Wurf-Speer",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 3,
-            "kosten": 2,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "3/6/12",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Steinschlosspistole": {
-            "name": "Steinschlosspistole",
-            "kategorie": "Fernkampfwaffe",
-            "gewicht": 1.5,
-            "kosten": 150,
-            "setting": "mittelalterlich",
-            "beschreibung": "-",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "2W6+1",
-                "Reichweite": "5/10/20",
-                "FR": 1,
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Gegengift, Phiole": {
-            "name": "Gegengift, Phiole",
-            "kategorie": "Allgemein",
-            "gewicht": 0.25,
-            "kosten": 50,
-            "setting": "mittelalterlich",
-            "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
-            "aktiv": true
-        },
-        "Ledertunika": {
-            "name": "Ledertunika",
-            "kategorie": "Rüstung",
-            "gewicht": 5.5,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Tunika oder Wams aus Leder oder beschlagenem Leder",
-            "aktiv": true,
-            "torso": 2,
-            "arme": 2,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W6"
-        },
-        "Lederbeinlinge": {
-            "name": "Lederbeinlinge",
-            "kategorie": "Rüstung",
-            "gewicht": 4,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Beinlinge aus Leder",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 2,
-            "kopf": 0,
-            "mindeststaerke": "W6"
-        },
-        "Lederkappe": {
-            "name": "Lederkappe",
-            "kategorie": "Rüstung",
-            "gewicht": 0.5,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Kappe aus Leder",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 2,
-            "mindeststaerke": "W6"
-        },
-        "Kettenhemd": {
-            "name": "Kettenhemd",
-            "kategorie": "Rüstung",
-            "gewicht": 11,
-            "kosten": 100,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Hemd aus Kettenrüstung oder Schuppenrüstung",
-            "aktiv": true,
-            "torso": 3,
-            "arme": 3,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W8"
-        },
-        "Kettenbeinlinge": {
-            "name": "Kettenbeinlinge",
-            "kategorie": "Rüstung",
-            "gewicht": 2.5,
-            "kosten": 100,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Beinlinge aus Kettenrüstung",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 3,
-            "kopf": 0,
-            "mindeststaerke": "W8"
-        },
-        "Kettenhaube": {
-            "name": "Kettenhaube",
-            "kategorie": "Rüstung",
-            "gewicht": 1.5,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Kettenhaube oder Helm",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 3,
-            "mindeststaerke": "W8"
-        },
-        "Plattenbrustharnisch": {
-            "name": "Plattenbrustharnisch",
-            "kategorie": "Rüstung",
-            "gewicht": 15,
-            "kosten": 500,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Brustharnisch aus Plattenrüstung",
-            "aktiv": true,
-            "torso": 4,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W10"
-        },
-        "Plattenarmschienen": {
-            "name": "Plattenarmschienen",
-            "kategorie": "Rüstung",
-            "gewicht": 5,
-            "kosten": 250,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Armschienen aus Plattenrüstung",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 4,
-            "beine": 0,
-            "kopf": 0,
-            "mindeststaerke": "W10"
-        },
-        "Plattenbeinschienen": {
-            "name": "Plattenbeinschienen",
-            "kategorie": "Rüstung",
-            "gewicht": 5,
-            "kosten": 500,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Beinschienen aus Plattenrüstung",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 4,
-            "kopf": 0,
-            "mindeststaerke": "W10"
-        },
-        "Schwerer Helm": {
-            "name": "Schwerer Helm",
-            "kategorie": "Rüstung",
-            "gewicht": 2,
-            "kosten": 250,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwerer Helm aus Metall",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 4,
-            "mindeststaerke": "W10"
-        },
-        "Schwerer Helm umschließend": {
-            "name": "Schwerer Helm umschließend",
-            "kategorie": "Rüstung",
-            "gewicht": 4,
-            "kosten": 300,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwerer umschließender Helm. –1 auf Wahrnehmungsproben, die auf Sicht basieren",
-            "aktiv": true,
-            "torso": 0,
-            "arme": 0,
-            "beine": 0,
-            "kopf": 4,
-            "mindeststaerke": "W10"
-        },
-        "Rüstungsstacheln": {
-            "name": "Rüstungsstacheln",
-            "kategorie": "Rüstungsmodifikation",
-            "gewicht": 5,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "+1 Schaden beim Zerquetschen beim Ringen",
-            "aktiv": true
-        },
-        "Panzerhandschuh beriemt": {
-            "name": "Panzerhandschuh beriemt",
-            "kategorie": "Rüstungsmodifikation",
-            "gewicht": 2.5,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "+1 auf Stärkeproben gegen Entwaffnen (Ketten und Spangen erfordern eine Aktion zum Anziehen/Ausziehen)",
-            "aktiv": true
-        },
-        "Rossharnisch Leder": {
-            "name": "Rossharnisch Leder",
-            "kategorie": "Pferderüstung",
-            "gewicht": 25,
-            "kosten": 300,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Pferderüstung aus Leder (+2 Panzerung)",
-            "aktiv": true,
-            "panzerung": 2,
-            "mindeststaerke": "W8"
-        },
-        "Rossharnisch Kette": {
-            "name": "Rossharnisch Kette",
-            "kategorie": "Pferderüstung",
-            "gewicht": 55,
-            "kosten": 500,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Pferderüstung aus Kette (+3 Panzerung)",
-            "aktiv": true,
-            "panzerung": 3,
-            "mindeststaerke": "W10"
-        },
-        "Rossharnisch Platte": {
-            "name": "Rossharnisch Platte",
-            "kategorie": "Pferderüstung",
-            "gewicht": 65,
-            "kosten": 5000,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Pferderüstung aus Platte (+4 Panzerung)",
-            "aktiv": true,
-            "panzerung": 4,
-            "mindeststaerke": "W12"
-        },
-        "Leichter Schild": {
-            "name": "Leichter Schild",
-            "kategorie": "Schild",
-            "gewicht": 2,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Leichter Schild für grundlegenden Schutz",
-            "aktiv": true,
-            "parade": 1,
-            "deckung": 0,
-            "mindeststaerke": "W6"
-        },
-        "Mittelschwerer Schild": {
-            "name": "Mittelschwerer Schild",
-            "kategorie": "Schild",
-            "gewicht": 4,
-            "kosten": 9,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Mittelschwerer Schild für besseren Schutz",
-            "aktiv": true,
-            "parade": 2,
-            "deckung": -2,
-            "mindeststaerke": "W8"
-        },
-        "Schwerer Schild": {
-            "name": "Schwerer Schild",
-            "kategorie": "Schild",
-            "gewicht": 6,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwerer Schild für maximalen Schutz. –1 Bewegungsweite",
-            "aktiv": true,
-            "parade": 2,
-            "deckung": -4,
-            "mindeststaerke": "W10"
-        },
-        "Schildstacheln": {
-            "name": "Schildstacheln",
-            "kategorie": "Schildmodifikation",
-            "gewicht": 0,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "+1 Schaden bei Angriffen mit dem Schild",
-            "aktiv": true
-        },
-        "Handarmbrust": {
-            "name": "Handarmbrust",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Nachladen 1, eine einhändige, pistolenartige Armbrust",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "2W4",
-                "Reichweite": "5/10/20",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Hand-Repetierarmbrust": {
-            "name": "Hand-Repetierarmbrust",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 160,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "2W4",
-                "Reichweite": "5/10/20",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Leichte Armbrust": {
-            "name": "Leichte Armbrust",
-            "kategorie": "Waffe",
-            "gewicht": 2.5,
-            "kosten": 35,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Nachladen 1, handgespannt",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W6",
-                "Reichweite": "10/20/40",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Leichte Repetierarmbrust": {
-            "name": "Leichte Repetierarmbrust",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 250,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W6",
-                "Reichweite": "10/20/40",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Schwere Armbrust": {
-            "name": "Schwere Armbrust",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "wird mit Winde gespannt, Nachladen 2",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W8",
-                "Reichweite": "15/30/60",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Schwere Repetierarmbrust": {
-            "name": "Schwere Repetierarmbrust",
-            "kategorie": "Waffe",
-            "gewicht": 6,
-            "kosten": 400,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 2 einzelnen Bolzen",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "2W8",
-                "Reichweite": "15/30/60",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Handaxt": {
-            "name": "Handaxt",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 6,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Bolas": {
-            "name": "Bolas",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Bolas haben eine Härte von 8.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Blasrohr": {
-            "name": "Blasrohr",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "W4-2",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kurzbogen": {
-            "name": "Kurzbogen",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 30,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "2W6",
-                "Reichweite": "12/24/48",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Langbogen": {
-            "name": "Langbogen",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 75,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "2W6",
-                "Reichweite": "15/30/60",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Kompositbogen": {
-            "name": "Kompositbogen",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 100,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "12/24/48",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Dolch/Messer Fernkampf": {
-            "name": "Dolch/Messer",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Dreizack Fernkampf": {
-            "name": "Dreizack",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kurzspeer/Wurfspeer": {
-            "name": "Kurzspeer/Wurfspeer",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "4/8/16",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Netz (beschwert)": {
-            "name": "Netz (beschwert)",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Das Netz hat Härte 10.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "-",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Schleuder": {
-            "name": "Schleuder",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Athletik (Werfen)",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "4/8/16",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Shuriken": {
-            "name": "Shuriken",
-            "kategorie": "Waffe",
-            "gewicht": 0,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Speer Fernkampf": {
-            "name": "Speer",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Sternmesser Fernkampf": {
-            "name": "Sternmesser",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 28,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Handaxt Nahkampf": {
-            "name": "Handaxt",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 6,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitaxt": {
-            "name": "Streitaxt",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Zweihandaxt": {
-            "name": "Zweihandaxt",
-            "kategorie": "Waffe",
-            "gewicht": 6,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 2, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W10",
-            "eigenschaften": {
-                "Schaden": "Stä+W10",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Sense": {
-            "name": "Sense",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 18,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Sichel": {
-            "name": "Sichel",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 3,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Speer Nahkampf": {
-            "name": "Speer",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kurzer Speer": {
-            "name": "Kurzer Speer",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Einhändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Stachelkette": {
-            "name": "Stachelkette",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, ignoriert Schildbonus, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Sternmesser Nahkampf": {
-            "name": "Sternmesser",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 28,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Parade +1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitkolben leicht": {
-            "name": "Streitkolben, leicht",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitkolben schwer": {
-            "name": "Streitkolben, schwer",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 12,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Totschläger": {
-            "name": "Totschläger",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Betäubungsschaden",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Bolzen (10)": {
-            "name": "Bolzen (10)",
-            "kategorie": "Munition",
-            "gewicht": 0.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Bolzen für alle Arten von Armbrüsten. Eine Kartusche mit fünf Bolzen, die 1 Pfund wiegt, kann für +10 GM für eine Repetierarmbrust erworben werden.",
-            "aktiv": true
-        },
-        "Pfeil Blasrohr (10)": {
-            "name": "Pfeil Blasrohr (10)",
-            "kategorie": "Munition",
-            "gewicht": 0,
-            "kosten": 0.5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Pfeile für ein Blasrohr",
-            "aktiv": true
-        },
-        "Pfeile (20)": {
-            "name": "Pfeile (20)",
-            "kategorie": "Munition",
-            "gewicht": 1.5,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Pfeile für alle Arten von Bögen",
-            "aktiv": true
-        },
-        "Schleudersteine (10)": {
-            "name": "Schleudersteine (10)",
-            "kategorie": "Munition",
-            "gewicht": 0.5,
-            "kosten": 0.1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Polierte Steine",
-            "aktiv": true
-        },
-        "Dolch/Messer Nahkampf": {
-            "name": "Dolch/Messer",
-            "kategorie": "Waffe",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Dreizack Nahkampf": {
-            "name": "Dreizack",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Reichweite 1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitflegel": {
-            "name": "Streitflegel",
-            "kategorie": "Waffe",
-            "gewicht": 2.5,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "ignoriert Schildbonus",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Streitflegel schwer": {
-            "name": "Streitflegel, schwer",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "ignoriert Schildbonus, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Glefe": {
-            "name": "Glefe",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Reichweite 1, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Guisarme": {
-            "name": "Guisarme",
-            "kategorie": "Waffe",
-            "gewicht": 4.5,
-            "kosten": 12,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, Reichweite 1, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Hellebarde": {
-            "name": "Hellebarde",
-            "kategorie": "Waffe",
-            "gewicht": 6,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, Reichweite 1, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Katana": {
-            "name": "Katana",
-            "kategorie": "Waffe",
-            "gewicht": 1.5,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6+1",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kampfstab": {
-            "name": "Kampfstab",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 0,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Parade +1, Reichweite 1, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Keule leicht": {
-            "name": "Keule, leicht",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Keule schwer": {
-            "name": "Keule, schwer",
-            "kategorie": "Waffe",
-            "gewicht": 2.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kriegshammer": {
-            "name": "Kriegshammer",
-            "kategorie": "Waffe",
-            "gewicht": 2.5,
-            "kosten": 12,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Krummsäbel": {
-            "name": "Krummsäbel",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Krummschwert": {
-            "name": "Krummschwert",
-            "kategorie": "Waffe",
-            "gewicht": 4,
-            "kosten": 75,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Lanze": {
-            "name": "Lanze",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 2 bei Sturmangriff, Reichweite 2, nur im berittenen Kampf verwendbar",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "2",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Morgenstern": {
-            "name": "Morgenstern",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 8,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Peitsche": {
-            "name": "Peitsche",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 5,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Parade –1, Reichweite 2. Bei einer Steigerung beim Angriffswurf ist das Opfer Festgehalten anstelle von Bonusschaden.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "2",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Pike": {
-            "name": "Pike",
-            "kategorie": "Waffe",
-            "gewicht": 9,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, wenn aufgesetzt, Reichweite 2, Zweihändig",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "2",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Ranseur": {
-            "name": "Ranseur",
-            "kategorie": "Waffe",
-            "gewicht": 6,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, Reichweite 1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "1",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Rapier": {
-            "name": "Rapier",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Parade +1",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W4",
-            "eigenschaften": {
-                "Schaden": "Stä+W4",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Schlägel": {
-            "name": "Schlägel",
-            "kategorie": "Waffe",
-            "gewicht": 5,
-            "kosten": 12,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 2, Zweihändig, +2 Schaden zum Zerstören von Gegenständen",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W10",
-            "eigenschaften": {
-                "Schaden": "Stä+W10",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "2"
-            }
-        },
-        "Bastardschwert": {
-            "name": "Bastardschwert",
-            "kategorie": "Waffe",
-            "gewicht": 3,
-            "kosten": 35,
-            "setting": "savage_pathfinder",
-            "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "1"
-            }
-        },
-        "Kurzschwert": {
-            "name": "Kurzschwert",
-            "kategorie": "Waffe",
-            "gewicht": 1,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W6",
-            "eigenschaften": {
-                "Schaden": "Stä+W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Langschwert": {
-            "name": "Langschwert",
-            "kategorie": "Waffe",
-            "gewicht": 2,
-            "kosten": 15,
-            "setting": "savage_pathfinder",
-            "beschreibung": "",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "W8",
-            "eigenschaften": {
-                "Schaden": "Stä+W8",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Kanone Rundgeschoss": {
-            "name": "Kanone Rundgeschoss",
-            "kategorie": "Belagerungswaffe",
-            "gewicht": 0,
-            "kosten": 0,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwere Waffe, Nachladen 8. Zwei Besatzungsmitglieder können gleichzeitig nachladen. Bei Erfolg prallt die Kugel bei geradem Würfelergebnis zu einem weiteren Opfer hinter dem ersten Ziel (innerhalb von 6\") ab.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "3W6+1",
-                "Reichweite": "50/100/200",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "4",
-                "Flächenschablone": "MFS"
-            }
-        },
-        "Balliste": {
-            "name": "Balliste",
-            "kategorie": "Belagerungswaffe",
-            "gewicht": 0,
-            "kosten": 500,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Einzelperson oder 2 Minuten für eine Mannschaft von 2.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "3W6",
-                "Reichweite": "15/30/60",
-                "FR": "Speziell",
-                "Schuss": "-",
-                "PB": "4"
-            }
-        },
-        "Belagerungsturm": {
-            "name": "Belagerungsturm",
-            "kategorie": "Belagerungsgerät",
-            "gewicht": 0,
-            "kosten": 2000,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Keine Fernkampfwaffe, wird zum Erklimmen von Mauern verwendet; Schützen können aus den oberen Stockwerken feuern. Bewegungsweite 1 mit 8 Personen, verdoppelt mit 16 Personen.",
-            "aktiv": true
-        },
-        "Trebuchet": {
-            "name": "Trebuchet",
-            "kategorie": "Belagerungswaffe",
-            "gewicht": 0,
-            "kosten": 1000,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "3W8",
-                "Reichweite": "30/60/120",
-                "FR": "Speziell",
-                "Schuss": "-",
-                "PB": "4",
-                "Flächenschablone": "MFS"
-            }
-        },
-        "Katapult": {
-            "name": "Katapult",
-            "kategorie": "Belagerungswaffe",
-            "gewicht": 0,
-            "kosten": 800,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "3W6",
-                "Reichweite": "24/48/96",
-                "FR": "Speziell",
-                "Schuss": "-",
-                "PB": "4",
-                "Flächenschablone": "MFS"
-            }
-        },
-        "Rammbock": {
-            "name": "Rammbock",
-            "kategorie": "Belagerungsgerät",
-            "gewicht": 1000,
-            "kosten": 1000,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Keine Fernkampfwaffe, wird zum Zertrümmern von Objekten verwendet. Mindestens 2 Personen nötig, bis zu 8 können helfen.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "3W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Alchemistenfeuer": {
-            "name": "Alchemistenfeuer",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.5,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Eine klebrige, brennbare Flüssigkeit, die beim Aufschlag in Brand gerät. Schwere Waffe. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn sie nicht in Wasser untergetaucht werden. Ziel könnte in Brand geraten.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "2W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-",
-                "Flächenschablone": "KFS"
-            }
-        },
-        "Donnerstein": {
-            "name": "Donnerstein",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.5,
-            "kosten": 30,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Ein verzauberter Felsen, der mit einem ohrenbetäubenden Knall explodiert. Alle in der Schablone müssen eine Konstitutionsprobe schaffen, um nicht Angeschlagen und für eine Stunde taub zu sein.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "-",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-",
-                "Flächenschablone": "MFS"
-            }
-        },
-        "Ewige Fackel": {
-            "name": "Ewige Fackel",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.5,
-            "kosten": 110,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Eine 'Fackel', die dauerhaft mit Licht verzaubert ist. Verbrennt nicht und gibt keine Hitze ab.",
-            "aktiv": true
-        },
-        "Gegengift Phiole": {
-            "name": "Gegengift, Phiole",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.25,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
-            "aktiv": true
-        },
-        "Rauchstab": {
-            "name": "Rauchstab",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.05,
-            "kosten": 20,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Ein alchemistisch behandelter Stock, der dichten Rauch (Dunkle Beleuchtung) in einer Mittleren Flächenschablone erzeugt. Er hält 1 Minute lang an und löst sich in starkem Wind innerhalb einer Runde auf.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "-",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-",
-                "Flächenschablone": "MFS"
-            }
-        },
-        "Säureflasche": {
-            "name": "Säureflasche",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.5,
-            "kosten": 10,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Wird wie eine Granate geworfen. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn die Säure nicht abgewaschen wird.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "2W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-",
-                "Flächenschablone": "KFS"
-            }
-        },
-        "Sonnenzepter": {
-            "name": "Sonnenzepter",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.5,
-            "kosten": 2,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Ein Eisenstab mit Goldspitzen, der für sechs Stunden in einem Radius von 9 m normales Licht erzeugt. Es erhöht die Beleuchtungsstufe darüber hinaus für weitere 9\" um eine Stufe. Es gibt keine Hitze ab und zählt als Sonnenlicht.",
-            "aktiv": true,
-            "typ": "Nahkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "1W6",
-                "Reichweite": "nah",
-                "FR": "-",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Verstrickungsbeutel": {
-            "name": "Verstrickungsbeutel",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 4,
-            "kosten": 50,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Ein Opfer mit Größe 3 oder weniger, das von diesem kleinen Beutel klebrigen Materials getroffen wird, ist für fünf Runden Abgelenkt und muss eine Athletikprobe schaffen, um nicht auch am Boden festzukleben (Festgehalten).",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "-",
-                "Reichweite": "1/2/4",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-"
-            }
-        },
-        "Heiliges Wasser": {
-            "name": "Heiliges Wasser",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0,
-            "kosten": 25,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Heiliges Wasser kann in einer Flasche geworfen oder auf eine angrenzende Kreatur gespritzt werden. Untote und bestimmte böse Kreaturen innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges.",
-            "aktiv": true,
-            "typ": "Fernkampf",
-            "mindeststaerke": "-",
-            "eigenschaften": {
-                "Schaden": "2W4",
-                "Reichweite": "3/6/12",
-                "FR": "1",
-                "Schuss": "-",
-                "PB": "-",
-                "Flächenschablone": "KFS"
-            }
-        },
-        "Zündholz": {
-            "name": "Zündholz",
-            "kategorie": "Alchemistischer Gegenstand",
-            "gewicht": 0.05,
-            "kosten": 1,
-            "setting": "savage_pathfinder",
-            "beschreibung": "Ein dünnes Stäbchen, das eine Flamme erzeugt, wenn es hart gegen eine Oberfläche geschlagen wird. Dies ermöglicht es, Fackeln und andere brennbare Substanzen in einer Aktion zu entzünden.",
-            "aktiv": true
-        }
+    "Oreads": {
+      "name": "Oreads",
+      "handicaps": [
+        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
+      ],
+      "talente": [],
+      "besonderheiten": [
+        "Stark (Stärke W6 statt W4, Maximum W12+1)",
+        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+        "Granitene Haut (Felsige Wucherungen gewähren +2 Rüstung)",
+        "Elementarzauberei (Oread-Zauberer mit dem Talent Elementarblut [Erde] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+        "Angeborene Macht: Blitz / Magischer Stein (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
+        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+        "Alternativfähigkeit – Eisenwuchs: 1×/Tag kann ein berührtes nicht-magisches Eisen- oder Stahlstück zu einem Gegenstand bis 4,5 kg wachsen (10 Minuten); ersetzt Angeborene Macht",
+        "Alternativfähigkeit – Stein im Blut (Schnell): Schnelle Regeneration für 2 Runden wenn durch Säure Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Stark; schließt Stein im Blut (Langsam) aus",
+        "Alternativfähigkeit – Stein im Blut (Langsam): Langsame Regeneration wenn durch Säure Erschüttert oder Verwundet; ersetzt Elementarzauberei; schließt Stein im Blut (Schnell) aus",
+        "Alternativfähigkeit – Tückische Erde: 1×/Tag kann der Oread eine große Schablone (Reichweite Verstand) in schweres Gelände verwandeln (Erde, Stein oder Sand); Dauer in Minuten je nach Rang: Anfänger 1, Erfahren 2, Veteran 3, Held 4, Legendär 5; ersetzt Granitene Haut"
+      ],
+      "sprachen": [
+        "Gemeinsprache",
+        "Terranisch"
+      ],
+      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut und Haar in steinigen Tönen (Schwarz, Braun, Grau, Weiß)",
+      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit glänzender Obsidian-Haut, Gesteinsvorsprüngen oder kristallinen Haarspitzen",
+      "aktiv": true,
+      "custom": false,
+      "effects": {
+        "attribute_bonuses": {
+          "Stärke": 2
+        },
+        "robustheit_bonus": 0,
+        "bewegungsweite_bonus": -1,
+        "fertigkeits_startboni": {},
+        "auto_talente": [],
+        "auto_handicaps": [
+          "Langsam_leicht"
+        ],
+        "spezielle_effekte": {
+          "dunkelsicht": true,
+          "granit_haut": true,
+          "elementarzauberei_erde": true,
+          "angeborene_macht_erde": true,
+          "heimischer_aussenseiter": true
+        },
+        "wahlmoeglichkeiten": {}
+      }
+    }
+  },
+  "voelker_selected": {
+    "Elf": false,
+    "Gnom": false,
+    "Halbelf": false,
+    "Halbling": false,
+    "Halbork": false,
+    "Ifrits": false,
+    "Mensch": true,
+    "Oreads": false,
+    "Zwerg": false
+  },
+  "attribute": {
+    "Geschicklichkeit": {
+      "attribut_name": "Geschicklichkeit",
+      "wert": 4,
+      "modifier": 0
     },
-    "settingregeln": {
-        "strahlschablone": false,
-        "große_hoehen": false,
-        "verrat": false,
-        "schwierige_heilung": false,
-        "freizeit": false,
-        "riesige_feinde,": false,
-        "schurkische_entschlossenheit": false,
-        "dynamischer_rueckschlag": false,
-        "entschlossenheit": false,
-        "fanatiker": false,
-        "fertigkeitsspezialisierungen": false,
-        "fieser_schaden": false,
-        "geborener_held": false,
-        "grosse_abenteuer": false,
-        "helden_sterben_nie": false,
-        "keine_machtpunkte": false,
-        "kreativer_kampf": false,
-        "mehr_fertigkeitspunkte": false,
-        "mehr_sprachen": false,
-        "narrenglueck": false,
-        "schnelle_genesung": false,
-        "schwere_entscheidungen": false,
-        "ungepanzerter_held": false,
-        "wundobergrenze": false
+    "Verstand": {
+      "attribut_name": "Verstand",
+      "wert": 4,
+      "modifier": 0
     },
-    "startgeld": 300,
-    "waehrung": "GM"
+    "Stärke": {
+      "attribut_name": "Stärke",
+      "wert": 4,
+      "modifier": 0
+    },
+    "Konstitution": {
+      "attribut_name": "Konstitution",
+      "wert": 4,
+      "modifier": 0
+    },
+    "Willenskraft": {
+      "attribut_name": "Willenskraft",
+      "wert": 4,
+      "modifier": 0
+    }
+  },
+  "fertigkeiten_daten": {
+    "Allgemeinwissen": [
+      "Verstand"
+    ],
+    "Athletik": [
+      "Geschicklichkeit"
+    ],
+    "Heimlichkeit": [
+      "Geschicklichkeit"
+    ],
+    "Überreden": [
+      "Willenskraft"
+    ],
+    "Wahrnehmung": [
+      "Verstand"
+    ],
+    "Kämpfen": [
+      "Geschicklichkeit"
+    ],
+    "Schießen": [
+      "Geschicklichkeit"
+    ],
+    "Diebeskunst": [
+      "Geschicklichkeit"
+    ],
+    "Überleben": [
+      "Verstand"
+    ],
+    "Reiten": [
+      "Geschicklichkeit"
+    ],
+    "Fahren": [
+      "Geschicklichkeit"
+    ],
+    "Seefahrt": [
+      "Geschicklichkeit"
+    ],
+    "Pilot": [
+      "Geschicklichkeit"
+    ],
+    "Darbietung": [
+      "Willenskraft"
+    ],
+    "Einschüchtern": [
+      "Willenskraft"
+    ],
+    "Glaube": [
+      "Willenskraft"
+    ],
+    "Heilen": [
+      "Verstand"
+    ],
+    "Provozieren": [
+      "Verstand"
+    ],
+    "Reparieren": [
+      "Verstand"
+    ],
+    "Glücksspiel": [
+      "Verstand"
+    ],
+    "Kriegskunst": [
+      "Verstand"
+    ],
+    "Okkultismus": [
+      "Verstand"
+    ],
+    "Geisteswissenschaften": [
+      "Verstand"
+    ],
+    "Naturwissenschaften": [
+      "Verstand"
+    ],
+    "Zaubern": [
+      "Verstand"
+    ],
+    "Zaubern (Zauberer)": [
+      "Willenskraft"
+    ],
+    "Verrückte Wissenschaft": [
+      "Verstand"
+    ],
+    "Alchemie": [
+      "Verstand"
+    ],
+    "Fokus": [
+      "Willenskraft"
+    ]
+  },
+  "talente": {
+    "Berserker": {
+      "name": "Berserker",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Nach Angeschlagen oder Wunde: Nahkampfangriffe müssen Rücksichtslose Angriffe sein, +1 Würfeltyp Stärke, +2 Robustheit, ignoriere eine Stufe Wundabzüge, Kritischer Fehlschlag bei Kämpfenproben trifft zufälliges Ziel. Erleidet Erschöpfung nach fünf Runden in Folge, kann dies mit Verstandsprobe mit –2 beenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Barbar": {
+      "name": "Barbar",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W6",
+        "KON W6"
+      ],
+      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Behände (Bewegungsweite +2), Kampfrausch (siehe Text)",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Berserker",
+        "Behände",
+        "Kampfrausch"
+      ],
+      "auto_handicaps": [
+        "Rüstungsbeschränkung_mittelschwer"
+      ]
+    },
+    "Kraftvoller Schlag": {
+      "name": "Kraftvoller Schlag",
+      "kategorie": "Barbar",
+      "rang": "F",
+      "voraussetzungen": [
+        "Barbar"
+      ],
+      "beschreibung": "Rücksichtslose Angriffe verursachen +4 Schaden anstatt +2.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Einschüchterndes Niederstarren": {
+      "name": "Einschüchterndes Niederstarren",
+      "kategorie": "Barbar",
+      "rang": "V",
+      "voraussetzungen": [
+        "Barbar"
+      ],
+      "beschreibung": "Der Barbar kann eine Einschüchternprobe als freie Aktion ausführen, wenn ihm im Kampf ein Bube oder besser ausgeteilt wird.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kraftrausch": {
+      "name": "Kraftrausch",
+      "kategorie": "Barbar",
+      "rang": "H",
+      "voraussetzungen": [
+        "Barbar"
+      ],
+      "beschreibung": "Die Stärke des Helden wird um zwei Würfeltypen erhöht.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Barde)": {
+      "name": "AH (Barde)",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "Allgemeinwissen W6"
+      ],
+      "beschreibung": "AH (Barde), Behindernde Rüstung (leicht), Scharfzüngig (kann Darbietung zum Provozieren verwenden)",
+      "neue_maechte": 3,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Scharfzüngig"
+      ],
+      "auto_handicaps": [
+        "Behindernde Rüstung_leicht"
+      ]
+    },
+    "Bannlied": {
+      "name": "Bannlied",
+      "kategorie": "Barde",
+      "rang": "V",
+      "voraussetzungen": [
+        "Barde"
+      ],
+      "beschreibung": "Verbündete innerhalb von 5'' erhalten eine Wurfwiederholung, wenn sie feindlichen Zaubereffekten widerstehen oder sich von ihnen erholen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Klagelied": {
+      "name": "Klagelied",
+      "kategorie": "Barde",
+      "rang": "H",
+      "voraussetzungen": [
+        "Barde"
+      ],
+      "beschreibung": "Feindliche Wildcards innerhalb von 10'' ziehen –2 vom Gesamtwert ab, wenn sie einen Benny ausgeben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Druide)": {
+      "name": "AH (Druide)",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "Überleben W6"
+      ],
+      "beschreibung": "AH (Druide), Behindernde Rüstung (leicht), Bindung mit der Natur, Naturgespür",
+      "neue_maechte": 3,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Bindung mit der Natur",
+        "Naturgespür"
+      ],
+      "auto_handicaps": [
+        "Schwur_schwer",
+        "Behindernde Rüstung_leicht"
+      ]
+    },
+    "Tiergestalt": {
+      "name": "Tiergestalt",
+      "kategorie": "Druide",
+      "rang": "F",
+      "voraussetzungen": [
+        "Druide"
+      ],
+      "beschreibung": "Der Druide erhält Gestaltwandeln. Wirkungsdauer ist eine Stunde, und er wirkt den Zauber mit einem Rang höher als normal.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bevorzugte Mächte (Druide)": {
+      "name": "Bevorzugte Mächte (Druide)",
+      "kategorie": "Druide",
+      "rang": "V",
+      "voraussetzungen": [
+        "Druide"
+      ],
+      "beschreibung": "Als begrenzte freie Aktion kann der Druide bis zu zwei Punkte Abzüge ignorieren, wenn er Schutz, Verstricken oder Waffe verbessern wirkt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Göttliche Meisterschaft (Druide)": {
+      "name": "Göttliche Meisterschaft (Druide)",
+      "kategorie": "Druide",
+      "rang": "H",
+      "voraussetzungen": [
+        "Druide"
+      ],
+      "beschreibung": "Der Druide kann Epische Machtmodifikatoren verwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kämpfer": {
+      "name": "Kämpfer",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W6",
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Kriegerische Anpassungsfähigkeit (kann einmal pro Begegnung ein Kampftalent erhalten)",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Kriegerische Anpassungsfähigkeit"
+      ],
+      "auto_handicaps": []
+    },
+    "Tödlicher Hieb": {
+      "name": "Tödlicher Hieb",
+      "kategorie": "Kämpfer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfer"
+      ],
+      "beschreibung": "Der Kämpfer addiert +1 auf alle Angriffe, die Schaden verursachen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Verbesserte kriegerische Anpassungsfähigkeit": {
+      "name": "Verbesserte kriegerische Anpassungsfähigkeit",
+      "kategorie": "Kämpfer",
+      "rang": "V",
+      "voraussetzungen": [
+        "Kämpfer"
+      ],
+      "beschreibung": "Der Kämpfer kann jetzt zwei Kampftalente pro Begegnung wählen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kämpferisches Können": {
+      "name": "Kämpferisches Können",
+      "kategorie": "Kämpfer",
+      "rang": "H",
+      "voraussetzungen": [
+        "Kämpfer"
+      ],
+      "beschreibung": "Der Kämpfer erhält eine freie Wiederholung bei jeder misslungenen Kämpfenprobe.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Kleriker)": {
+      "name": "AH (Kleriker)",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "Okkultismus W6"
+      ],
+      "beschreibung": "AH (Kleriker), Energie fokussieren (kann mit Reichweite von Willenskraft heilen)",
+      "neue_maechte": 3,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Gnade",
+        "Energie fokussieren"
+      ],
+      "auto_handicaps": [
+        "Schwur_schwer"
+      ]
+    },
+    "Bevorzugte Mächte (Kleriker)": {
+      "name": "Bevorzugte Mächte (Kleriker)",
+      "kategorie": "Kleriker",
+      "rang": "V",
+      "voraussetzungen": [
+        "Kleriker"
+      ],
+      "beschreibung": "Als begrenzte freie Aktion kann der Kleriker bis zu zwei Punkte Abzüge ignorieren, wenn er Heiligtum, Heilung oder Waffe verbessern wirkt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Göttliche Meisterschaft (Kleriker)": {
+      "name": "Göttliche Meisterschaft (Kleriker)",
+      "kategorie": "Kleriker",
+      "rang": "H",
+      "voraussetzungen": [
+        "Kleriker"
+      ],
+      "beschreibung": "Der Kleriker kann Epische Machtmodifikatoren verwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Magier)": {
+      "name": "AH (Magier)",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6",
+        "Okkultismus W6"
+      ],
+      "beschreibung": "AH (Magier) Arkane Verbindung (Verbindung mit einem Gegenstand für +1 Zaubern oder ein Vertrauter), Behindernde Rüstung (jede), Schule, Zauberbücher",
+      "neue_maechte": 3,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Zauberbücher",
+        "Arkane Verbindung",
+        "Schule"
+      ],
+      "auto_handicaps": [
+        "Behindernde Rüstung_jede"
+      ]
+    },
+    "Bevorzugte Mächte (Magier)": {
+      "name": "Bevorzugte Mächte (Magier)",
+      "kategorie": "Magier",
+      "rang": "F",
+      "voraussetzungen": [
+        "Magier"
+      ],
+      "beschreibung": "Als begrenzte freie Aktion kann der Magier bis zu zwei Punkte Abzüge ignorieren, wenn er Abwehren, Arkanen Schutz oder Aufheben wirkt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Meisterschaft (Magier)": {
+      "name": "Arkane Meisterschaft (Magier)",
+      "kategorie": "Magier",
+      "rang": "V",
+      "voraussetzungen": [
+        "Magier"
+      ],
+      "beschreibung": "Der Magier kann Epische Machtmodifikatoren verwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mönch": {
+      "name": "Mönch",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W6",
+        "WIL W6",
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Rüstungsbeschränkung (jede), Betäubende Fäuste, Beweglichkeit, Kämpferische Disziplin, Waffenloser Schlag",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Betäubende Fäuste",
+        "Beweglichkeit",
+        "Kämpferische Disziplin",
+        "Waffenloser Schlag"
+      ],
+      "auto_handicaps": [
+        "Rüstungsbeschränkung_jede"
+      ]
+    },
+    "Mystische Mächte (Mönch)": {
+      "name": "Mystische Mächte (Mönch)",
+      "kategorie": "Mönch",
+      "rang": "F",
+      "voraussetzungen": [
+        "Mönch"
+      ],
+      "beschreibung": "Der Mönch hat 10 gewidmete Machtpunkte, die er verwenden kann, um Abwehren, Beschleunigung, Eigenschaft erhöhen (Geschicklichkeit, Athletik, Kämpfen oder Heimlichkeit) oder Waffe verbessern zu wirken. Alle wirken nur auf den Mönch selbst.",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mächtiges Ki": {
+      "name": "Mächtiges Ki",
+      "kategorie": "Mönch",
+      "rang": "V",
+      "voraussetzungen": [
+        "Mönch",
+        "Mystische Mächte (Mönch)"
+      ],
+      "beschreibung": "Zu den mystischen Mächten des Mönchs gehören jetzt Eigenschaft erhöhen (Stärke), Kriegersegen, Schutz, Wandkrabbler.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Unversehrtheit des Körpers": {
+      "name": "Unversehrtheit des Körpers",
+      "kategorie": "Mönch",
+      "rang": "H",
+      "voraussetzungen": [
+        "Mönch",
+        "Mystische Mächte (Mönch)"
+      ],
+      "beschreibung": "Der Mönch kann 2 Machtpunkte ausgeben, um auf Schaden wegstecken zu würfeln. Dies wird nicht behandelt, als hätte er einen Benny ausgegeben",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Paladin": {
+      "name": "Paladin",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "STÄ W6"
+      ],
+      "beschreibung": "Aura der Tapferkeit (+1 auf Furchtproben innerhalb von 10''), Ehrenkodex, Böses entdecken, Böses niederstrecken (freie Wiederholung bei Angriffswürfen gegen einen gewählten bösen Gegner pro Begegnung)",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Aura der Tapferkeit",
+        "Böses Entdecken",
+        "Böses Niederstrecken"
+      ],
+      "auto_handicaps": [
+        "Ehrenkodex"
+      ]
+    },
+    "Mystische Mächte (Paladin)": {
+      "name": "Mystische Mächte (Paladin)",
+      "kategorie": "Paladin",
+      "rang": "F",
+      "voraussetzungen": [
+        "Paladin"
+      ],
+      "beschreibung": "Der Paladin hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Kämpfen, Stärke, Konstitution), Heilung, Linderung, Waffe verbessern nutzen kann. Alle außer Heilung und Linderung wirken nur auf den Paladin selbst.",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Gnade (Paladin)": {
+      "name": "Gnade (Paladin)",
+      "kategorie": "Paladin",
+      "rang": "V",
+      "voraussetzungen": [
+        "Paladin"
+      ],
+      "beschreibung": "Der Paladin kann Abgelenkt, Verwundbar, Angeschlagen bei einem Verbündeten in Willenskraft-Reichweite aufheben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Reittier (Paladin)": {
+      "name": "Reittier (Paladin)",
+      "kategorie": "Paladin",
+      "rang": "H",
+      "voraussetzungen": [
+        "Paladin"
+      ],
+      "beschreibung": "Der Held erhält ein loyales leichtes oder schweres Pferd als Wildcard.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schurke": {
+      "name": "Schurke",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W6",
+        "Wahrnehmung W6",
+        "Heimlichkeit W6"
+      ],
+      "beschreibung": "Rüstungsbeschränkung (leicht), Hinterhältiger Angriff",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Hinterhältiger Angriff"
+      ],
+      "auto_handicaps": [
+        "Rüstungsbeschränkung_leicht"
+      ]
+    },
+    "Reflexbewegung": {
+      "name": "Reflexbewegung",
+      "kategorie": "Schurke",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schurke"
+      ],
+      "beschreibung": "Der Schurke ignoriert den üblichen Abzug von –2 beim Wegspringen und kann versuchen, bei jedem Flächenangriff wegzuspringen, der dies normalerweise nicht erlaubt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Opportunist": {
+      "name": "Opportunist",
+      "kategorie": "Schurke",
+      "rang": "H",
+      "voraussetzungen": [
+        "Schurke"
+      ],
+      "beschreibung": "Der Schurke erhält einen freien Angriff gegen einen Feind, der sich aus dem Nahkampf zurückzieht, auch wenn dieser Rückzug besitzt. Wenn er nicht über Rückzug verfügt, zählt der Gegner als Verwundbar.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Waldläufer": {
+      "name": "Waldläufer",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "Athletik W6, Kämpfen oder Schießen W6",
+        "Überleben W6"
+      ],
+      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Erzfeind, Bevorzugtes Gelände, Wildnis durchqueren",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Erzfeind",
+        "Bevorzugtes Gelände",
+        "Wildnis durchqueren"
+      ],
+      "auto_handicaps": [
+        "Rüstungsbeschränkung_mittelschwer"
+      ]
+    },
+    "Beute": {
+      "name": "Beute",
+      "kategorie": "Waldläufer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Waldläufer"
+      ],
+      "beschreibung": "Der Waldläufer wählt einen zusätzlichen Gegner- und Geländetyp für Erzfeind und Bevorzugtes Gelände.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystische Mächte (Waldläufer)": {
+      "name": "Mystische Mächte (Waldläufer)",
+      "kategorie": "Waldläufer",
+      "rang": "V",
+      "voraussetzungen": [
+        "Waldläufer"
+      ],
+      "beschreibung": "Der Waldläufer hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Athletik, Kämpfen, Schießen), Kriegersegen, Tierfreund, Verstricken nutzen kann. Alle bis auf Verstricken wirken nur auf den Waldläufer selbst.",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meisterjäger": {
+      "name": "Meisterjäger",
+      "kategorie": "Waldläufer",
+      "rang": "H",
+      "voraussetzungen": [
+        "Waldläufer"
+      ],
+      "beschreibung": "Der Jäger addiert zusätzliche W6 Schaden, wenn er einen erfolgreichen Angriff mit Athletik (Werfen), Kämpfen oder Schießen gegen einen Erzfeind ausführt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Zauberer)": {
+      "name": "AH (Zauberer)",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6",
+        "WIL W6"
+      ],
+      "beschreibung": "AH (Zauberer), Behindernde Rüstung (jede), Blutlinie",
+      "neue_maechte": 2,
+      "machtpunkte": 15,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Blutlinie"
+      ],
+      "auto_handicaps": [
+        "Behindernde Rüstung_jede"
+      ]
+    },
+    "AH (Hexenmeister)": {
+      "name": "AH (Hexenmeister)",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6",
+        "Okkultismus W4"
+      ],
+      "beschreibung": "AH (Hexenmeister), Behindernde Rüstung (jede), Vertrauter, Hexerei (1 freie Hexerei aus der Liste). Arkane Fertigkeit: Zaubern. Startet mit 2 Mächten aus der Hexenmeister-Liste. Der Vertraute speichert die Zauber des Patrons; tägliche Kommunikation mit dem Vertrauten erforderlich.",
+      "neue_maechte": 2,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "Vertrauter"
+      ],
+      "auto_handicaps": [
+        "Behindernde Rüstung_jede"
+      ]
+    },
+    "Weitere Hexerei": {
+      "name": "Weitere Hexerei",
+      "kategorie": "Hexenmeister",
+      "rang": "F",
+      "voraussetzungen": [
+        "Hexenmeister"
+      ],
+      "beschreibung": "Der:ie Hexenmeister:in kann eine neue Hexerei auswählen. Kann einmal pro Rang genommen werden. Hexereien (Auswahl): Agonie, Verstärkung, Verfluchen, Kichern, Verzaubern, Böser Blick, Heilung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Starke Hexerei": {
+      "name": "Starke Hexerei",
+      "kategorie": "Hexenmeister",
+      "rang": "V",
+      "voraussetzungen": [
+        "Hexenmeister"
+      ],
+      "beschreibung": "Der:ie Hexenmeister:in kann eine Starke Hexerei auswählen. Kann einmal pro Rang genommen werden. Starke Hexereien (Auswahl): Vettelnauge, Albträume, Vision, Wachsabbild, Wetterkontrolle.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Meisterschaft (Hexenmeister)": {
+      "name": "Arkane Meisterschaft (Hexenmeister)",
+      "kategorie": "Hexenmeister",
+      "rang": "H",
+      "voraussetzungen": [
+        "Hexenmeister"
+      ],
+      "beschreibung": "Durch ihren finsteren Patron erschließt die Hexe die Geheimnisse ihrer mystischen Kräfte. Erhält Zugriff auf alle Epischen Machtmodifikatoren ihrer Mächte.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mächtige Hexerei": {
+      "name": "Mächtige Hexerei",
+      "kategorie": "Hexenmeister",
+      "rang": "L",
+      "voraussetzungen": [
+        "Hexenmeister",
+        "Mindestens zwei Hexenmeister-Vorteile"
+      ],
+      "beschreibung": "Wild Card. Der:ie Hexenmeister:in kann eine Mächtige Hexerei auswählen. Kann einmal pro Rang genommen werden. Mächtige Hexereien (Auswahl): Todesfluch, Ewiger Schlaf, Erzwungene Wiedergeburt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bevorzugte Mächte (Zauberer)": {
+      "name": "Bevorzugte Mächte (Zauberer)",
+      "kategorie": "Zauberer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Zauberer"
+      ],
+      "beschreibung": "Als begrenzte freie Aktion kann der Zauberer bis zu zwei Punkte von Abzügen ignorieren, wenn er Geschoss, Elementarmanipulation oder Schutz wirkt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Meisterschaft (Zauberer)": {
+      "name": "Arkane Meisterschaft (Zauberer)",
+      "kategorie": "Zauberer",
+      "rang": "V",
+      "voraussetzungen": [
+        "Zauberer"
+      ],
+      "beschreibung": "Der Zauberer kann Epische Machtmodifikatoren verwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mächtige Blutlinie": {
+      "name": "Mächtige Blutlinie",
+      "kategorie": "Zauberer",
+      "rang": "H",
+      "voraussetzungen": [
+        "Zauberer"
+      ],
+      "beschreibung": "Der Zauberer erhält die mächtige Fähigkeit seiner Blutlinie.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Formationskämpfer": {
+      "name": "Formationskämpfer",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Erhöht Überzahlbonus um zusätzlich +1 (Maximum +4).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kampf mit zwei Waffen": {
+      "name": "Kampf mit zwei Waffen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Mach einen zusätzlichen Kämpfen- oder Athletik-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnelles Nachladen": {
+      "name": "Schnelles Nachladen",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Schießen W6"
+      ],
+      "beschreibung": "Verringere den Nachlade-Wert der Waffe um 1.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnelles Schießen": {
+      "name": "Schnelles Schießen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Schießen W6"
+      ],
+      "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Verbessertes Schießen": {
+      "name": "Verbessertes Schießen",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schnelles Schießen"
+      ],
+      "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Rüstung": {
+      "name": "Arkane Rüstung",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Die Behindernde Rüstung des Charakters wird um eine Stufe verbessert (beispielsweise von mittelschwer auf leicht)",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkaner Bogenschütze": {
+      "name": "Arkaner Bogenschütze",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH oder MM",
+        "Schießen W8"
+      ],
+      "beschreibung": "Pfeile verstärken für +1 Schießen und Schaden, oder Pfeile erhalten eine Ausprägung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkaner Bogenschütze II": {
+      "name": "Arkaner Bogenschütze II",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Arkaner Bogenschütze"
+      ],
+      "beschreibung": "Phasenpfeile durchdringen Barrieren, oder Pfeilhagel gilt in großer Flächenschablone.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkaner Bogenschütze III": {
+      "name": "Arkaner Bogenschütze III",
+      "kategorie": "Prestige",
+      "rang": "H",
+      "voraussetzungen": [
+        "Arkaner Bogenschütze II"
+      ],
+      "beschreibung": "Ermächtigter Pfeil mit Flächeneffekt-Macht einmal pro Zug, oder Todespfeil einmal pro Tag (Opfer das durch Pfeil Angeschlagen wird oder eine Wunde erleidet, muss Konstitutionsprobe schaffen, oder es stirbt)",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkaner Betrüger": {
+      "name": "Arkaner Betrüger",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH",
+        "Diebeskunst W8"
+      ],
+      "beschreibung": "Weitreichende Fingerfertigkeit: kann Diebeskunst mit –2 auf Entfernung von 5'' verwenden; Spontaner Angriff: Einmal pro Begegnung kann der Schwindler Hinterhältiger Angriff ohne Überraschungsangriff oder Verwundbar verwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkaner Betrüger II": {
+      "name": "Arkaner Betrüger II",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Arkaner Betrüger"
+      ],
+      "beschreibung": "Unsichtbarer Dieb: einmal pro Tag automatisch Unsichtbarkeit für 1 Machtpunkt mit automatischer Steigerung (kein Wurf)",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkaner Betrüger III": {
+      "name": "Arkaner Betrüger III",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Arkaner Betrüger II"
+      ],
+      "beschreibung": "Überraschungszauber: Die Zauber des Helden profitieren von Hinterhältiger Angriff.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Assassine": {
+      "name": "Assassine",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [],
+      "beschreibung": "Todesangriff: Wenn Assassine mit Überraschungsangriff angreift und mindestens eine Wunde erzielt, muss Opfer Konstitutionsprobe schaffen oder sterben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Assassine II": {
+      "name": "Assassine II",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Assassine"
+      ],
+      "beschreibung": "Meisterliches Verstecken: –4 um Assassinen zu sehen, wenn er sich nicht bewegt. Widerstand gegen Gift: +4 Widerstand gegen Gift",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Assassine III": {
+      "name": "Assassine III",
+      "kategorie": "Prestige",
+      "rang": "H",
+      "voraussetzungen": [
+        "Assassine II"
+      ],
+      "beschreibung": "Todesengel: Der Assassine lässt ein getötetes Opfer zu Staub zerfallen und verhindert eine Wiederauferstehung. Schneller Tod: Einmal pro Tag erhält der Assassine einen Überraschungsangriff gegen ein Opfer seiner Wahl.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Drachenjünger": {
+      "name": "Drachenjünger",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH oder MM",
+        "Okkultismus W6"
+      ],
+      "beschreibung": "Odemangriff: 3W6 Schaden plus Ausprägung, Kegelschablone, einmal pro Begegnung",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Drachenjünger II": {
+      "name": "Drachenjünger II",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Drachenjünger"
+      ],
+      "beschreibung": "Schwingen: Charakter erhält Flügel für Flug, Bewegungsweite 8.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Drachenjünger III": {
+      "name": "Drachenjünger III",
+      "kategorie": "Prestige",
+      "rang": "H",
+      "voraussetzungen": [
+        "Drachenjünger II"
+      ],
+      "beschreibung": "Drachengestalt: Zweimal pro Tag kann der Drachenjünger als beschränkte Aktion die Gestalt eines Drachens seiner Blutlinie annehmen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Duellant": {
+      "name": "Duellant",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Geschicklichkeit W8",
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Chirurgischer Schlag: +2 Schaden mit bestimmten Waffen. Parieren: Duellant kann sich Verteidigen, wenn er noch nicht gehandelt hat, mit Paradebonus +6.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Duellant II": {
+      "name": "Duellant II",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Duellant"
+      ],
+      "beschreibung": "Schwächender Schlag: Verringere Bewegungsweite des Gegners um 2 bis geheilt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Duellant III": {
+      "name": "Duellant III",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Duellant II"
+      ],
+      "beschreibung": "Geschosse abwehren: –2, um mit physischen Fernkampfangriffen getroffen zu werden",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kundschafter-Chronist": {
+      "name": "Kundschafter-Chronist",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Überleben W6",
+        "Allgemeinwissen oder Okkultismus W8"
+      ],
+      "beschreibung": "Finden des Weges: Erhöht Reisegeschwindigkeit um 10 %, kann feindliche Begegnung umgehen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kundschafter-Chronist II": {
+      "name": "Kundschafter-Chronist II",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kundschafter-Chronist"
+      ],
+      "beschreibung": "Epische Geschichten: Erzähle bei der Rast eine Geschichte, um Gruppe einen Benny zu gewähren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kundschafter-Chronist III": {
+      "name": "Kundschafter-Chronist III",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Kundschafter-Chronist II"
+      ],
+      "beschreibung": "Rufen der Legenden: Beschwöre 5 Schatten für eine Stunde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystischer Ritter": {
+      "name": "Mystischer Ritter",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH",
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Mystische Aufladung: Erhalte Machtpunkt bei Steigerung mit Angriff oder arkaner Fertigkeit.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystischer Ritter II": {
+      "name": "Mystischer Ritter II",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Mystischer Ritter"
+      ],
+      "beschreibung": "Mystischer Schlag: Gib 2 Machtpunkte nach Angriff aus, und addiere +2 auf Angriff.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystischer Ritter III": {
+      "name": "Mystischer Ritter III",
+      "kategorie": "Prestige",
+      "rang": "H",
+      "voraussetzungen": [
+        "Mystischer Ritter II"
+      ],
+      "beschreibung": "Verb. Mystischer Schlag: Gib zwei Machtpunkte aus, nachdem du einen erfolgreichen Angriffswurf abgelegt hat, um den Schaden des Angriffs um +2 zu erhöhen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystischer Theurg": {
+      "name": "Mystischer Theurg",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (beliebig)"
+      ],
+      "beschreibung": "Magiefusion: Wirke zwei Zauber auf einmal und würfle eine arkane Fertigkeit für jede sowie den Wildcard-Würfel.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystischer Theurg II": {
+      "name": "Mystischer Theurg II",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Mystischer Theurg"
+      ],
+      "beschreibung": "Zaubersynergie: Verringere die Kosten beider Zauber wenn du Magiefusion verwendest.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystischer Theurg III": {
+      "name": "Mystischer Theurg III",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Mystischer Theurg II"
+      ],
+      "beschreibung": "Zaubersynthese: Klassentalente sind für alle Mächte verfügbar.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schattentänzer": {
+      "name": "Schattentänzer",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Darbietung W6",
+        "Heimlichkeit W8",
+        "Diebeskunst W6"
+      ],
+      "beschreibung": "Mächtige Dunkelsicht: Sehen in absoluter oder magischer Dunkelheit",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schattentänzer II": {
+      "name": "Schattentänzer II",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Schattentänzer"
+      ],
+      "beschreibung": "Schattenmantel: freies Schaden wegstecken mit –2 in Düsterer oder Dunkler Beleuchtung",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schattentänzer III": {
+      "name": "Schattentänzer III",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schattentänzer II"
+      ],
+      "beschreibung": "Mystische Mächte (Schattenkraft): 10 gewidmete Machtpunkte zum Wirken von Flächenschlag, Illusion, Teleportation oder Verbündeten beschwören (nur Schatten) (nur selbst)",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wissenshüter": {
+      "name": "Wissenshüter",
+      "kategorie": "Prestige",
+      "rang": "F",
+      "voraussetzungen": [
+        "Ver W8"
+      ],
+      "beschreibung": "Legendenkunde: freie Wiederholung bei Allgemeinwissen, Geisteswissenschaften, Okkultismus oder Naturwissenschaften",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wissenshüter II": {
+      "name": "Wissenshüter II",
+      "kategorie": "Prestige",
+      "rang": "V",
+      "voraussetzungen": [
+        "Wissenshüter"
+      ],
+      "beschreibung": "Geheimnis: Erhalte eine Fähigkeit eines Kern-Klassentalents.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wissenshüter III": {
+      "name": "Wissenshüter III",
+      "kategorie": "Prestige",
+      "rang": "H",
+      "voraussetzungen": [
+        "Wissenshüter II"
+      ],
+      "beschreibung": "Höhere Legendenkunde: Erhalte 2 neue Mächte, die in der Kampagne verfügbar sind.",
+      "neue_maechte": 2,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Chi": {
+      "name": "Chi",
+      "kategorie": "Übersinnlich",
+      "rang": "V",
+      "voraussetzungen": [
+        "Kampfkunstmeister"
+      ],
+      "beschreibung": "Einmal pro Kampf kannst du eine misslungene Kämpfenprobe wiederholen, einen Gegner einen erfolgreichen Angriff wiederholen lassen oder +W6 Schaden auf einen waffenlosen Angriff addieren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mut in Flaschen": {
+      "name": "Mut in Flaschen",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [
+        "KON W8"
+      ],
+      "beschreibung": "Alkohol erhöht Konstitution um einen Würfeltyp und du ignorierst eine Stufe Wundabzüge; –1 Geschicklichkeit, Verstand und verknüpfte Fertigkeiten.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Eiserner Wille": {
+      "name": "Eiserner Wille",
+      "kategorie": "Sozial",
+      "rang": "F",
+      "voraussetzungen": [
+        "Mutig",
+        "Starker Wille"
+      ],
+      "beschreibung": "Der Bonus gilt jetzt zum Widerstehen und Erholen von Mächten.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnell": {
+      "name": "Schnell",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Held kann Aktionskarten von 5 oder weniger abwerfen und neu ziehen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Riesentöter": {
+      "name": "Riesentöter",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "+1W6 Schaden gegen Kreaturen, deren Größe die eigene um 3 oder mehr übersteigt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ermittler": {
+      "name": "Ermittler",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W8",
+        "Geisteswissenschaften W8"
+      ],
+      "beschreibung": "+2 Geisteswissenschaften und auf bestimmte Wahrnehmungsproben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Gelehrter": {
+      "name": "Gelehrter",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W8"
+      ],
+      "beschreibung": "+2 auf eine Wissensfertigkeit",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Reparaturgenie": {
+      "name": "Reparaturgenie",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "Reparieren W8"
+      ],
+      "beschreibung": "+2 auf Reparieren, halbe Zeit bei Steigerung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Alchemist)": {
+      "name": "AH (Alchemist)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Arkane Fertigkeit: Alchemie (Verstand)",
+      "neue_maechte": 3,
+      "machtpunkte": 15,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Chemiker": {
+      "name": "Chemiker",
+      "kategorie": "Alchemist",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Alchemist)",
+        "Alchemie W8"
+      ],
+      "beschreibung": "Die Gebräue des Alchemisten halten eine Woche statt 48 Stunden, wenn sie an andere weitergegeben werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meisterlicher Alchemist": {
+      "name": "Meisterlicher Alchemist",
+      "kategorie": "Alchemist",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Alchemist)",
+        "Alchemie W10"
+      ],
+      "beschreibung": "Erlaubt die Herstellung permanenter Tränke zu halb so hohen Kosten mit improvisierten Vorräten oder einer Alchemistentasche.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Grabgesang": {
+      "name": "Grabgesang",
+      "kategorie": "Barde",
+      "rang": "H",
+      "voraussetzungen": [
+        "AH (Barde)"
+      ],
+      "beschreibung": "Löst Furcht aus und reduziert Proben von Feinden um -2, wenn sie Bennys verwenden. Der Barde muss singen oder ein Instrument spielen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Heldentum inspirieren": {
+      "name": "Heldentum inspirieren",
+      "kategorie": "Barde",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Barde)",
+        "Darbietung W8"
+      ],
+      "beschreibung": "Erlaubt es, fünf Inspirations-Marker zu generieren, die Kameraden Boni auf Proben oder Schadenswürfe geben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Instrument": {
+      "name": "Instrument",
+      "kategorie": "Barde",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Barde)"
+      ],
+      "beschreibung": "Bietet +1 auf Darbietungsproben, wenn ein Instrument beim Zaubern verwendet wird.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Beschwörer)": {
+      "name": "AH (Beschwörer)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+      "neue_maechte": 5,
+      "machtpunkte": 15,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Diabolist)": {
+      "name": "AH (Diabolist)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+      "neue_maechte": 5,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Elementarist)": {
+      "name": "AH (Elementarist)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+      "neue_maechte": 5,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Illusionist)": {
+      "name": "AH (Illusionist)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+      "neue_maechte": 5,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Nekromant)": {
+      "name": "AH (Nekromant)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+      "neue_maechte": 5,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Schamane)": {
+      "name": "AH (Schamane)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6"
+      ],
+      "beschreibung": "Arkane Fertigkeit: Glaube (Willenskraft)",
+      "neue_maechte": 5,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "AH (Tüftler)": {
+      "name": "AH (Tüftler)",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Arkane Fertigkeit: Reparieren (Verstand)",
+      "neue_maechte": 2,
+      "machtpunkte": 15,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Stärkung": {
+      "name": "Arkane Stärkung",
+      "kategorie": "Beschwörer",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Beschwörer)"
+      ],
+      "beschreibung": "Beschworene Tiere erhalten einen magischen Harnisch, der ihre Robustheit um +2 erhöht.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ungezügelte Beschwörung": {
+      "name": "Ungezügelte Beschwörung",
+      "kategorie": "Beschwörer",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Beschwörer)"
+      ],
+      "beschreibung": "Erlaubt dem Beschwörer, beschworenen Monstern ein Kampftalent seines Rangs oder niedriger zu gewähren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Höhere Beschwörung": {
+      "name": "Höhere Beschwörung",
+      "kategorie": "Beschwörer",
+      "rang": "H",
+      "voraussetzungen": [
+        "AH (Beschwörer)"
+      ],
+      "beschreibung": "Erlaubt das Beschwören mächtiger Kreaturen wie Barghest, Mammut, Frostmammut, Tyrannosaurus Rex oder jungen Drachen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zorn der Hölle": {
+      "name": "Zorn der Hölle",
+      "kategorie": "Diabolist",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Diabolist)"
+      ],
+      "beschreibung": "Mächte wie Flächenschlag, Geschoss und Strahl verursachen +2 Schaden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Infernale Rüstung": {
+      "name": "Infernale Rüstung",
+      "kategorie": "Diabolist",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Diabolist)"
+      ],
+      "beschreibung": "Verleiht +2 Rüstung durch eine höllische Aura, macht Heimlichkeit jedoch nahezu unmöglich.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Herzholzstab": {
+      "name": "Herzholzstab",
+      "kategorie": "Druide",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Druide)"
+      ],
+      "beschreibung": "Ein Kampfstab, der zusätzlichen Schaden verursacht und bei Verlust durch ein Ritual ersetzt werden kann.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wahre Form": {
+      "name": "Wahre Form",
+      "kategorie": "Druide",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Druide)"
+      ],
+      "beschreibung": "Ermöglicht Druiden, in Tierform zu sprechen und Mächte zu wirken, mit Risiken bei längerem Verweilen in Tiergestalt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Elementare Absorption": {
+      "name": "Elementare Absorption",
+      "kategorie": "Elementarmagier",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Elementarmagier)"
+      ],
+      "beschreibung": "Erhöht Robustheit um +2 während der Nutzung von Elementarsynergie.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Elementarer Meister": {
+      "name": "Elementarer Meister",
+      "kategorie": "Elementarmagier",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Elementarist)"
+      ],
+      "beschreibung": "Erlaubt die Beherrschung eines zusätzlichen Elements, Mächte können zwischen Elementen gewechselt werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Böser Blick": {
+      "name": "Böser Blick",
+      "kategorie": "Hexer/Hexe",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Hexer/Hexe)"
+      ],
+      "beschreibung": "Zwingt Feinde zu Willenskraftproben mit -2 bei der Nutzung von Bennys, die fehlschlagen können.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Hexenzeit": {
+      "name": "Hexenzeit",
+      "kategorie": "Hexer/Hexe",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Hexer/Hexe)"
+      ],
+      "beschreibung": "Verleiht Boni während einer besonderen Stunde, z. B. keine Kritischen Fehlschläge und kostenloses Wegstecken von Schaden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Tödliche Illusion": {
+      "name": "Tödliche Illusion",
+      "kategorie": "Illusionist",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Illusionist)",
+        "Zaubern W10"
+      ],
+      "beschreibung": "Erlaubt den Einsatz des Machtmodifikators Tödliche Illusion ohne zusätzliche Machtpunkte.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meisterlicher Illusionist": {
+      "name": "Meisterlicher Illusionist",
+      "kategorie": "Illusionist",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Illusionist)",
+        "Zaubern W8"
+      ],
+      "beschreibung": "Illusionen erhalten die Machtmodifikatoren Beweglich und Geräusch ohne zusätzliche Machtpunkte.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Untote zerstören": {
+      "name": "Untote zerstören",
+      "kategorie": "Kleriker",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Kleriker)"
+      ],
+      "beschreibung": "Kanalisierung positiver Energie, um Untote mit 2W6 (oder 3W6 für 2 Machtpunkte) Schaden zu treffen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Gnade": {
+      "name": "Gnade",
+      "kategorie": "Kleriker",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Kleriker)",
+        "Glaube W8"
+      ],
+      "beschreibung": "Hebt Abgelenkt, Angeschlagen oder Verwundbar durch Einsatz von 1 Machtpunkt auf.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Unheimliche Inspiration": {
+      "name": "Unheimliche Inspiration",
+      "kategorie": "Magier",
+      "rang": "H",
+      "voraussetzungen": [
+        "AH (Magier)"
+      ],
+      "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht mit einem Benny, solange Zugang zu Zauberbüchern besteht.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zauberbücher": {
+      "name": "Zauberbücher",
+      "kategorie": "Magier",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Magie)"
+      ],
+      "beschreibung": "Erhält drei neue Mächte bei Wahl des Talents Neue Mächte und sofort eine Macht des eigenen Ranges.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Seelengefäß": {
+      "name": "Seelengefäß",
+      "kategorie": "Nekromant",
+      "rang": "L",
+      "voraussetzungen": [
+        "AH (Nekromant)",
+        "Okkultismus W10"
+      ],
+      "beschreibung": "Versteckt die Seele in einem Behälter, um nach dem Tod in einen vorbereiteten Leichnam zurückzukehren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Untoter Vertrauter": {
+      "name": "Untoter Vertrauter",
+      "kategorie": "Nekromant",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Nekromant)"
+      ],
+      "beschreibung": "Erhält einen untoten Tiergefährten mit speziellen Boni, ähnlich wie das Talent Vertrauter.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Urtümliche Magie": {
+      "name": "Urtümliche Magie",
+      "kategorie": "Schamane",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Schamane)"
+      ],
+      "beschreibung": "Erhöht Schaden von Mächten um +2, verursacht jedoch bei Kritischen Fehlschlägen Betäubung im Umkreis.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Geweihter Fetisch": {
+      "name": "Geweihter Fetisch",
+      "kategorie": "Schamane",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Schamane)",
+        "Glaube W8"
+      ],
+      "beschreibung": "Verleiht eine Freie Wurfwiederholung bei Glaubensproben, wenn ein geweihter Fetisch genutzt wird.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Konstrukt-Vertrauter": {
+      "name": "Konstrukt-Vertrauter",
+      "kategorie": "Tüftler",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Tüftler)"
+      ],
+      "beschreibung": "Erhält einen mechanischen Tiergefährten mit speziellen Vorteilen, ähnlich wie das Talent Vertrauter.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Tüftlerrüstung": {
+      "name": "Tüftlerrüstung",
+      "kategorie": "Tüftler",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Tüftler)"
+      ],
+      "beschreibung": "Ermöglicht modifizierte Rüstung mit Boni auf Arme, Rumpf oder Beine, unterliegt jedoch Ausfällen bei Wunden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Große Macht": {
+      "name": "Große Macht",
+      "kategorie": "Zauberer",
+      "rang": "V",
+      "voraussetzungen": [
+        "AH (Zauberer)"
+      ],
+      "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht bis 20 Machtpunkte mit einem Abzug von -2 auf die Zaubernprobe.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Phänomenale Macht": {
+      "name": "Phänomenale Macht",
+      "kategorie": "Zauberer",
+      "rang": "H",
+      "voraussetzungen": [
+        "AH (Zauberer)",
+        "Große Macht"
+      ],
+      "beschreibung": "Erlaubt das Wirken jeder Macht mit Entschlossenheit und fügt den Entschlossenheitsbonus dem Zauberwurf hinzu.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Auserkoren": {
+      "name": "Auserkoren",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Entschlossenheit hält bis zum Ende der Begegnung an, ohne dass sie mit Bennys aufrechterhalten werden muss. Der Charakter hat ein unverkennbares Mal und wird von mächtigen Feinden verfolgt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bevorzugtes Gelände": {
+      "name": "Bevorzugtes Gelände",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Überleben W6"
+      ],
+      "beschreibung": "Wähle ein Geländetyp. In diesem Gelände erhält der Charakter eine freie Wiederholung bei Überlebens- und Wahrnehmungsproben sowie eine zusätzliche Aktionskarte zur Initiative.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Erbstück": {
+      "name": "Erbstück",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Gewährt einen magischen Gegenstand im Wert von bis zu 10.000 Goldmünzen. Der Gegenstand muss bei Verlust durch ein Abenteuer wiedergefunden werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Erzfeind": {
+      "name": "Erzfeind",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Athletik W6",
+        "Kämpfen oder Schießen W6"
+      ],
+      "beschreibung": "Wähle eine Art von Feind. Der Charakter erhält eine freie Wiederholung bei Überlebensproben, um diese zu verfolgen, und bei Angriffen auf diese Feinde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Feenblütig": {
+      "name": "Feenblütig",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Gewährt eine freie Wiederholung, um feindlichen Mächten und zauberähnlichen Effekten zu widerstehen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Betäubungsschlag": {
+      "name": "Betäubungsschlag",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "STÄ W8"
+      ],
+      "beschreibung": "Schläge mit stumpfen Waffen zwingen Gegner zu Konstitutionsproben. Bei einem Misserfolg wird der Gegner Betäubt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Böe": {
+      "name": "Böe",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [],
+      "beschreibung": "Mächtige Flügelschläge können Gegner in einem Kegel Angeschlagen machen oder Betäuben, wenn ein Joker gezogen wird.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Doppelschuss": {
+      "name": "Doppelschuss",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Athletik W8 für Wurfwaffen oder Schießen W8 für Bögen"
+      ],
+      "beschreibung": "Erlaubt das Schießen oder Werfen von zwei Geschossen in einem Angriff mit separaten Angriffswürfen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Vierfachschuss": {
+      "name": "Vierfachschuss",
+      "kategorie": "Kampf",
+      "rang": "H",
+      "voraussetzungen": [
+        "Doppelschuss",
+        "Athletik W10 für Wurfwaffen oder Schießen W10 für Bögen"
+      ],
+      "beschreibung": "Erlaubt das zweimalige Nutzen des Talents Doppelschuss pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Unglaubliche Reflexe": {
+      "name": "Unglaubliche Reflexe",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Geschicklichkeit W8",
+        "Athletik W8"
+      ],
+      "beschreibung": "Der Charakter ignoriert den üblichen -2 Geschicklichkeits-Abzug beim Wegspringen und kann bei Flächeneffekten oder Angriffen wie Strahl oder Verwirrung Wegspringen anwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Versengen": {
+      "name": "Versengen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "KON W8"
+      ],
+      "beschreibung": "Erhöht den Schaden einer Odemwaffe um einen Würfeltyp und erlaubt die Wahl zwischen Kegel- und Strahlschablone.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Verteidiger": {
+      "name": "Verteidiger",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Erlaubt das Teilen des Parade- und Deckungsbonus eines Schildes mit einem Verbündeten in der Nähe als freie Aktion.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wildling": {
+      "name": "Wildling",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Ein Rücksichtsloser Angriff verursacht +4 Schaden statt +2.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zerschmettern": {
+      "name": "Zerschmettern",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W8"
+      ],
+      "beschreibung": "Fügt bei Angriffen auf Objekte +W6 Schaden hinzu, wobei die Schadenswürfel nicht explodieren können.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Artefakterschaffer": {
+      "name": "Artefakterschaffer",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (beliebig)"
+      ],
+      "beschreibung": "Erlaubt die Herstellung von temporären Arkane Apparaturen und permanenter magischer Gegenstände.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meisterlicher Artefakterschaffer": {
+      "name": "Meisterlicher Artefakterschaffer",
+      "kategorie": "Macht",
+      "rang": "H",
+      "voraussetzungen": [
+        "Artefakterschaffer",
+        "Okkultismus W10"
+      ],
+      "beschreibung": "Erhöht die Belohnung für Okkultismusproben bei der Herstellung magischer Gegenstände auf 1000 G pro Erfolg oder Steigerung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bevorzugte Macht": {
+      "name": "Bevorzugte Macht",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (beliebig)",
+        "Glaube oder Zaubern W8"
+      ],
+      "beschreibung": "Erlaubt das Ignorieren von bis zu zwei Punkten Abzügen bei der Aktivierung einer ausgewählten Macht.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Blutmagie": {
+      "name": "Blutmagie",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (beliebig)"
+      ],
+      "beschreibung": "Gewährt W6 Machtpunkte zurück, wenn der Charakter einem bewussten Wesen eine Wunde zufügt, die nicht weggesteckt wird.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Epische Meisterschaft": {
+      "name": "Epische Meisterschaft",
+      "kategorie": "Macht",
+      "rang": "V",
+      "voraussetzungen": [
+        "AH (beliebig)",
+        "Glaube oder Zaubern W6"
+      ],
+      "beschreibung": "Gewährt Zugang zu epischen Machtmodifikatoren für alle Mächte des Helden. Gilt für alle arkanen Hintergründe, die der Charakter besitzt, wenn er die Voraussetzungen erfüllt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystische Kräfte": {
+      "name": "Mystische Kräfte",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "Fortgeschritten"
+      ],
+      "beschreibung": "Erlaubt das Erlernen von 10 dedizierten Machtpunkten mit ausgewählten Mächten, die automatisch aktiviert werden können. Die Mächte und Einschränkungen sind abhängig vom gewählten Paket (z. B. Barbar, Kämpfer, Mönch, etc.).",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schlachtenmagie": {
+      "name": "Schlachtenmagie",
+      "kategorie": "Macht",
+      "rang": "V",
+      "voraussetzungen": [
+        "AH (beliebig)",
+        "Glaube oder Zaubern W10"
+      ],
+      "beschreibung": "Erlaubt das Wirken von Zaubern auf große Einheiten von Statisten. Siehe Regeln für Schlachtenmagie.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Stillzauberer": {
+      "name": "Stillzauberer",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (jeder außer Barde)",
+        "Okkultismus W8"
+      ],
+      "beschreibung": "Erlaubt das Wirken von Zaubern ohne zu sprechen. Funktioniert auch unter Wasser, in einem Vakuum, oder innerhalb der Macht Stille.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Übertragung": {
+      "name": "Übertragung",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (beliebig)"
+      ],
+      "beschreibung": "Erlaubt das Übertragen von bis zu fünf Machtpunkten auf eine andere Person in Sichtweite als begrenzte freie Aktion.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Vertrauter": {
+      "name": "Vertrauter",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Diabolist, Druide, Elementarmagier, Schamane, Hexer, Nekromant, Hexer, Zauberer, Hexenmeister)"
+      ],
+      "beschreibung": "Gewährt einen loyalen magischen Begleiter, der 5 eigene Machtpunkte hat und als Wildcard fungiert. Der Vertraute kann keine Zauber wirken, aber der Meister kann auf seine Machtpunkte zugreifen.",
+      "neue_maechte": 0,
+      "machtpunkte": 5,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Entdecker": {
+      "name": "Entdecker",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "KON W6",
+        "Überleben W8"
+      ],
+      "beschreibung": "Ermöglicht eine zusätzliche Aktionskarte bei Reisen und verkürzt die Reisezeit der Gruppe um 10%.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Fallengespür": {
+      "name": "Fallengespür",
+      "kategorie": "Experte",
+      "rang": "F",
+      "voraussetzungen": [
+        "Reparieren W6"
+      ],
+      "beschreibung": "Ermöglicht eine Wahrnehmungsprobe zum Erkennen von Fallen in 10 Metern Entfernung und ignoriert 2 Punkte Abzüge beim Entschärfen von Fallen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Giftmischer": {
+      "name": "Giftmischer",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "Alchemie, Heilen oder Überleben W6"
+      ],
+      "beschreibung": "Erstellt Gifte in der Hälfte der Zeit, die Kontaktgifte halten 12 statt 4 Stunden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Im Sattel geboren": {
+      "name": "Im Sattel geboren",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "Geschicklichkeit W8",
+        "Reiten W6"
+      ],
+      "beschreibung": "Verleiht eine freie Wiederholung bei Reitenproben, erhöht die Bewegungsweite des Reittiers um 2 und den Sprintwürfel um einen Würfeltyp.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kundschafter": {
+      "name": "Kundschafter",
+      "kategorie": "Experte",
+      "rang": "F",
+      "voraussetzungen": [
+        "Überleben W6"
+      ],
+      "beschreibung": "Ermöglicht Wahrnehmungsproben zum frühzeitigen Erkennen von Gefahren, verbessert Wachsamkeit und gibt Boni auf Allgemeinwissen über bereiste Orte.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Reittier": {
+      "name": "Reittier",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "Reiten W6"
+      ],
+      "beschreibung": "Gewährt ein treues, aufsteigbares Reittier mit besonderen Fähigkeiten. Ermöglicht die Wahl eines mächtigen Reittiers auf höheren Rängen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ritter": {
+      "name": "Ritter",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "STÄ W8",
+        "KON W8",
+        "Kämpfen W8",
+        "Reiten W6"
+      ],
+      "beschreibung": "Repräsentiert einen Lehnsherrn, gewährt +1 auf Einschüchtern- oder Überredenproben gegenüber Autorität-respektierenden Personen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schatzjäger": {
+      "name": "Schatzjäger",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "Wahrnehmung W8",
+        "Okkultismus W8"
+      ],
+      "beschreibung": "Erlaubt Verstandsproben zur Einschätzung von Schätzen und magischen Gegenständen. Ermöglicht das Neuwürfeln von magischen Gegenstandseffekten mit einem Benny.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Steingespür": {
+      "name": "Steingespür",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "Reparieren W6"
+      ],
+      "beschreibung": "Erhöht Wahrnehmungsproben um +2, um Fallen oder versteckte Türen in Stein zu entdecken.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Troubadour": {
+      "name": "Troubadour",
+      "kategorie": "Experte",
+      "rang": "F",
+      "voraussetzungen": [
+        "Allgemeinwissen W6",
+        "Darbietung W8"
+      ],
+      "beschreibung": "Gewährt +2 auf Allgemeinwissenproben und erlaubt die Nutzung von Darbietung statt Kriegskunst für Anführertalente.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Täuscher": {
+      "name": "Täuscher",
+      "kategorie": "Sozial",
+      "rang": "F",
+      "voraussetzungen": [
+        "VER W8"
+      ],
+      "beschreibung": "Erlaubt das Ziel, bei Herausforderungen entweder mit Verstand oder Willenskraft zu widerstehen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Aura der Tapferkeit": {
+      "name": "Aura der Tapferkeit",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Verbündete im Umkreis von 20 Metern erhalten +1 auf Furchtproben und -1 auf der Furchttabelle.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bestienflüsterer": {
+      "name": "Bestienflüsterer",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Erlaubt es, mit einer Tiergattung zu kommunizieren und Informationen von ihnen zu erhalten, abhängig von ihrer Intelligenz.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnelle Verwandlung": {
+      "name": "Schnelle Verwandlung",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Erlaubt eine Formveränderung als begrenzte Aktion statt der üblichen 10 Minuten.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Aristokrat": {
+      "name": "Aristokrat",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "+2 auf Allgemeinwissen und Informationsbeschaffung in der Oberschicht.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Resistenz": {
+      "name": "Arkane Resistenz",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –2 verringert.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Starke Arkane Resistenz": {
+      "name": "Starke Arkane Resistenz",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Arkane Resistenz"
+      ],
+      "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –4 verringert.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Attraktiv": {
+      "name": "Attraktiv",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "KON W6"
+      ],
+      "beschreibung": "+1 auf Darbietung und Überreden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Sehr Attraktiv": {
+      "name": "Sehr Attraktiv",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Attraktiv"
+      ],
+      "beschreibung": "+2 auf Darbietung und Überreden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Aufmerksamkeit": {
+      "name": "Aufmerksamkeit",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "+2 auf Wahrnehmungsproben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Beidhändig": {
+      "name": "Beidhändig",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Ignoriere den Abzug von –2 für Aktionen mit der falschen Hand.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bekannt": {
+      "name": "Bekannt",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "+1 auf Überredenproben, wenn erkannt (Allgemeinwissen), doppelte normale Summe für Darbietung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Berühmt": {
+      "name": "Berühmt",
+      "kategorie": "Hintergrund",
+      "rang": "F",
+      "voraussetzungen": [
+        "Bekannt"
+      ],
+      "beschreibung": "+2 auf Überredenproben, wenn erkannt (Allgemeinwissen), fünffache normale Summe oder mehr für Darbietung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Charismatisch": {
+      "name": "Charismatisch",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Freie Wiederholung bei der Verwendung von Überreden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Elan": {
+      "name": "Elan",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "+2 beim Ausgeben eines Bennys für die Wiederholung einer Eigenschaftsprobe.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Flink": {
+      "name": "Flink",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W6"
+      ],
+      "beschreibung": "Bewegungsweite +2, erhöhe Sprintwürfel um einen Schritt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Glück": {
+      "name": "Glück",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "+1 Benny zu Beginn jeder Sitzung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Großes Glück": {
+      "name": "Großes Glück",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Glück"
+      ],
+      "beschreibung": "+2 Bennys zu Beginn jeder Sitzung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kräftig": {
+      "name": "Kräftig",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W6",
+        "KON W6"
+      ],
+      "beschreibung": "Größe (und somit Robustheit) +1. Behandle Stärke als einen Würfeltyp höher für Belastung und Mindeststärke bei Waffen, Rüstung und Ausrüstung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Linguist": {
+      "name": "Linguist",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Charakter hat einen W6 in Sprachen gleich halbem Verstandswürfel.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mutig": {
+      "name": "Mutig",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6"
+      ],
+      "beschreibung": "+2 auf Furchtproben und –2 bei Würfen auf der Furchttabelle.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Reich": {
+      "name": "Reich",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Charakter beginnt mit dreifachem Startkapital und einem Jahreseinkommen von $150.000.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Stinkreich": {
+      "name": "Stinkreich",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Reich"
+      ],
+      "beschreibung": "Fünffaches Startkapital und $500.000 Jahreseinkommen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Rohling": {
+      "name": "Rohling",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W6",
+        "KON W6"
+      ],
+      "beschreibung": "Verknüpfe Athletik mit Stärke anstelle von Geschicklichkeit (auch für Herausfordern). Kurze Entfernung von geworfenen Gegenständen +1. Verdopple den Bonus für die angepasste mittlere Entfernung und nochmal für die weite Entfernung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnelle Heilung": {
+      "name": "Schnelle Heilung",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "KON W8"
+      ],
+      "beschreibung": "+2 Konstitution für natürliche Heilung, Wurf alle 3 Tage.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ausweichen": {
+      "name": "Ausweichen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "–2 bei Angriffen durch Fernkampfwaffen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnelles Ausweichen": {
+      "name": "Schnelles Ausweichen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Ausweichen"
+      ],
+      "beschreibung": "+2 auf Wegspringen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Beidhändiger Fernkampf": {
+      "name": "Beidhändiger Fernkampf",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Führe einen zusätzlichen Angriff mit Athletik (Werfen) oder Schießen mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Beidhändiger Kampf": {
+      "name": "Beidhändiger Kampf",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Führe einen zusätzlichen Kämpfen-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Berechnend": {
+      "name": "Berechnend",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W8"
+      ],
+      "beschreibung": "Ignoriere 2 Punkte Abzüge bei einer Aktion mit einer Aktionskarte von 5 oder weniger.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Block": {
+      "name": "Block",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfen W8"
+      ],
+      "beschreibung": "+1 Parade, ignoriere 1 Punkt Überzahlbonus.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Harter Block": {
+      "name": "Harter Block",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Block"
+      ],
+      "beschreibung": "+2 Parade, ignoriere 2 Punkt Überzahlbonus.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Eisenkiefer": {
+      "name": "Eisenkiefer",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "KON W8"
+      ],
+      "beschreibung": "+2 auf Schaden wegstecken und Konstitutionsproben, um K.O.-Schlägen zu widerstehen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Erstschlag": {
+      "name": "Erstschlag",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Freier Kämpfen-Angriff einmal pro Runde, wenn sich ein Feind in Reichweite bewegt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schneller Erstschlag": {
+      "name": "Schneller Erstschlag",
+      "kategorie": "Kampf",
+      "rang": "H",
+      "voraussetzungen": [
+        "Erstschlag"
+      ],
+      "beschreibung": "Freie Kämpfen-Angriffe gegen bis zu drei Gegner, wenn sie sich in Reichweite bewegen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Finte": {
+      "name": "Finte",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Du kannst einen Feind bei einer Kämpfen-Herausforderung mit Verstand statt mit Geschicklichkeit widerstehen lassen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Improvisationsgabe": {
+      "name": "Improvisationsgabe",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Ignoriere den Abzug von –2, wenn du mit improvisierten Waffen angreifst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kampfkünstler": {
+      "name": "Kampfkünstler",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Unbewaffnetes Kämpfen +1, Fäuste und Füße zählen als Natürliche Waffen, addiere W4 auf den Schaden unbewaffneter Angriffe (oder erhöhe den Schaden um einen Würfeltyp, wenn du bereits einen Würfel hast).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kampfkunstmeister": {
+      "name": "Kampfkunstmeister",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kampfkünstler"
+      ],
+      "beschreibung": "Unbewaffnetes Kämpfen +2, erhöhe Schadenswürfel um einen Würfeltyp.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kampfreflexe": {
+      "name": "Kampfreflexe",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [],
+      "beschreibung": "+2 Erholungsproben gegen Angeschlagen oder Betäubt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Keine Gnade": {
+      "name": "Keine Gnade",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [],
+      "beschreibung": "+2 Schaden, wenn du einen Benny ausgibst, um den Schadenswurf zu wiederholen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Killerinstinkt": {
+      "name": "Killerinstinkt",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [],
+      "beschreibung": "Freie Wiederholung für vergleichende Proben, wenn er Herausfordern einleitet.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kühler Kopf": {
+      "name": "Kühler Kopf",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "VER W8"
+      ],
+      "beschreibung": "Ziehe jede Runde eine zusätzliche Aktionskarte und wähle, welche du verwenden willst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Sehr Kühler Kopf": {
+      "name": "Sehr Kühler Kopf",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kühler Kopf"
+      ],
+      "beschreibung": "Ziehe jede Runde zwei zusätzliche Aktionskarten und wähle, welche du verwenden willst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Lieblingswaffe": {
+      "name": "Lieblingswaffe",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Kämpfen oder Schießen W8"
+      ],
+      "beschreibung": "+1 auf Athletik (Werfen), Kämpfen oder Schießen mit einer bestimmten Waffe; +1 Parade, wenn die Waffe bereit ist.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Absolute Lieblingswaffe": {
+      "name": "Absolute Lieblingswaffe",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Lieblingswaffe"
+      ],
+      "beschreibung": "Der Bonus auf Angriff und Parade steigt auf +2.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mächtiger Hieb": {
+      "name": "Mächtiger Hieb",
+      "kategorie": "Kampf",
+      "rang": "WC",
+      "voraussetzungen": [
+        "A",
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden des ersten erfolgreichen Kämpfen-Angriffs in dieser Runde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meisterschütze": {
+      "name": "Meisterschütze",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Athletik oder Schießen W8"
+      ],
+      "beschreibung": "Bei erster Aktion +1 Bonus oder ignoriere bis zu 2 Punkte Abzüge auf Athletik (Werfen) oder Schießen, wenn du dich nicht bewegst und nicht mehr als FR 1 verwendest.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Parkour": {
+      "name": "Parkour",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Ignoriere Schwieriges Gelände und addiere +2 auf Athletikproben in Verfolgungsjagden zu Fuß.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Raufbold": {
+      "name": "Raufbold",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W8",
+        "KON W8"
+      ],
+      "beschreibung": "Robustheit +1, addiere W4 zum Schaden von Fäusten oder erhöhe Würfeltyp bei Kombination mit Kampfkünstler, Klauen oder ähnlichen Fähigkeiten.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schläger": {
+      "name": "Schläger",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Raufbold"
+      ],
+      "beschreibung": "Erhöhe unbewaffneten Schaden um einen Würfeltyp und Robustheit noch einmal um +1.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Riposte": {
+      "name": "Riposte",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Freier Angriff gegen einen Feind, der eine Kämpfenprobe nicht geschafft hat.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Geschickte Riposte": {
+      "name": "Geschickte Riposte",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Riposte"
+      ],
+      "beschreibung": "Wie Riposte, jedoch bei bis zu drei Angriffen pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Rückzug": {
+      "name": "Rückzug",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Ein angrenzender Gegner erhält keinen freien Angriff, wenn du dich aus dem Nahkampf zurückziehst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wendiger Rückzug": {
+      "name": "Wendiger Rückzug",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Rückzug"
+      ],
+      "beschreibung": "Drei angrenzende Gegner erhalten keine freien Angriffe, wenn du dich aus dem Nahkampf zurückziehst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ruhige Hände": {
+      "name": "Ruhige Hände",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Ignoriere den Abzug für Unsicheren Grund; verringere Abzüge für Sprinten auf –1.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Rundumschlag": {
+      "name": "Rundumschlag",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "STÄ W8",
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Kämpfen-Wurf mit –2 gegen alle Ziele in der Reichweite der Waffe, nicht öfter als einmal pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kontrollierter Rundumschlag": {
+      "name": "Kontrollierter Rundumschlag",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Rundumschlag"
+      ],
+      "beschreibung": "Wie oben, aber ohne den Abzug von –2.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schmerzresistenz": {
+      "name": "Schmerzresistenz",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "KON W8"
+      ],
+      "beschreibung": "Ignoriere eine Stufe Wundabzüge.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Stärkere Schmerzresistenz": {
+      "name": "Stärkere Schmerzresistenz",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Schmerzresistenz"
+      ],
+      "beschreibung": "Ignoriere bis zu zwei Stufen Wundabzüge.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schneller Angriff": {
+      "name": "Schneller Angriff",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei einem Nahkampfangriff pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Blitzschneller Angriff": {
+      "name": "Blitzschneller Angriff",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schneller Angriff"
+      ],
+      "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei bis zu zwei Nahkampfangriffen pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnellfeuer": {
+      "name": "Schnellfeuer",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Schießen W6"
+      ],
+      "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Verbessertes Schnellfeuer": {
+      "name": "Verbessertes Schnellfeuer",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schnellfeuer"
+      ],
+      "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schwer zu töten": {
+      "name": "Schwer zu töten",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Ignoriere Wundabzüge, wenn du Konstitutionsproben machst, um Verbluten zu verhindern.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wirklich schwer zu töten": {
+      "name": "Wirklich schwer zu töten",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schwer zu töten"
+      ],
+      "beschreibung": "Wirf einen Würfel, wenn der Charakter umkommt. Auch wenn er Ausgeschaltet ist, überlebt er irgendwie.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Volles Rohr!": {
+      "name": "Volles Rohr!",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Schießen W8"
+      ],
+      "beschreibung": "Sofern du dich in deinem Zug nicht bewegst, ignoriere den Rückstoß-Malus, wenn du Waffen mit einer FR von 2 oder mehr verwendest.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Volltreffer": {
+      "name": "Volltreffer",
+      "kategorie": "Kampf",
+      "rang": "WC",
+      "voraussetzungen": [
+        "A",
+        "Athletik oder Schießen W8"
+      ],
+      "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden deines ersten erfolgreichen Angriffs mit Athletik (Werfen) oder Schießen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Anführer": {
+      "name": "Anführer",
+      "kategorie": "Anführer",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "+1 auf Erholungsproben gegen Angeschlagen und Betäubt von Statisten im Befehlsradius.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Großer Anführer": {
+      "name": "Großer Anführer",
+      "kategorie": "Anführer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Anführer"
+      ],
+      "beschreibung": "Erhöhe Befehlsradius auf 10“ (20 m).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Anheizen": {
+      "name": "Anheizen",
+      "kategorie": "Anführer",
+      "rang": "V",
+      "voraussetzungen": [
+        "WIL W8",
+        "Anführer"
+      ],
+      "beschreibung": "+1 auf Kämpfen-Schadenswürfe von Statisten im Befehlsradius.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Geborener Anführer": {
+      "name": "Geborener Anführer",
+      "kategorie": "Anführer",
+      "rang": "F",
+      "voraussetzungen": [
+        "WIL W8",
+        "Anführer"
+      ],
+      "beschreibung": "Anführertalente gelten nun auch für Wildcards.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Haltet die Stellung!": {
+      "name": "Haltet die Stellung!",
+      "kategorie": "Anführer",
+      "rang": "F",
+      "voraussetzungen": [
+        "VER W8",
+        "Anführer"
+      ],
+      "beschreibung": "+1 auf Robustheit der Statisten im Befehlsradius.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Inspirieren": {
+      "name": "Inspirieren",
+      "kategorie": "Anführer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Anführer"
+      ],
+      "beschreibung": "Einmal pro Zug kann der Held auf Kriegskunst würfeln, um alle Statisten im Befehlsradius bei einer Art von Eigenschaftsprobe zu unterstützen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Taktiker": {
+      "name": "Taktiker",
+      "kategorie": "Anführer",
+      "rang": "F",
+      "voraussetzungen": [
+        "VER W8",
+        "Anführer",
+        "Kriegskunst W6"
+      ],
+      "beschreibung": "Ziehe eine zusätzliche Aktionskarte pro Zug und weise sie einem verbündeten Statisten im Befehlsradius zu.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meistertaktiker": {
+      "name": "Meistertaktiker",
+      "kategorie": "Anführer",
+      "rang": "V",
+      "voraussetzungen": [
+        "Taktiker"
+      ],
+      "beschreibung": "Ziehe und verteile zwei zusätzliche Aktionskarten anstelle von einer.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Energieschub": {
+      "name": "Energieschub",
+      "kategorie": "Macht",
+      "rang": "WC",
+      "voraussetzungen": [
+        "A",
+        "Glaube oder Zaubern W8",
+        "AH"
+      ],
+      "beschreibung": "Erhalte 10 Machtpunkte zurück, wenn du im Kampf einen Joker ziehst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Heiliger/Unheiliger Krieger": {
+      "name": "Heiliger/Unheiliger Krieger",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Wunder)",
+        "Glaube W6"
+      ],
+      "beschreibung": "Addiere +1 bis +4 auf Schaden wegstecken für jeden Machtpunkt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kanalisieren": {
+      "name": "Kanalisieren",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH"
+      ],
+      "beschreibung": "Verringere Machtpunktekosten um –1 nach einer Steigerung beim Aktivierungswurf.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Konzentration": {
+      "name": "Konzentration",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH"
+      ],
+      "beschreibung": "Wirkungsdauer von Mächten wird verdoppelt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Machtpunkte": {
+      "name": "Machtpunkte",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH"
+      ],
+      "beschreibung": "Erhalte 5 zusätzliche Machtpunkte, nur einmal pro Rang.",
+      "neue_maechte": 0,
+      "machtpunkte": 5,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Neue Mächte": {
+      "name": "Neue Mächte",
+      "kategorie": "Macht",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH"
+      ],
+      "beschreibung": "Dein Charakter kennt zwei neue Mächte.",
+      "neue_maechte": 2,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnelle Machtregeneration": {
+      "name": "Schnelle Machtregeneration",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "WIL W6",
+        "AH"
+      ],
+      "beschreibung": "Regeneriere 10 Machtpunkte pro Stunde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schnellere Machtregeneration": {
+      "name": "Schnellere Machtregeneration",
+      "kategorie": "Macht",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schnelle Machtregeneration"
+      ],
+      "beschreibung": "Regeneriere 20 Machtpunkte pro Stunde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Seelenentzug": {
+      "name": "Seelenentzug",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH",
+        "Glaube oder Zaubern W10"
+      ],
+      "beschreibung": "Erhalte 5 Machtpunkte für eine Stufe Erschöpfung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zusätzliche Anstrengung": {
+      "name": "Zusätzliche Anstrengung",
+      "kategorie": "Macht",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Begabt)",
+        "Fokus W6"
+      ],
+      "beschreibung": "Erhöhe Fokus um +1 für 1 Machtpunkt oder +2 für 3 Machtpunkte.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Akrobat": {
+      "name": "Akrobat",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8",
+        "Athletik W8"
+      ],
+      "beschreibung": "Wurfwiederholung bei akrobatischen Athletik-Aktionen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kampfakrobat": {
+      "name": "Kampfakrobat",
+      "kategorie": "Experte",
+      "rang": "F",
+      "voraussetzungen": [
+        "Akrobat"
+      ],
+      "beschreibung": "–1 für Gegner zum Treffen mit Fernkampf- und Nahkampfangriffen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Alleskönner": {
+      "name": "Alleskönner",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W10"
+      ],
+      "beschreibung": "Du erhältst W4 in einer Fertigkeit (oder W6 bei einer Steigerung), bis du sie ersetzt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ass am Steuer": {
+      "name": "Ass am Steuer",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8"
+      ],
+      "beschreibung": "Charakter kann Bennys ausgeben, um für sein Fahrzeug Schaden wegstecken anzuwenden und ignoriert bis zu 2 Punkte Abzüge.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Dieb": {
+      "name": "Dieb",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W8",
+        "Heimlichkeit W6",
+        "Diebeskunst W6"
+      ],
+      "beschreibung": "+1 Diebeskunst, Athletik zum Klettern, Heimlichkeit in urbanen Umgebungen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "McGyver": {
+      "name": "McGyver",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6",
+        "Reparieren W8",
+        "Wahrnehmung W8"
+      ],
+      "beschreibung": "Du kannst schnell improvisierte Gerätschaften aus Schrott erfinden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Naturbursche": {
+      "name": "Naturbursche",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "Überleben W8"
+      ],
+      "beschreibung": "+2 Überleben und Heimlichkeit in der Wildnis.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Soldat": {
+      "name": "Soldat",
+      "kategorie": "Experte",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6",
+        "KON W6"
+      ],
+      "beschreibung": "Stärke ist einen Würfeltyp höher für Belastung und Mindeststärke. Wiederhole Konstitutionsproben beim Widerstand gegen Umweltgefahren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Aufwiegler": {
+      "name": "Aufwiegler",
+      "kategorie": "Sozial",
+      "rang": "F",
+      "voraussetzungen": [
+        "Heimlichkeit W8"
+      ],
+      "beschreibung": "Einmal pro Zug kannst du alle Feinde in einer mittleren Flächenschablone mit einer Einschüchtern- oder Provozieren-Herausforderung beeinflussen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bedrohlich": {
+      "name": "Bedrohlich",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "+2 auf Einschüchtern.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Beziehungen": {
+      "name": "Beziehungen",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Kontakte bieten einmal pro Sitzung Unterstützung oder andere Gefallen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ermutigen": {
+      "name": "Ermutigen",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Kann den Zustand Abgelenkt oder Verwundbar nach Herausfordern aufheben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Erniedrigen": {
+      "name": "Erniedrigen",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "Provozieren W8"
+      ],
+      "beschreibung": "Freie Wiederholung bei Provozieren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Erzürnen": {
+      "name": "Erzürnen",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "Provozieren W6"
+      ],
+      "beschreibung": "Kann Feinde mit einer Steigerung bei einer Provozierenprobe „erzürnen“.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Gassenwissen": {
+      "name": "Gassenwissen",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "+2 auf Proben mit Allgemeinwissen und Informationsbeschaffung in kriminellen Kreisen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Konter": {
+      "name": "Konter",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "Provozieren W6"
+      ],
+      "beschreibung": "Eine Steigerung beim Widerstand gegen Provozieren oder Einschüchtern verursacht beim Feind Abgelenkt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Rampensau": {
+      "name": "Rampensau",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Einmal pro Zug wirf einen zweiten Würfel, wenn du mit Darbietung oder Überreden unterstützt und wende das Ergebnis auf einen Verbündeten an.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Echte Rampensau": {
+      "name": "Echte Rampensau",
+      "kategorie": "Sozial",
+      "rang": "F",
+      "voraussetzungen": [
+        "Rampensau"
+      ],
+      "beschreibung": "Wie oben, aber bis zu zweimal pro Zug.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Selbstlos": {
+      "name": "Selbstlos",
+      "kategorie": "Sozial",
+      "rang": "WC",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Der Held kann anderen seine Bennys geben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Starker Wille": {
+      "name": "Starker Wille",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "+2 um Herausfordern mit Verstand oder Willenskraft zu widerstehen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Verlässlich": {
+      "name": "Verlässlich",
+      "kategorie": "Sozial",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Freie Wiederholung bei Unterstützung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Auserwählter": {
+      "name": "Auserwählter",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8",
+        "Kämpfen W6"
+      ],
+      "beschreibung": "+2 Schaden gegen übernatürlich böse (oder gute) Kreaturen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Heiler": {
+      "name": "Heiler",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "+2 auf Heilungsproben, magisch oder anderweitig.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Sammler": {
+      "name": "Sammler",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [
+        "Glück"
+      ],
+      "beschreibung": "Kann einmal pro Begegnung einen benötigten Gegenstand finden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Sechster Sinn": {
+      "name": "Sechster Sinn",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Wahrnehmungsprobe mit +2 zum Spüren von Hinterhalten oder ähnlichen Ereignissen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Tierempathie": {
+      "name": "Tierempathie",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Der Held kann Bennys für Tiere unter seiner Kontrolle ausgeben.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Tiermeister": {
+      "name": "Tiermeister",
+      "kategorie": "Übersinnlich",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W8"
+      ],
+      "beschreibung": "Tiere mögen deinen Helden und er hat eine Art von Haustier.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Gefolgsleute": {
+      "name": "Gefolgsleute",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "WC"
+      ],
+      "beschreibung": "Der Held hat fünf Gefolgsleute.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Handlanger": {
+      "name": "Handlanger",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "WC"
+      ],
+      "beschreibung": "Der Charakter erhält einen Wildcard-Handlanger.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Profi": {
+      "name": "Profi",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [],
+      "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Experte": {
+      "name": "Experte",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "Profi"
+      ],
+      "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen weiteren Schritt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meister": {
+      "name": "Meister",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "Experte"
+      ],
+      "beschreibung": "Der Wildcard-Würfel des Charakters für die Eigenschaft ist ein W10.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Waffenmeister": {
+      "name": "Waffenmeister",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "Kämpfen W12"
+      ],
+      "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W8.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Meister aller Waffen": {
+      "name": "Meister aller Waffen",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "Waffenmeister"
+      ],
+      "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W10.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zäh wie Leder": {
+      "name": "Zäh wie Leder",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "Konstitution W8"
+      ],
+      "beschreibung": "Der Held kann vier Wunden einstecken, ehe er Ausgeschaltet ist.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zäher als Leder": {
+      "name": "Zäher als Leder",
+      "kategorie": "Legendär",
+      "rang": "L",
+      "voraussetzungen": [
+        "Zäh wie Leder",
+        "KON W12"
+      ],
+      "beschreibung": "Der Held kann fünf Wunden einstecken, ehe er Ausgeschaltet ist.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Behände": {
+      "name": "Behände",
+      "kategorie": "Barbar",
+      "rang": "A",
+      "voraussetzungen": [
+        "Barbar"
+      ],
+      "beschreibung": "Bewegungsweite +2.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kampfrausch": {
+      "name": "Kampfrausch",
+      "kategorie": "Barbar",
+      "rang": "A",
+      "voraussetzungen": [
+        "Barbar"
+      ],
+      "beschreibung": "Der Barbar kann freiwillig in einen Kampfrausch verfallen. Nach Angeschlagen oder Wunde: Rücksichtslose Angriffe erzwungen, +1 Würfeltyp Stärke, +2 Robustheit, ignoriere eine Stufe Wundabzüge. Endet nach 5 Runden mit Erschöpfung oder Verstandsprobe mit -2.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Scharfzüngig": {
+      "name": "Scharfzüngig",
+      "kategorie": "Barde",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Barde)"
+      ],
+      "beschreibung": "Der Barde kann Darbietung statt Provozieren verwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bindung mit der Natur": {
+      "name": "Bindung mit der Natur",
+      "kategorie": "Druide",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Druide)"
+      ],
+      "beschreibung": "Der Druide kann ein Tier beschwören, das als sein Begleiter dient.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Naturgespür": {
+      "name": "Naturgespür",
+      "kategorie": "Druide",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Druide)"
+      ],
+      "beschreibung": "-2 auf Überreden und Einschüchtern in der Stadt, +2 in der Wildnis.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kriegerische Anpassungsfähigkeit": {
+      "name": "Kriegerische Anpassungsfähigkeit",
+      "kategorie": "Kämpfer",
+      "rang": "A",
+      "voraussetzungen": [
+        "Kämpfer"
+      ],
+      "beschreibung": "Einmal pro Begegnung kann der Kämpfer als begrenzte freie Aktion die Vorteile eines Kampftalents erhalten. Er muss alle Voraussetzungen erfüllen, und die Vorteile enden nach fünf Runden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Energie fokussieren": {
+      "name": "Energie fokussieren",
+      "kategorie": "Kleriker",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Kleriker)"
+      ],
+      "beschreibung": "Der Kleriker kann die Macht Heilung auf eine Entfernung gleich seiner Willenskraft wirken. Er erhält außerdem den Machtmodifikator Zusätzlicher Empfänger, sodass er für jeweils 1 Machtpunkt nahe Verbündete heilen kann.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Verbindung": {
+      "name": "Arkane Verbindung",
+      "kategorie": "Magier",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Magier)"
+      ],
+      "beschreibung": "Der Magier wählt eine Arkane Verbindung: einen Gegenstand (+1 auf Zaubern) oder einen Vertrauten (siehe Regeln).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schule": {
+      "name": "Schule",
+      "kategorie": "Magier",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Magier)"
+      ],
+      "beschreibung": "Der Magier wählt eine Schule, die bestimmt, auf welche Arten von Mächten er sich spezialisiert.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Betäubende Fäuste": {
+      "name": "Betäubende Fäuste",
+      "kategorie": "Mönch",
+      "rang": "A",
+      "voraussetzungen": [
+        "Mönch"
+      ],
+      "beschreibung": "Bei einer Steigerung beim Kämpfen-Wurf kann der Mönch einen Feind betäuben oder einen Verursacher machen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Beweglichkeit": {
+      "name": "Beweglichkeit",
+      "kategorie": "Mönch",
+      "rang": "A",
+      "voraussetzungen": [
+        "Mönch"
+      ],
+      "beschreibung": "Der Mönch ist schnell und wendig und erhält +1 auf Sprint und Ausweichen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kämpferische Disziplin": {
+      "name": "Kämpferische Disziplin",
+      "kategorie": "Mönch",
+      "rang": "A",
+      "voraussetzungen": [
+        "Mönch"
+      ],
+      "beschreibung": "Der Mönch erhält +1 Robustheit, wenn er keine Rüstung trägt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Waffenloser Schlag": {
+      "name": "Waffenloser Schlag",
+      "kategorie": "Mönch",
+      "rang": "A",
+      "voraussetzungen": [
+        "Mönch"
+      ],
+      "beschreibung": "Der Mönch erhält +1 auf Kampfwürfe und verursacht STÄ+W4 Schaden bei waffenlosen Angriffen. Dieser Schadenswürfel steigt mit dem Rang.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Böses Entdecken": {
+      "name": "Böses Entdecken",
+      "kategorie": "Paladin",
+      "rang": "A",
+      "voraussetzungen": [
+        "Paladin"
+      ],
+      "beschreibung": "Als freie Aktion kann der Paladin eine Wahrnehmungsprobe ablegen, um böse übernatürliche Kreaturen oder Charaktere in einer Entfernung von 5'' (10 Metern) zu entdecken.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Böses Niederstrecken": {
+      "name": "Böses Niederstrecken",
+      "kategorie": "Paladin",
+      "rang": "A",
+      "voraussetzungen": [
+        "Paladin"
+      ],
+      "beschreibung": "Einmal pro Begegnung erhält der Paladin eine freie Wiederholung bei allen Angriffswürfen gegen einen gewählten bösen Gegner.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Hinterhältiger Angriff": {
+      "name": "Hinterhältiger Angriff",
+      "kategorie": "Schurke",
+      "rang": "A",
+      "voraussetzungen": [
+        "Schurke"
+      ],
+      "beschreibung": "Der Schurke addiert +W6 auf den Schaden, wenn er einen Überraschungsangriff gegen ein Ziel durchführen kann und das Opfer verwundbar ist. Dies gilt für Angriffe mit Athletik (Werfen), Kämpfen oder Schießen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wildnis durchqueren": {
+      "name": "Wildnis durchqueren",
+      "kategorie": "Waldläufer",
+      "rang": "A",
+      "voraussetzungen": [
+        "Waldläufer"
+      ],
+      "beschreibung": "Der Waldläufer ignoriert Abzüge für Schwieriges Gelände in der Wildnis.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Blutlinie": {
+      "name": "Blutlinie",
+      "kategorie": "Zauberer",
+      "rang": "A",
+      "voraussetzungen": [
+        "AH (Zauberer)"
+      ],
+      "beschreibung": "Der Zauberer muss eine Blutlinie wählen (siehe Seite 69). Bei der Beschreibung jeder Blutlinie findest du auch die zusätzliche Spezialfähigkeit, die du erhältst, wenn du das Talent Mächtige Blutlinie wählst.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    }
+  },
+  "handicaps": {
+    "Ahnen-Schwäche_leicht": {
+      "name": "Ahnen-Schwäche",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Einige Familien können ihre Abstammungslinie weit genug zurückverfolgen, um einen Vorfahren von einer anderen Ebene zu entdecken. Wähle eines: Feuer, Kälte oder Elektrizität. Der Charakter erleidet +2 Schaden durch Angriffe dieses Typs.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Ahnen-Schwäche_schwer": {
+      "name": "Ahnen-Schwäche",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Einige Familien können ihre Abstammungslinie weit genug zurückverfolgen, um einen Vorfahren von einer anderen Ebene zu entdecken. Wähle eines: Feuer, Kälte oder Elektrizität. Der Charakter erleidet +4 Schaden durch Angriffe dieses Typs.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Akribisch": {
+      "name": "Akribisch",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Dein Held plant und bereitet alles bis ins Detail vor und improvisiert schlecht, wenn die Dinge nicht nach Plan laufen. Dieser Charakter erleidet –4 auf ungelernte Fertigkeitsproben anstelle der üblichen –2.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Alt": {
+      "name": "Alt",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–1 auf Bewegungsweite, Sprint-Würfel, Geschicklichkeit, Stärke und Konstitution. Held erhält 5 zusätzliche Fertigkeitspunkte.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Analphabet": {
+      "name": "Analphabet",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter kann nicht lesen oder schreiben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Angetrieben_leicht": {
+      "name": "Angetrieben",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Angetrieben_schwer": {
+      "name": "Angetrieben",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Angewohnheit_leicht": {
+      "name": "Angewohnheit",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Angewohnheit_schwer": {
+      "name": "Angewohnheit",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Arm": {
+      "name": "Arm",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Halbiere das Startkapital, und der Charakter ist immer pleite.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Arrogant": {
+      "name": "Arrogant",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Dominiert gerne seine Gegner, fordert den mächtigsten Feind im Kampf heraus.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Außenseiter_leicht": {
+      "name": "Außenseiter",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Außenseiter_schwer": {
+      "name": "Außenseiter",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab. Bei einem schweren Handicap hat er keine Rechte oder leidet unter anderen schweren Konsequenzen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Befleckter Geist": {
+      "name": "Befleckter Geist",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Als Kind schloss ein Elternteil oder eine Autoritätsperson einen Pakt mit einem Teufelswesen und stahl dabei einen Teil der Lebenskraft des Charakters als Pfand. Unmittelbar nachdem ein Kampf endet, muss dieser Charakter einen Konstitutionswurf ablegen oder erleidet eine Erschöpfungsstufe. Diese Erschöpfung dauert an, bis der Charakter 24 Stunden ohne Kampf verbracht hat.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Behindernde Rüstung_jede": {
+      "name": "Behindernde Rüstung (jede)",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er jede Art von Rüstung trägt.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Behindernde Rüstung_leicht": {
+      "name": "Behindernde Rüstung (leicht)",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er leichte oder schwerere Rüstung trägt.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Beschämt_leicht": {
+      "name": "Beschämt",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Beschämt_schwer": {
+      "name": "Beschämt",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Bevorzugte Klasse_leicht": {
+      "name": "Bevorzugte Klasse",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Wenn sich dein Held auf etwas einlässt, zieht er es bis zum Ende durch, auch auf Kosten anderer Studien. Wähle eine Kern-Klassen-Eigenschaft. Alle Merkmalsanforderungen für andere Klassen-Eigenschaften und Prestige-Eigenschaften werden um einen Würfeltyp erhöht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Bevorzugte Klasse_schwer": {
+      "name": "Bevorzugte Klasse",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Wenn sich dein Held auf etwas einlässt, zieht er es bis zum Ende durch, auch auf Kosten anderer Studien. Der Charakter kann nur eine Kern-Klassen-Eigenschaft haben und kann keine Prestige-Eigenschaften erwerben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Blind": {
+      "name": "Blind",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–6 auf alle Aufgaben, die Sicht erfordern (aber ein freies Talent zum Ausgleich).",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Blutrünstig": {
+      "name": "Blutrünstig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Nimmt niemals Gefangene.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Dünnhäutig_leicht": {
+      "name": "Dünnhäutig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –2, wenn er Provozieren-Angriffen widerstehen will.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Dünnhäutig_schwer": {
+      "name": "Dünnhäutig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –4, wenn er Provozieren-Angriffen widerstehen will.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Ehrenkodex": {
+      "name": "Ehrenkodex",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter hält sein Wort und benimmt sich wie ein Gentleman.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Eifersüchtig_leicht": {
+      "name": "Eifersüchtig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter will das, was andere haben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Eifersüchtig_schwer": {
+      "name": "Eifersüchtig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter will das, was andere haben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Einarmig": {
+      "name": "Einarmig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–4 auf Aufgaben (wie Athletik), die beide Hände erfordern.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Eingeengt": {
+      "name": "Eingeengt",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Manche Menschen können die einengende Natur von Rüstungen nicht ertragen. Die enge Umhüllung aus Leder und erstickende Helme versetzen sie in Panik. Dieser Charakter erhält Rüstungsbeschränkung (mittelschwer) für eine seiner Klassen-Eigenschaften. Besitzt er bereits eine Rüstungsbeschränkung, wird diese um eine Stufe erhöht (mittelschwer zu leicht, leicht zu jede).",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Einzelgänger": {
+      "name": "Einzelgänger",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Aufgewachsen unter Piraten, Banditen oder anderen Unruhestiftern, die nicht bereit waren, für ihn den Kopf hinzuhalten, ist dieser Charakter es gewohnt, auf eigene Faust zu agieren. Die Anwesenheit von Verbündeten kann leicht zur Ablenkung werden. Dieser Charakter profitiert nicht von Überzahl-Boni.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Einäugig": {
+      "name": "Einäugig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–2 auf Aktionen auf 5ʺ (10 Meter) oder mehr Entfernung.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Feengeraubt": {
+      "name": "Feengeraubt",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Als Kind wurde dein Held von schelmischen Feenwesen für eine Zeit entführt. Als er zurückkehrte, galt er für immer als eigenartig und distanziert. Er sehnt sich zurück und findet die sterbliche Welt stumpf und manchmal abstoßend, isst schlecht und vertraut seltsamen Visionen. Der Charakter erleidet –2 auf Proben gegen Krankheiten und Gift sowie auf Proben gegen Zauber, Fähigkeiten und Konfrontationen von Feenwesen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Feige": {
+      "name": "Feige",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–2 auf Furchtproben und beim Widerstand gegen Einschüchtern.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Feind_leicht": {
+      "name": "Feind",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Feind_schwer": {
+      "name": "Feind",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Fettleibig": {
+      "name": "Fettleibig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Größe +1, Bewegungsweite –1, Sprintwürfel W4. Behandle Stärke als einen Würfeltyp niedriger, wenn es um Mindeststärke geht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Fies": {
+      "name": "Fies",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–1 auf Überredenproben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Geheimnis_leicht": {
+      "name": "Geheimnis",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Held hat ein dunkles Geheimnis.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Geheimnis_schwer": {
+      "name": "Geheimnis",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Held hat ein dunkles Geheimnis.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gesucht_leicht": {
+      "name": "Gesucht",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gesucht_schwer": {
+      "name": "Gesucht",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gewöhnliche Sicht": {
+      "name": "Gewöhnliche Sicht",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Etwas – oft ein Fluch, eine Krankheit oder ein ähnlicher Effekt – hat dazu geführt, dass dein Held die übernatürliche Sicht seiner Abstammung verloren hat. Der Charakter verliert seine Dämmerungssicht oder Nachtsicht. Voraussetzung: Der Charakter muss Dämmerungssicht oder Nachtsicht besitzen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gierig_leicht": {
+      "name": "Gierig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gierig_schwer": {
+      "name": "Gierig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Große Klappe": {
+      "name": "Große Klappe",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Kann kein Geheimnis bewahren, und verrät ständig private Informationen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Heldenhaft": {
+      "name": "Heldenhaft",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter hilft immer anderen, die in Not sind.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Hilflos_leicht": {
+      "name": "Hilflos",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Dieser Charakter stand einst hilflos dabei, als einem geliebten Menschen großes Leid widerfuhr, und diese Lähmung kehrt manchmal zurück. Wann immer ein Verbündeter eine Wunde erleidet, ist dieser Charakter Abgelenkt.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Hilflos_schwer": {
+      "name": "Hilflos",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Dieser Charakter stand einst hilflos dabei, als einem geliebten Menschen großes Leid widerfuhr, und diese Lähmung kehrt manchmal zurück. Wann immer ein Verbündeter eine Wunde erleidet, ist dieser Charakter Abgelenkt und Verwundbar.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Hässlich_leicht": {
+      "name": "Hässlich",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –1 von Überredenproben ab.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Hässlich_schwer": {
+      "name": "Hässlich",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –2 von Überredenproben ab.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Impulsiv": {
+      "name": "Impulsiv",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Held springt, ehe er schaut.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Jung_leicht": {
+      "name": "Jung",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "4 Attributspunkte, 10 Fertigkeitspunkte, einen zusätzlichen Benny pro Sitzung.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Jung_schwer": {
+      "name": "Jung",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "3 Attributspunkte, 10 Fertigkeitspunkte, zwei zusätzliche Bennys pro Sitzung.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Klein": {
+      "name": "Klein",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Größe und Robustheit sinken um 1. Größe kann nicht unter –1 liegen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Kränklich": {
+      "name": "Kränklich",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–2 Konstitution beim Widerstand gegen Erschöpfung.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Kurzsichtig_leicht": {
+      "name": "Kurzsichtig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Manche Abenteurer verfolgen Dinge bis zum bitteren Ende und erschöpfen jede Option – das ist nicht dein Held. Dieser Charakter kann keine Überzeugung ausgeben, um eine zusätzliche Nutzung von einmal-pro-Begegnung-, -Sitzung- oder -Tages-Fähigkeiten zu erhalten.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Kurzsichtig_schwer": {
+      "name": "Kurzsichtig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Manche Abenteurer verfolgen Dinge bis zum bitteren Ende und erschöpfen jede Option – das ist nicht dein Held. Der Charakter kann Überzeugung für zusätzliche Nutzungen von Fähigkeiten ausgeben, aber der Überzeugungswürfel ist dabei ein W4.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Langsam_leicht": {
+      "name": "Langsam",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Bewegungsweite –1, verringere den Sprintwürfel um eine Stufe.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Langsam_schwer": {
+      "name": "Langsam",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Bewegungsweite –2, –2 auf Athletikproben und Würfe, um Athletik zu widerstehen, kann nicht das Talent Flink wählen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Lebensaufgabe": {
+      "name": "Lebensaufgabe",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Held will sterben, nachdem er eine epische Aufgabe abgeschlossen hat.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Loyal": {
+      "name": "Loyal",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Held ist seinen Freunden und Verbündeten gegenüber loyal.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Magischer Tollpatsch": {
+      "name": "Magischer Tollpatsch",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Dein Held wurde an einem Ort mit einer Fülle seltsam interagierender Magie geboren, und Magie ist gefährlich begierig, um ihn herum aktiv zu werden. Das Aktivieren eines magischen Gegenstands ist eine beschränkte Aktion statt einer regulären Aktion. Erforderte der Gegenstand normalerweise bereits eine beschränkte Aktion, kann der Charakter keine Mehrfachaktion durchführen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Misstrauisch_leicht": {
+      "name": "Misstrauisch",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter ist paranoid.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Misstrauisch_schwer": {
+      "name": "Misstrauisch",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter ist paranoid und Verbündete, die ihn unterstützen wollen, ziehen –2 von ihren Würfen ab.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Neugierig": {
+      "name": "Neugierig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter will immer alles wissen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Nichtschwimmer": {
+      "name": "Nichtschwimmer",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–2 auf Proben mit Athletik (Schwimmen); jedes Zoll Bewegung im Wasser kostet 3ʺ Bewegungsweite.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Pazifist_leicht": {
+      "name": "Pazifist",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Kämpft nur in Selbstverteidigung.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Pazifist_schwer": {
+      "name": "Pazifist",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Kämpft gar nicht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Pech": {
+      "name": "Pech",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter beginnt jede Spielsitzung mit einem Benny weniger.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Phobie_leicht": {
+      "name": "Phobie",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter hat vor etwas Angst und zieht –1 von allen Eigenschaftsproben in dessen Gegenwart ab.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Phobie_schwer": {
+      "name": "Phobie",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter hat vor etwas Angst und zieht –2 von allen Eigenschaftsproben in dessen Gegenwart ab.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Rachsüchtig_leicht": {
+      "name": "Rachsüchtig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Rachsüchtig_schwer": {
+      "name": "Rachsüchtig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen. Bei einem schweren Handicap greift er auch zu körperlicher Gewalt.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Rüstungsbeschränkung_jede": {
+      "name": "Rüstungsbeschränkung (jede)",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter darf keine Rüstung tragen und keine Schilde verwenden.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Rüstungsbeschränkung_leicht": {
+      "name": "Rüstungsbeschränkung (leicht)",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er mittelschwere oder schwere Rüstung trägt oder mittlere/schwere Schilde verwendet.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Rüstungsbeschränkung_mittelschwer": {
+      "name": "Rüstungsbeschränkung (mittelschwer)",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er schwere Rüstung trägt oder einen schweren Schild verwendet.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Sanftmütig": {
+      "name": "Sanftmütig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–2 auf Einschüchternproben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schattenentblößung": {
+      "name": "Schattenentblößung",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Held wirft überhaupt keinen Schatten, oder sein Schatten ist monströs. Unter normalen Lichtbedingungen ist dies nicht schwer zu beobachten, aber ungewöhnlich zu bemerken. Jeder, der den Schatten dieses Charakters bemerkt, reagiert schlechter auf ihn (schlechtere Anfangsreaktion bei Überredung).",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schlechte Augen_leicht": {
+      "name": "Schlechte Augen",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–1 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schlechte Augen_schwer": {
+      "name": "Schlechte Augen",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–2 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schreckhaft": {
+      "name": "Schreckhaft",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Eine traumatische Erfahrung in jungen Jahren mit einem Geist, einem Untoten oder einem anderen übernatürlichen Wesen prägt die Reaktionen deines Helden. Immer wenn er ein Feenwesen, einen Außenseiter oder einen Untoten innerhalb von 10\" (20 Yards) wahrnimmt, muss er eine Schreckensprobe ablegen. Verursacht das Wesen von Natur aus Schrecken, erleidet er zusätzlich –2 auf die Probe. Gegenüber Schrecken abgehärtet zu sein gilt beim Schreckhaften nur für das spezifische Individuum, nicht für den gesamten Kreaturtyp.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schwerhörig_leicht": {
+      "name": "Schwerhörig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–4 auf Wahrnehmung bei Geräuschen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schwerhörig_schwer": {
+      "name": "Schwerhörig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Automatischer Fehlschlag bei vollständiger Taubheit.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schwerzüngig": {
+      "name": "Schwerzüngig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter sagt oft das Falsche oder bekommt seine Worte nicht heraus; –1 auf Einschüchtern, Überreden und Provozieren.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schwur_leicht": {
+      "name": "Schwur",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schwur_schwer": {
+      "name": "Schwur",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Skrupellos_leicht": {
+      "name": "Skrupellos",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Skrupellos_schwer": {
+      "name": "Skrupellos",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Stumm": {
+      "name": "Stumm",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter kann nicht sprechen.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Stur": {
+      "name": "Stur",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter will seinen Willen durchsetzen und gibt selten Fehler zu.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Tick": {
+      "name": "Tick",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter hat eine kleine, aber hartnäckige Marotte, die anderen oft auf die Nerven geht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Tollpatschig": {
+      "name": "Tollpatschig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–2 auf Proben mit Athletik und Heimlichkeit.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Unaufmerksam": {
+      "name": "Unaufmerksam",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Dein Held hat Schwierigkeiten, den Wirkungsbereich von Flächenangriffen zu erfassen. Dieser Charakter erleidet halben Schaden, wenn er einen erfolgreichen Ausweichmanöver-Wurf erzielt.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verbittert": {
+      "name": "Verbittert",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Dieser Held wurde wiederholt von Menschen enttäuscht, denen er vertraute, und fällt es ihm schwer, Hilfe anzunehmen. Andere Charaktere, die diesen Charakter heilen wollen, erleiden –2 auf ihre Probe. Dies gilt für gewöhnliche und magische Heilung, nicht jedoch für natürliche Heilungswürfe.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verpeilt": {
+      "name": "Verpeilt",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "–1 auf Proben mit Allgemeinwissen und Wahrnehmung.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verpflichtung_leicht": {
+      "name": "Verpflichtung",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 20 Stunden.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verpflichtung_schwer": {
+      "name": "Verpflichtung",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 40 Stunden.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Von der Natur gemieden": {
+      "name": "Von der Natur gemieden",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Tiere empfinden deinen Charakter als besonders beunruhigend. Selbst die am besten abgerichteten Tiere müssen zum Umgang mit ihm überredet werden. Tiere nähern sich freiwillig nicht innerhalb von 10\" (20 Yards) des Charakters, außer sie werden dazu überredet. Zusätzlich erleidet der Held –2 auf alle Proben zur Kontrolle von Tieren, einschließlich Reiten.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Vorsichtig": {
+      "name": "Vorsichtig",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter schmiedet aufwendige Pläne und/oder ist übermäßig vorsichtig.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Wahnvorstellungen_leicht": {
+      "name": "Wahnvorstellungen",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm manchmal Schwierigkeiten macht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Wahnvorstellungen_schwer": {
+      "name": "Wahnvorstellungen",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm oft Schwierigkeiten macht.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Zwei linke Hände": {
+      "name": "Zwei linke Hände",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "–2 bei der Verwendung von mechanischen oder elektrischen Geräten.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Zögerlich": {
+      "name": "Zögerlich",
+      "stufe": "leicht",
+      "punkte": 1,
+      "beschreibung": "Ziehe zwei Aktionskarten und nimm die schlechtere (außer Joker, die darfst du behalten).",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Übermütig": {
+      "name": "Übermütig",
+      "stufe": "schwer",
+      "punkte": 2,
+      "beschreibung": "Der Held glaubt, dass er alles tun kann.",
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    }
+  },
+  "maechte": {
+    "Abwehren": {
+      "name": "Abwehren",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "–2/–4 bei Angriffen auf Empfänger",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Arkaner Schutz": {
+      "name": "Arkaner Schutz",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Gegnerische Wirker ziehen –2 (–4 mit Steigerung) ab, wenn sie den Charakter mit Mächten angreifen; verringert Schaden um die gleiche Summe",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Arkanes entdecken/verbergen": {
+      "name": "Arkanes entdecken/verbergen",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5/1h",
+      "beschreibung": "Entdeckt Magie für Wirkungsdauer 5 oder verbirgt sie für 1 Stunde",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Aufheben": {
+      "name": "Aufheben",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Negiert magische Effekte",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Aufspüren": {
+      "name": "Aufspüren",
+      "rang": "A",
+      "machtpunkte": 3,
+      "reichweite": "Selbst",
+      "dauer": "10 Minuten",
+      "beschreibung": "Findet ein Objekt",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Ausspähung": {
+      "name": "Ausspähung",
+      "rang": "F",
+      "machtpunkte": 3,
+      "reichweite": "Selbst",
+      "dauer": "5",
+      "beschreibung": "Wirker kann ein Ziel und seine Umgebung auf Entfernung sehen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Barriere": {
+      "name": "Barriere",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Erschafft Barriere mit 5ʺ (10 Meter) Länge, 1ʺ (2 Meter) Höhe und Härte 10 (12 mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Betäuben": {
+      "name": "Betäuben",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Ziel ist Betäubt",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Bindender Ruf": {
+      "name": "Bindender Ruf",
+      "rang": "V",
+      "machtpunkte": 8,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Beschwört und bindet eine Kreatur von einer anderen Ebene",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Blenden": {
+      "name": "Blenden",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Verursacht Abzug von –2/–4 bei Opfern",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Böswillige Verwandlung": {
+      "name": "Böswillige Verwandlung",
+      "rang": "V",
+      "machtpunkte": 3,
+      "reichweite": "Ver",
+      "dauer": "5",
+      "beschreibung": "Tier von Größe –2 bis 3 wird in eine relativ harmlose Kreatur verwandelt",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Chaos": {
+      "name": "Chaos",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Ziele in MFS oder Kegel sind Abgelenkt und könnten geschleudert werden",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Dunkelsicht": {
+      "name": "Dunkelsicht",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver",
+      "dauer": "1 Stunde",
+      "beschreibung": "Ignoriere bis zu 4 Punkte Beleuchtungsabzüge, 6 bei Steigerung",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Ebenenwechsel": {
+      "name": "Ebenenwechsel",
+      "rang": "V",
+      "machtpunkte": 5,
+      "reichweite": "Ver",
+      "dauer": "5",
+      "beschreibung": "Erlaubt Reisen zu anderen Existenzebenen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Eigenschaft erhöhen/senken": {
+      "name": "Eigenschaft erhöhen/senken",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5/Sofort",
+      "beschreibung": "Erhöht oder senkt Fertigkeit oder Attribut",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Elementarmanipulation": {
+      "name": "Elementarmanipulation",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Erlaubt einfache Manipulation der grundlegenden Elemente",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Empathie": {
+      "name": "Empathie",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Vergleichender Wurf gegen Willenskraft, für +1/+2 auf Darbietung, Einschüchtern, Provozieren und Überreden gegen das Ziel",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Fernsicht": {
+      "name": "Fernsicht",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Sieht Details auf größere Entfernung; halbiert Entfernungsabzüge bei Steigerung",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Flächenschlag": {
+      "name": "Flächenschlag",
+      "rang": "F",
+      "machtpunkte": 3,
+      "reichweite": "Ver×2",
+      "dauer": "Sofort",
+      "beschreibung": "2W6 Schaden in mittlerer Flächenschablone",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Fliegen": {
+      "name": "Fliegen",
+      "rang": "V",
+      "machtpunkte": 3,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Ziel fliegt mit Bewegungsweite 12",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Fluch": {
+      "name": "Fluch",
+      "rang": "F",
+      "machtpunkte": 5,
+      "reichweite": "Berührung",
+      "dauer": "Speziell",
+      "beschreibung": "Legt Fluch auf Ziel",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Furcht": {
+      "name": "Furcht",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Verursacht Furchtproben",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gedankenleere": {
+      "name": "Gedankenleere",
+      "rang": "V",
+      "machtpunkte": 3,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Entfernt oder verändert Erinnerungen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gedankenlesen": {
+      "name": "Gedankenlesen",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Vergleichender Wurf gegen Verstand zum Gedankenlesen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gedankenverbindung": {
+      "name": "Gedankenverbindung",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 30m",
+      "dauer": "5",
+      "beschreibung": "Geistige Verbindung auf 1,5 Kilometer (8 mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gegenstand beschwören": {
+      "name": "Gegenstand beschwören",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "1 Stunde",
+      "beschreibung": "Beschwört Gegenstand, 1 Pfund pro 2 Machtpunkte",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Geräusch/Stille": {
+      "name": "Geräusch/Stille",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver×5/Ver",
+      "dauer": "5/Sofort",
+      "beschreibung": "Erzeugt oder dämpft Geräusche",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Geschoss": {
+      "name": "Geschoss",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver×2",
+      "dauer": "Sofort",
+      "beschreibung": "2W6 Fernkampfangriff",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gestaltwandeln": {
+      "name": "Gestaltwandeln",
+      "rang": "A",
+      "machtpunkte": 3,
+      "reichweite": "Selbst",
+      "dauer": "5",
+      "beschreibung": "Wirker nimmt die Gestalt verschiedener Wesen an",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Graben": {
+      "name": "Graben",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Ziel gräbt sich durch die Erde",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Heiligtum": {
+      "name": "Heiligtum",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Berührung",
+      "dauer": "5",
+      "beschreibung": "Feinde müssen Willenskraftprobe machen, um angreifen zu können",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Heilung": {
+      "name": "Heilung",
+      "rang": "A",
+      "machtpunkte": 3,
+      "reichweite": "Berührung",
+      "dauer": "Sofort",
+      "beschreibung": "Stellt Wunden wieder her, die weniger als eine Stunde alt sind",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Illusion": {
+      "name": "Illusion",
+      "rang": "A",
+      "machtpunkte": 3,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Erschafft eine visuelle Szene oder Abbildung von so gut wie allem, was der Wirker sich vorstellen kann",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Kriegersegen": {
+      "name": "Kriegersegen",
+      "rang": "F",
+      "machtpunkte": 4,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Gewährt Ziel ein Kampftalent",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Licht/Dunkelheit": {
+      "name": "Licht/Dunkelheit",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 10m",
+      "dauer": "5",
+      "beschreibung": "Erschafft oder verbannt Beleuchtung",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Linderung": {
+      "name": "Linderung",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver",
+      "dauer": "Sofort/1h",
+      "beschreibung": "Entfernt Zustände Angeschlagen, Abgelenkt oder Verwundbar (2 mit Steigerung) oder ignoriert 1 Punkt Wund- und Erschöpfungsabzüge (2 mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Machtpunkte entziehen": {
+      "name": "Machtpunkte entziehen",
+      "rang": "V",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Entzieht Gegner W6 Machtpunkte bei erfolgreichem vergleichendem Wurf",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Magisches Glas": {
+      "name": "Magisches Glas",
+      "rang": "H",
+      "machtpunkte": 5,
+      "reichweite": "Ver",
+      "dauer": "5 Stunden",
+      "beschreibung": "Überträgt die Seele des Wirkers in ein verzaubertes Gefäß (Kristall oder Edelstein). Der Wirker kann zwischen Gefäß und Körper wechseln (Körper wirkt leblos) und versuchen, andere Körper zu besetzen (vergleichender Wurf arkane Fertigkeit vs. Geist). Bei Erfolg wird die Seele des Opfers im Gefäß gefangen. Verstand, Willenskraft, Gesinnung und Vorteile des Wirkers bleiben erhalten; Körperattribute und Wunden stammen vom Wirt.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Marionette": {
+      "name": "Marionette",
+      "rang": "V",
+      "machtpunkte": 3,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Ziel zu kontrollieren",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Objekt auslesen": {
+      "name": "Objekt auslesen",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Berührung",
+      "dauer": "Speziell",
+      "beschreibung": "Offenbart vage Erinnerungen der Geschichte des Ziels (mehr Details mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schadensfeld": {
+      "name": "Schadensfeld",
+      "rang": "F",
+      "machtpunkte": 4,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Erschafft Aura, die 2W4 Schaden verursacht",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schlummer": {
+      "name": "Schlummer",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "1 Stunde",
+      "beschreibung": "Lässt Opfer einschlafen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schutz": {
+      "name": "Schutz",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Gewährt Panzerung +2 bei Erfolg, Robustheit +2 bei Steigerung",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Schutz vor Naturgewalten": {
+      "name": "Schutz vor Naturgewalten",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "1 Stunde",
+      "beschreibung": "Beschützt Ziel vor schädlichen Umwelteinflüssen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Sprachen sprechen": {
+      "name": "Sprachen sprechen",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 10m",
+      "dauer": "5",
+      "beschreibung": "Wirker kann Sprachen sprechen und verstehen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Strahl": {
+      "name": "Strahl",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Kegel",
+      "dauer": "Sofort",
+      "beschreibung": "Kegelförmiger Angriff mit 2W6 Schaden",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Telekinese": {
+      "name": "Telekinese",
+      "rang": "F",
+      "machtpunkte": 5,
+      "reichweite": "Ver×2",
+      "dauer": "5",
+      "beschreibung": "Bewegt Gegenstände mit Stärke W10 (W12 mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Teleportation": {
+      "name": "Teleportation",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Charakter teleportiert sich bis zu 12ʺ weit",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Tierfreund": {
+      "name": "Tierfreund",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Ver 10m",
+      "dauer": "5",
+      "beschreibung": "Kontrolliert Tiere",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Trägheit/Beschleunigung": {
+      "name": "Trägheit/Beschleunigung",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort/5",
+      "beschreibung": "Erhöht oder verlangsamt Bewegung",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Unberührbarkeit": {
+      "name": "Unberührbarkeit",
+      "rang": "V",
+      "machtpunkte": 5,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Ziel wird körperlos",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Unsichtbarkeit": {
+      "name": "Unsichtbarkeit",
+      "rang": "F",
+      "machtpunkte": 5,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Ziel wird unsichtbar (–4/–6, um es zu beeinflussen)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verbannen": {
+      "name": "Verbannen",
+      "rang": "V",
+      "machtpunkte": 3,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Wesenheiten zu verbannen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verbündeten beschwören": {
+      "name": "Verbündeten beschwören",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Beschwört verschiedene Verbündete",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verkleiden": {
+      "name": "Verkleiden",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver 10m",
+      "dauer": "5",
+      "beschreibung": "Ziel sieht aus wie jemand anders",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verstricken": {
+      "name": "Verstricken",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Feind wird Gebunden oder Festgehalten",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verwirrung": {
+      "name": "Verwirrung",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver",
+      "dauer": "Speziell",
+      "beschreibung": "Macht Ziel Abgelenkt und Verwundbar",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Wachsen/Schrumpfen": {
+      "name": "Wachsen/Schrumpfen",
+      "rang": "F",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Erhöht oder verringert Größe",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Waffe verbessern": {
+      "name": "Waffe verbessern",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Erhöht Schaden einer Waffe um +2/+4",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Wandkrabbler": {
+      "name": "Wandkrabbler",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Ver 5",
+      "dauer": "5",
+      "beschreibung": "Charakter kann mit halber Bewegungsweite an Wänden laufen (volle Bewegungsweite mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Wiederauferstehung": {
+      "name": "Wiederauferstehung",
+      "rang": "H",
+      "machtpunkte": 20,
+      "reichweite": "Berührung",
+      "dauer": "Sofort",
+      "beschreibung": "Erweckt die Toten zum Leben",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Wunsch": {
+      "name": "Wunsch",
+      "rang": "L",
+      "machtpunkte": 20,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Wähle eines von mehreren realitätsverändernden Ereignissen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Zeitstopp": {
+      "name": "Zeitstopp",
+      "rang": "H",
+      "machtpunkte": 8,
+      "reichweite": "Ver",
+      "dauer": "Sofort",
+      "beschreibung": "Wirker erhält einen zusätzlichen Zug (bis zu 4 Aktionen mit Steigerung)",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Zombie": {
+      "name": "Zombie",
+      "rang": "V",
+      "machtpunkte": 3,
+      "reichweite": "Ver",
+      "dauer": "1 Stunde",
+      "beschreibung": "Erhebt und kontrolliert Untote",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Zwiesprache": {
+      "name": "Zwiesprache",
+      "rang": "F",
+      "machtpunkte": 5,
+      "reichweite": "Selbst",
+      "dauer": "5 Minuten",
+      "beschreibung": "Wirker kann anderweltlichen Wesenheit Fragen stellen",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Gegenstand Beschwören": {
+      "name": "Gegenstand Beschwören",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Verstand",
+      "dauer": "Eine Stunde",
+      "beschreibung": "Erschafft einen Gegenstand bis 0,5 kg pro 2 Machtpunkte.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Monster Beschwören": {
+      "name": "Monster Beschwören",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Verstand",
+      "dauer": "5",
+      "beschreibung": "Beschwört ein mächtiges Monster.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Mystisches Eingreifen": {
+      "name": "Mystisches Eingreifen",
+      "rang": "Legendär",
+      "machtpunkte": 20,
+      "reichweite": "Speziell",
+      "dauer": "Speziell",
+      "beschreibung": "Bittet um Hilfe von größeren Mächten.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Segen": {
+      "name": "Segen",
+      "rang": "F",
+      "machtpunkte": 10,
+      "reichweite": "Eine Stadt/Gemeinde",
+      "dauer": "Ein Jahr",
+      "beschreibung": "Segnet Gemeinschaften und Ressourcen.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Tier Beschwören": {
+      "name": "Tier Beschwören",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Verstand",
+      "dauer": "5",
+      "beschreibung": "Beschwört Tiere zur Unterstützung.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Untoten Beschwören": {
+      "name": "Untoten Beschwören",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Verstand",
+      "dauer": "5",
+      "beschreibung": "Beschwört einfache Untote.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Verriegeln/Entriegeln": {
+      "name": "Verriegeln/Entriegeln",
+      "rang": "A",
+      "machtpunkte": 1,
+      "reichweite": "Verstand",
+      "dauer": "Permanent (Verriegeln); Sofort (Entriegeln)",
+      "beschreibung": "Verriegelt oder entriegelt magisch.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    },
+    "Zuflucht": {
+      "name": "Zuflucht",
+      "rang": "A",
+      "machtpunkte": 2,
+      "reichweite": "Berührung",
+      "dauer": "5",
+      "beschreibung": "Schützt vor Angriffen und Flächeneffekten; erfordert Willenskraftprobe bei bösen Kreaturen.",
+      "voraussetzungen": [],
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "custom": false
+    }
+  },
+  "ausruestung": {
+    "Angelhaken": {
+      "name": "Angelhaken",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Beutel, Gürtel": {
+      "name": "Beutel, Gürtel",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Fackel": {
+      "name": "Fackel",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.01,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Licht für 1 Stunde, 4'' Radius.",
+      "aktiv": true
+    },
+    "Feuerholz (pro Tag)": {
+      "name": "Feuerholz (pro Tag)",
+      "kategorie": "Allgemein",
+      "gewicht": 10,
+      "kosten": 0.01,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Feuerstein und Stahl": {
+      "name": "Feuerstein und Stahl",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Fischernetz (2,5 Quadratmeter)": {
+      "name": "Fischernetz (2,5 Quadratmeter)",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 4,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Flasche oder Krug, Keramik (leer)": {
+      "name": "Flasche oder Krug, Keramik (leer)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.03,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Flasche, Glas (leer)": {
+      "name": "Flasche, Glas (leer)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Flaschenzug": {
+      "name": "Flaschenzug",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Handschellen": {
+      "name": "Handschellen",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Behälter, Karte oder Schriftrolle": {
+      "name": "Behälter, Karte oder Schriftrolle",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Kerze": {
+      "name": "Kerze",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.01,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Brennt eine Stunde, spendet Licht in 2'' Radius.",
+      "aktiv": true
+    },
+    "Kette": {
+      "name": "Kette",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Krähenfüße": {
+      "name": "Krähenfüße",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Ein Beutel deckt eine kleine Flächenschablone ab, zwei eine mittlere und drei eine große. Zählt als Schwieriges Gelände; jeder der sich durch das Gebiet bewegt, muss Athletik würfeln, um nicht Angeschlagen zu werden. Ein Kritischer Fehlschlag verursacht eine Wunde an den Füßen (–2 Bewegungsweite bis geheilt).",
+      "aktiv": true
+    },
+    "Kreide": {
+      "name": "Kreide",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.01,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Lampe, klein": {
+      "name": "Lampe, klein",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "3'' Radius",
+      "aktiv": true
+    },
+    "Laterne, Blend-": {
+      "name": "Laterne, Blend-",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 12,
+      "setting": "savage_pathfinder",
+      "beschreibung": "10'' Kegel",
+      "aktiv": true
+    },
+    "Laterne, abdeckbar": {
+      "name": "Laterne, abdeckbar",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 7,
+      "setting": "savage_pathfinder",
+      "beschreibung": "6'' Radius",
+      "aktiv": true
+    },
+    "Nähnadel": {
+      "name": "Nähnadel",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Öl (für Laterne; halber Liter)": {
+      "name": "Öl (für Laterne; halber Liter)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
+      "aktiv": true
+    },
+    "Papier": {
+      "name": "Papier",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.4,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Pergament": {
+      "name": "Pergament",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Pfeife, Keramik": {
+      "name": "Pfeife, Keramik",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Phiole, klein": {
+      "name": "Phiole, klein",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Rucksack (leer)": {
+      "name": "Rucksack (leer)",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Halbiert das effektive Gewicht des Inhalts.",
+      "aktiv": true
+    },
+    "Sack (leer)": {
+      "name": "Sack (leer)",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Sanduhr": {
+      "name": "Sanduhr",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 25,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Schaufel": {
+      "name": "Schaufel",
+      "kategorie": "Allgemein",
+      "gewicht": 4,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Schlafsack": {
+      "name": "Schlafsack",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Schleifstein": {
+      "name": "Schleifstein",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.02,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Seife": {
+      "name": "Seife",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Seil, Hanf (10''/20 Meter)": {
+      "name": "Seil, Hanf (10''/20 Meter)",
+      "kategorie": "Allgemein",
+      "gewicht": 5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
+      "aktiv": true
+    },
+    "Seil, Seide (10''/20 Meter)": {
+      "name": "Seil, Seide (10''/20 Meter)",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Segeltuch (Quadratmeter)": {
+      "name": "Segeltuch (Quadratmeter)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Siegelwachs, Stange": {
+      "name": "Siegelwachs, Stange",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Spiegel, klein, Stahl": {
+      "name": "Spiegel, klein, Stahl",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Stachel (Kletterhaken)": {
+      "name": "Stachel (Kletterhaken)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 0.05,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Stange, 4 Meter": {
+      "name": "Stange, 4 Meter",
+      "kategorie": "Allgemein",
+      "gewicht": 4,
+      "kosten": 0.25,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Brechstange": {
+      "name": "Brechstange",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Tintenstift (Schreibfeder)": {
+      "name": "Tintenstift (Schreibfeder)",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Topf, Eisen": {
+      "name": "Topf, Eisen",
+      "kategorie": "Allgemein",
+      "gewicht": 2,
+      "kosten": 0.8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Trinkkrug, Keramik": {
+      "name": "Trinkkrug, Keramik",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.02,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Truhe (klein, leer)": {
+      "name": "Truhe (klein, leer)",
+      "kategorie": "Allgemein",
+      "gewicht": 6,
+      "kosten": 25,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wasserschlauch": {
+      "name": "Wasserschlauch",
+      "kategorie": "Allgemein",
+      "gewicht": 2,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Gewicht ist mit Inhalt",
+      "aktiv": true
+    },
+    "Wolldecke": {
+      "name": "Wolldecke",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wurfhaken": {
+      "name": "Wurfhaken",
+      "kategorie": "Allgemein",
+      "gewicht": 2,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Zelt, Tuch (2 Personen)": {
+      "name": "Zelt, Tuch (2 Personen)",
+      "kategorie": "Allgemein",
+      "gewicht": 10,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Bankett (pro Person)": {
+      "name": "Bankett (pro Person)",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Bier, 4 Liter": {
+      "name": "Bier, 4 Liter",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 4,
+      "kosten": 0.2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Bier, Krug": {
+      "name": "Bier, Krug",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0.5,
+      "kosten": 0.04,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Brot, Leib": {
+      "name": "Brot, Leib",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0.25,
+      "kosten": 0.02,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Käse, Klotz": {
+      "name": "Käse, Klotz",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Reiseproviant (pro Tag)": {
+      "name": "Reiseproviant (pro Tag)",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0.5,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Mahlzeit, schlicht (pro Tag)": {
+      "name": "Mahlzeit, schlicht (pro Tag)",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Mahlzeit, gewöhnlich (pro Tag)": {
+      "name": "Mahlzeit, gewöhnlich (pro Tag)",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0,
+      "kosten": 0.3,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Mahlzeit, gut (pro Tag)": {
+      "name": "Mahlzeit, gut (pro Tag)",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Tierfutter (pro Tag)": {
+      "name": "Tierfutter (pro Tag)",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 4,
+      "kosten": 0.05,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Trockenfrüchte, Beutel": {
+      "name": "Trockenfrüchte, Beutel",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0.5,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wein, 4 Liter": {
+      "name": "Wein, 4 Liter",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 4,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wein, Becher": {
+      "name": "Wein, Becher",
+      "kategorie": "Essen & Trinken",
+      "gewicht": 0.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Adeligenkleindung": {
+      "name": "Adeligenkleindung",
+      "kategorie": "Kleidung",
+      "gewicht": 5,
+      "kosten": 75,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Händlerkleidung": {
+      "name": "Händlerkleidung",
+      "kategorie": "Kleidung",
+      "gewicht": 2,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Handwerkerkleidung": {
+      "name": "Handwerkerkleidung",
+      "kategorie": "Kleidung",
+      "gewicht": 2,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Kaltwetterkleidung": {
+      "name": "Kaltwetterkleidung",
+      "kategorie": "Kleidung",
+      "gewicht": 3.5,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schützt vor Kälte",
+      "aktiv": true
+    },
+    "Königliche Kleidung": {
+      "name": "Königliche Kleidung",
+      "kategorie": "Kleidung",
+      "gewicht": 7.5,
+      "kosten": 100,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Reisekleidung": {
+      "name": "Reisekleidung",
+      "kategorie": "Kleidung",
+      "gewicht": 2.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Esel oder Maultier": {
+      "name": "Esel oder Maultier",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Hund, Wachhund": {
+      "name": "Hund, Wachhund",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0,
+      "kosten": 25,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Pferd, leicht": {
+      "name": "Pferd, leicht",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0,
+      "kosten": 75,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Siehe Seite 248",
+      "aktiv": true
+    },
+    "Pferd, schwer": {
+      "name": "Pferd, schwer",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0,
+      "kosten": 300,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Siehe Seite 248",
+      "aktiv": true
+    },
+    "Pony, leicht": {
+      "name": "Pony, leicht",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Siehe Seite 248",
+      "aktiv": true
+    },
+    "Pony, schwer": {
+      "name": "Pony, schwer",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0,
+      "kosten": 45,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Siehe Seite 248",
+      "aktiv": true
+    },
+    "Sattel, Kriegssattel": {
+      "name": "Sattel, Kriegssattel",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 15,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Freie Wiederholung bei Reitenproben, um im Sattel zu bleiben",
+      "aktiv": true
+    },
+    "Sattel, Reitsattel": {
+      "name": "Sattel, Reitsattel",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 12.5,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Satteltaschen, leer": {
+      "name": "Satteltaschen, leer",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 4,
+      "kosten": 4,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Zaumzeug und Zügel": {
+      "name": "Zaumzeug und Zügel",
+      "kategorie": "Tiere & Ausrüstung",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Herberge, schlicht (pro Tag)": {
+      "name": "Herberge, schlicht (pro Tag)",
+      "kategorie": "Unterkunft",
+      "gewicht": 0,
+      "kosten": 0.2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Herberge, gewöhnlich (pro Tag)": {
+      "name": "Herberge, gewöhnlich (pro Tag)",
+      "kategorie": "Unterkunft",
+      "gewicht": 0,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Herberge, gut (pro Tag)": {
+      "name": "Herberge, gut (pro Tag)",
+      "kategorie": "Unterkunft",
+      "gewicht": 0,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Stall (pro Tag)": {
+      "name": "Stall (pro Tag)",
+      "kategorie": "Unterkunft",
+      "gewicht": 0,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Abenteurerausrüstung": {
+      "name": "Abenteurerausrüstung",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 2.5,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Blendlaterne, Feuerstein und Stahl, Hanfseil, Kerze, kleiner Spiegel, Kreide, Mahlzeiten für 1 Woche, Rucksack, Öl, Schaufel, Schlafsack, Schleifstein, Seife, Wasserschlauch, Wurfhaken, Zusatzkleidung, 3 x Fackeln",
+      "aktiv": true
+    },
+    "Diebeswerkzeug": {
+      "name": "Diebeswerkzeug",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.25,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Dietriche und Nadeln, Handschuhe, Ölflaschen, Schmiere, Seidenseil, –2 auf Diebeskunst ohne.",
+      "aktiv": true
+    },
+    "Fernrohr": {
+      "name": "Fernrohr",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.5,
+      "kosten": 1000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Wahrnehmung +2 auf Entfernung",
+      "aktiv": true
+    },
+    "Hammer": {
+      "name": "Hammer",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.25,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Werkzeug eines Handwerkers": {
+      "name": "Werkzeug eines Handwerkers",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 1.25,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Heilertasche": {
+      "name": "Heilertasche",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.25,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Rudimentäre medizinische Ausrüstung, inklusive Salben und Verbänden, –1 auf Heilen ohne.",
+      "aktiv": true
+    },
+    "Heiliges Symbol, Holz": {
+      "name": "Heiliges Symbol, Holz",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Heiliges Symbol, Silber": {
+      "name": "Heiliges Symbol, Silber",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.5,
+      "kosten": 25,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Kaufmannswaage": {
+      "name": "Kaufmannswaage",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.25,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Kletterausrüstung": {
+      "name": "Kletterausrüstung",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 2.5,
+      "kosten": 80,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Hammer, Kletterhaken, Seil, Steigeisen und andere Ausrüstung zum Klettern. Diese Ausrüstung erlaubt es dem Anwender, bis zu 2 Punkte Abzüge beim Klettern zu ignorieren.",
+      "aktiv": true
+    },
+    "Musikinstrument": {
+      "name": "Musikinstrument",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.75,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Spitzhacke": {
+      "name": "Spitzhacke",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 1.25,
+      "kosten": 3,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Vergrößerungsglas": {
+      "name": "Vergrößerungsglas",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0,
+      "kosten": 100,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Verkleidungsausrüstung": {
+      "name": "Verkleidungsausrüstung",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 2,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schminke, Prothesen und falsches Haar. Gewährt eine freie Wiederholung bei Darbietungsproben bei Verwendung einer Verkleidung.",
+      "aktiv": true
+    },
+    "Vorschlaghammer": {
+      "name": "Vorschlaghammer",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 2.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Zauberbuch, Magier (leer)": {
+      "name": "Zauberbuch, Magier (leer)",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.75,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Zauberkomponentenbeutel": {
+      "name": "Zauberkomponentenbeutel",
+      "kategorie": "Werkzeuge & Ausrüstungssets",
+      "gewicht": 0.5,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Alchemistentasche": {
+      "name": "Alchemistentasche",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 25,
+      "setting": "fantasy",
+      "beschreibung": "Tragbares Labor mit Werkzeugen und Kräutern.",
+      "aktiv": true
+    },
+    "Artefakterschaffertasche": {
+      "name": "Artefakterschaffertasche",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 100,
+      "setting": "fantasy",
+      "beschreibung": "Werkzeuge zum Verzaubern von magischen Gegenständen.",
+      "aktiv": true
+    },
+    "Bandolier": {
+      "name": "Bandolier",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 0.5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Behälter für Karte oder Schriftrolle": {
+      "name": "Behälter für Karte oder Schriftrolle",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Buch": {
+      "name": "Buch",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 50,
+      "setting": "fantasy",
+      "beschreibung": "Ermöglicht Rechercheproben.",
+      "aktiv": true
+    },
+    "Diebeswerkzeuge": {
+      "name": "Diebeswerkzeuge",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 30,
+      "setting": "fantasy",
+      "beschreibung": "-2 auf Diebeskunst ohne Werkzeuge.",
+      "aktiv": true
+    },
+    "Fallenherstellungsset": {
+      "name": "Fallenherstellungsset",
+      "kategorie": "Allgemein",
+      "gewicht": 5,
+      "kosten": 150,
+      "setting": "fantasy",
+      "beschreibung": "-2 auf Reparieren ohne Set.",
+      "aktiv": true
+    },
+    "Fass": {
+      "name": "Fass",
+      "kategorie": "Allgemein",
+      "gewicht": 15,
+      "kosten": 2,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Feder": {
+      "name": "Feder",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Feldflasche (Metall)": {
+      "name": "Feldflasche (Metall)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Fernglas": {
+      "name": "Fernglas",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1000,
+      "setting": "fantasy",
+      "beschreibung": "Wahrnehmung +2, um entfernte Objekte zu erkennen.",
+      "aktiv": true
+    },
+    "Flasche": {
+      "name": "Flasche",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Flickzeug": {
+      "name": "Flickzeug",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Glocke": {
+      "name": "Glocke",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Gürteltasche": {
+      "name": "Gürteltasche",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Karren": {
+      "name": "Karren",
+      "kategorie": "Allgemein",
+      "gewicht": 40,
+      "kosten": 15,
+      "setting": "fantasy",
+      "beschreibung": "150 kg Ladevermögen.",
+      "aktiv": true
+    },
+    "Kette (10 Meter)": {
+      "name": "Kette (10 Meter)",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 30,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Kiste": {
+      "name": "Kiste",
+      "kategorie": "Allgemein",
+      "gewicht": 5,
+      "kosten": 5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Laterne": {
+      "name": "Laterne",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 12,
+      "setting": "fantasy",
+      "beschreibung": "Licht für 3 Stunden, 4'' Radius.",
+      "aktiv": true
+    },
+    "Öl (0,5 l)": {
+      "name": "Öl (0,5 l)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
+      "aktiv": true
+    },
+    "Pergament (pro Blatt)": {
+      "name": "Pergament (pro Blatt)",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Ruderboot": {
+      "name": "Ruderboot",
+      "kategorie": "Allgemein",
+      "gewicht": 50,
+      "kosten": 50,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Sack, klein": {
+      "name": "Sack, klein",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Seil, Hanf (20 Meter)": {
+      "name": "Seil, Hanf (20 Meter)",
+      "kategorie": "Allgemein",
+      "gewicht": 5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
+      "aktiv": true
+    },
+    "Stab (3,5 m)": {
+      "name": "Stab (3,5 m)",
+      "kategorie": "Allgemein",
+      "gewicht": 4,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Tagebuch, leer": {
+      "name": "Tagebuch, leer",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Tinte (Fläschchen)": {
+      "name": "Tinte (Fläschchen)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Krug, Keramik": {
+      "name": "Krug, Keramik",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Heiliges Symbol, Gold": {
+      "name": "Heiliges Symbol, Gold",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 100,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Schubkarre": {
+      "name": "Schubkarre",
+      "kategorie": "Allgemein",
+      "gewicht": 10,
+      "kosten": 10,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Schwertscheide": {
+      "name": "Schwertscheide",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 8,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Siegelwachs, Stab": {
+      "name": "Siegelwachs, Stab",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Kreide (Schachtel mit 12 Stück)": {
+      "name": "Kreide (Schachtel mit 12 Stück)",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Leinwand (m2)": {
+      "name": "Leinwand (m2)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Reitbedarf": {
+      "name": "Reitbedarf",
+      "kategorie": "Allgemein",
+      "gewicht": 12.5,
+      "kosten": 15,
+      "setting": "fantasy",
+      "beschreibung": "Sattel, Zaumzeug und Zügel. -2 auf Reiten ohne Ausrüstung.",
+      "aktiv": true
+    },
+    "Schaufel, klein": {
+      "name": "Schaufel, klein",
+      "kategorie": "Allgemein",
+      "gewicht": 2,
+      "kosten": 2,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Steigeisen/Kletterhaken (10)": {
+      "name": "Steigeisen/Kletterhaken (10)",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Bier, Becher": {
+      "name": "Bier, Becher",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Futter, Tier (1 Tag)": {
+      "name": "Futter, Tier (1 Tag)",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 2,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Grundrationen (1 Tag)": {
+      "name": "Grundrationen (1 Tag)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Mahlzeit, billig": {
+      "name": "Mahlzeit, billig",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Mahlzeit, durchschnittlich": {
+      "name": "Mahlzeit, durchschnittlich",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 0.5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Mahlzeit, gut": {
+      "name": "Mahlzeit, gut",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Rationen, edel (1 Tag)": {
+      "name": "Rationen, edel (1 Tag)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wasser, 1 Liter (1 Tag)": {
+      "name": "Wasser, 1 Liter (1 Tag)",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 0.25,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wein, Flasche": {
+      "name": "Wein, Flasche",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Wein, Glas": {
+      "name": "Wein, Glas",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 0.5,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Feine Kleidung": {
+      "name": "Feine Kleidung",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 100,
+      "setting": "fantasy",
+      "beschreibung": "+1 auf Überreden in Statussituationen.",
+      "aktiv": true
+    },
+    "Formelle Kleidung": {
+      "name": "Formelle Kleidung",
+      "kategorie": "Allgemein",
+      "gewicht": 2.5,
+      "kosten": 75,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Gewöhnliche Kleidung": {
+      "name": "Gewöhnliche Kleidung",
+      "kategorie": "Allgemein",
+      "gewicht": 1,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Stiefel, schwer": {
+      "name": "Stiefel, schwer",
+      "kategorie": "Allgemein",
+      "gewicht": 2,
+      "kosten": 2,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Umhang, leicht (mit Kapuze)": {
+      "name": "Umhang, leicht (mit Kapuze)",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 2,
+      "setting": "fantasy",
+      "beschreibung": "",
+      "aktiv": true
+    },
+    "Winterkleidung": {
+      "name": "Winterkleidung",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 8,
+      "setting": "fantasy",
+      "beschreibung": "Schützt vor Kälte (siehe SWAE, S. 118).",
+      "aktiv": true
+    },
+    "Abenteurerpaket": {
+      "name": "Abenteurerpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 11.5,
+      "kosten": 45,
+      "setting": "fantasy",
+      "beschreibung": "Rucksack, Schlafsack, Kerze, Kreide, gewöhnliche Kleidung, Feuerstein und Stahl, Wurfhaken, Laterne, Spiegel, Seil, Öl, Schaufel, Seife, 3 Fackeln, Wasserschlauch, Schleifstein, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Alchemistenpaket": {
+      "name": "Alchemistenpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 15.5,
+      "kosten": 50,
+      "setting": "fantasy",
+      "beschreibung": "Alchemistentasche, Rucksack, Feuerstein und Stahl, Schlafsack, Spiegel, Gürteltasche, Öl, Seil, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Diebespaket": {
+      "name": "Diebespaket",
+      "kategorie": "Allgemein",
+      "gewicht": 9.5,
+      "kosten": 65,
+      "setting": "fantasy",
+      "beschreibung": "Diebeswerkzeug, Rucksack, Spiegel, Feuerstein und Stahl, Gürteltasche, Wurfhaken, Seil, Krähenfüße, Sack (klein), Öl, Laterne, Wasserschlauch, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Gewölbeforscherpaket": {
+      "name": "Gewölbeforscherpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 15.5,
+      "kosten": 50,
+      "setting": "fantasy",
+      "beschreibung": "Seil, Wurfhaken, Rucksack, Feuerstein und Stahl, Hammer, Schlafsack, Brechstange, Laterne, Öl, Steigeisen, Schaufel, Wasserschläuche, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Klerikerpaket": {
+      "name": "Klerikerpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 6,
+      "kosten": 100,
+      "setting": "fantasy",
+      "beschreibung": "Heiliges Symbol, Schlafsack, Feuerstein und Stahl, Kerze, Heilertasche, Laterne, Öl, Pergament, Tinte, Feder, Rucksack, Wasserschlauch, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Magierpaket": {
+      "name": "Magierpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 8,
+      "kosten": 80,
+      "setting": "fantasy",
+      "beschreibung": "Zauberbuch, Rucksack, Schlafsack, Lampe, Feuerstein und Stahl, Tinte, Feder, Öl, Umhang, Buch, Wasserschlauch, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Söldnerpaket": {
+      "name": "Söldnerpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 12,
+      "kosten": 45,
+      "setting": "fantasy",
+      "beschreibung": "Schlafsack, Rucksack, Krähenfüße, Laterne, 1,5 l Öl, Bier (5 l), Feuerstein und Stahl, Krug, Seil, Handschellen, Wasserschlauch, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Unterhalterpaket": {
+      "name": "Unterhalterpaket",
+      "kategorie": "Allgemein",
+      "gewicht": 8,
+      "kosten": 120,
+      "setting": "fantasy",
+      "beschreibung": "Musikinstrument, Rucksack, Schlafsack, Spiegel, Tagebuch, Tinte und Federkiel, Feuerstein und Stahl, Mantel (leicht, mit Kapuze), formelle Kleidung, Verpflegung für 1 Woche, Flickzeug, Flasche Wein.",
+      "aktiv": true
+    },
+    "Wildnispaket": {
+      "name": "Wildnispaket",
+      "kategorie": "Allgemein",
+      "gewicht": 12,
+      "kosten": 36,
+      "setting": "fantasy",
+      "beschreibung": "Zelt (2 Personen), Rucksack, Seil, Schlafsack, Winterkleidung, Stiefel (schwer), Feuerstein und Stahl, Schaufel (klein), Umhang mit Kapuze, Wasserschlauch, Verpflegung für 1 Woche.",
+      "aktiv": true
+    },
+    "Blasrohrpfeile (20)": {
+      "name": "Blasrohrpfeile (20)",
+      "kategorie": "Allgemein",
+      "gewicht": 0,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "Nur für den Gebrauch mit dem Blasrohr. Enthält 20 Pfeile.",
+      "aktiv": true
+    },
+    "Brandpfeile (20)": {
+      "name": "Brandpfeile/-bolzen (20)",
+      "kategorie": "Allgemein",
+      "gewicht": 1.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "Halbe normale Reichweite, +1W6 Schaden, kann brennbare Gegenstände entzünden. Pro Stück.",
+      "aktiv": true
+    },
+    "Schießpulver (10)": {
+      "name": "Schießpulver (10)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "Für Schwarzpulverwaffen. Enthält 10 Schuss.",
+      "aktiv": true
+    },
+    "Schleudersteine (20)": {
+      "name": "Schleudersteine (20)",
+      "kategorie": "Allgemein",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "fantasy",
+      "beschreibung": "Polierte Steine für Schleudern. Enthält 20 Steine.",
+      "aktiv": true
+    },
+    "Beinlinge": {
+      "name": "Beinlinge",
+      "kategorie": "Rüstung",
+      "gewicht": 2.5,
+      "kosten": 5,
+      "setting": "mittelalterlich",
+      "beschreibung": "Leichte Stoffbeinlinge",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 1,
+      "kopf": 0,
+      "mindeststaerke": "W4"
+    },
+    "Robe mit Kapuze": {
+      "name": "Robe mit Kapuze",
+      "kategorie": "Rüstung",
+      "gewicht": 4,
+      "kosten": 10,
+      "setting": "mittelalterlich",
+      "beschreibung": "Robe mit Kapuze schützt Torso, Arme und Kopf",
+      "aktiv": true,
+      "torso": 1,
+      "arme": 1,
+      "beine": 0,
+      "kopf": 1,
+      "mindeststaerke": "W4"
+    },
+    "Tunika": {
+      "name": "Tunika",
+      "kategorie": "Rüstung",
+      "gewicht": 2.5,
+      "kosten": 10,
+      "setting": "mittelalterlich",
+      "beschreibung": "Leichte Stofftunika schützt Torso und Arme",
+      "aktiv": true,
+      "torso": 1,
+      "arme": 1,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W4"
+    },
+    "Umhang mit Kapuze": {
+      "name": "Umhang mit Kapuze",
+      "kategorie": "Rüstung",
+      "gewicht": 2.5,
+      "kosten": 5,
+      "setting": "mittelalterlich",
+      "beschreibung": "Leichter Umhang schützt Torso und Kopf",
+      "aktiv": true,
+      "torso": 1,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 1,
+      "mindeststaerke": "W4"
+    },
+    "Bronzearmschienen": {
+      "name": "Bronzearmschienen",
+      "kategorie": "Rüstung",
+      "gewicht": 2.5,
+      "kosten": 100,
+      "setting": "mittelalterlich",
+      "beschreibung": "Mittlere Armschienen aus Bronze",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 3,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W8"
+    },
+    "Bronzebeinschienen": {
+      "name": "Bronzebeinschienen",
+      "kategorie": "Rüstung",
+      "gewicht": 3,
+      "kosten": 200,
+      "setting": "mittelalterlich",
+      "beschreibung": "Mittlere Beinschienen aus Bronze",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 3,
+      "kopf": 0,
+      "mindeststaerke": "W8"
+    },
+    "Bronzebrustpanzer": {
+      "name": "Bronzebrustpanzer",
+      "kategorie": "Rüstung",
+      "gewicht": 6.5,
+      "kosten": 200,
+      "setting": "mittelalterlich",
+      "beschreibung": "Mittlerer Brustpanzer aus Bronze",
+      "aktiv": true,
+      "torso": 3,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W8"
+    },
+    "Schwerer geschlossener Helm": {
+      "name": "Schwerer geschlossener Helm",
+      "kategorie": "Rüstung",
+      "gewicht": 4,
+      "kosten": 300,
+      "setting": "mittelalterlich",
+      "beschreibung": "Schwerer Helm mit geschlossenem Visier",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 4,
+      "mindeststaerke": "W10"
+    },
+    "Kettenhose": {
+      "name": "Kettenhose",
+      "kategorie": "Rüstung",
+      "gewicht": 10,
+      "kosten": 100,
+      "setting": "mittelalterlich",
+      "beschreibung": "Mittlere Kettenhose schützt die Beine",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 3,
+      "kopf": 0,
+      "mindeststaerke": "W8"
+    },
+    "Bronzehelm": {
+      "name": "Bronzehelm",
+      "kategorie": "Rüstung",
+      "gewicht": 3,
+      "kosten": 120,
+      "setting": "mittelalterlich",
+      "beschreibung": "Mittlerer Helm aus Bronze",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 3,
+      "mindeststaerke": "W8"
+    },
+    "Beinlinge aus natürlicher Rüstung": {
+      "name": "Beinlinge aus natürlicher Rüstung",
+      "kategorie": "Rüstung",
+      "gewicht": 3.5,
+      "kosten": 20,
+      "setting": "mittelalterlich",
+      "beschreibung": "Beinlinge aus dicker natürlicher Rüstung",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 2,
+      "kopf": 0,
+      "mindeststaerke": "W6"
+    },
+    "Hemd aus natürlicher Rüstung": {
+      "name": "Hemd aus natürlicher Rüstung",
+      "kategorie": "Rüstung",
+      "gewicht": 5,
+      "kosten": 20,
+      "setting": "mittelalterlich",
+      "beschreibung": "Hemd aus natürlicher Rüstung schützt Torso und Arme",
+      "aktiv": true,
+      "torso": 2,
+      "arme": 2,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W6"
+    },
+    "Kleiner Schild": {
+      "name": "Kleiner Schild",
+      "kategorie": "Schild",
+      "gewicht": 2,
+      "kosten": 5,
+      "setting": "mittelalterlich",
+      "beschreibung": "Kleiner Schild für grundlegenden Schutz.",
+      "aktiv": true,
+      "parade": 1,
+      "deckung": 0,
+      "mindeststaerke": "W6"
+    },
+    "Mittlerer Schild": {
+      "name": "Mittlerer Schild",
+      "kategorie": "Schild",
+      "gewicht": 4,
+      "kosten": 9,
+      "setting": "mittelalterlich",
+      "beschreibung": "Mittlerer Schild für besseren Schutz.",
+      "aktiv": true,
+      "parade": 2,
+      "deckung": -2,
+      "mindeststaerke": "W8"
+    },
+    "Großer Schild": {
+      "name": "Großer Schild",
+      "kategorie": "Schild",
+      "gewicht": 6,
+      "kosten": 20,
+      "setting": "mittelalterlich",
+      "beschreibung": "Großer Schild für maximalen Schutz. Verringert die Bewegungsweite um 1.",
+      "aktiv": true,
+      "parade": 2,
+      "deckung": -4,
+      "mindeststaerke": "W10"
+    },
+    "Chakram": {
+      "name": "Chakram",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "mittelalterlich",
+      "beschreibung": "Parade +1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Dolch": {
+      "name": "Dolch",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "mittelalterlich",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Dreizack": {
+      "name": "Dreizack",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "mittelalterlich",
+      "beschreibung": "Reichweite 1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Haken-Schwert": {
+      "name": "Haken-Schwert",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 20,
+      "setting": "mittelalterlich",
+      "beschreibung": "+1 zum Entwaffnen.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Zweihandschwert": {
+      "name": "Zweihandschwert",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 50,
+      "setting": "mittelalterlich",
+      "beschreibung": "PB 2, Zweihändig.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W10",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": 2
+      }
+    },
+    "Spalthammer": {
+      "name": "Spalthammer",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 12,
+      "setting": "mittelalterlich",
+      "beschreibung": "PB 2, Zweihändig, +2 Schaden gegen Gegenstände.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W10",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": 2
+      }
+    },
+    "Stab": {
+      "name": "Stab",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 0,
+      "setting": "mittelalterlich",
+      "beschreibung": "Parade +1, Reichweite 1, Zweihändig.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Entermesser": {
+      "name": "Entermesser",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Keule, leicht": {
+      "name": "Keule, leicht",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 1,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Keule, schwer": {
+      "name": "Keule, schwer",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 2,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Menschenfänger": {
+      "name": "Menschenfänger",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 15,
+      "setting": "mittelalterlich",
+      "beschreibung": "Reichweite 2, Zweihändig, kein Bonusschaden bei einer Steigerung, aber das Opfer ist Gebunden",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "2",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Meteorhammer": {
+      "name": "Meteorhammer",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 12,
+      "setting": "mittelalterlich",
+      "beschreibung": "Reichweite 2, ignoriert Schildbonus, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "2",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Speer": {
+      "name": "Speer",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 2,
+      "setting": "mittelalterlich",
+      "beschreibung": "Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Speer, Kurz-": {
+      "name": "Speer, Kurz-",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 1,
+      "setting": "mittelalterlich",
+      "beschreibung": "Einhändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitflegel, Zweihand": {
+      "name": "Streitflegel, Zweihand",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 15,
+      "setting": "mittelalterlich",
+      "beschreibung": "Ignoriert Schildbonus, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitkolben, leicht": {
+      "name": "Streitkolben, leicht",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 5,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitkolben, schwer": {
+      "name": "Streitkolben, schwer",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 12,
+      "setting": "mittelalterlich",
+      "beschreibung": "PB 1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "-",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Handrepetierarmbrust": {
+      "name": "Handrepetierarmbrust",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 160,
+      "setting": "mittelalterlich",
+      "beschreibung": "Kartusche mit 5 Bolzen oder 1 Bolzen. Nachladen 1. Rückstoßabzug.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "5/10/20",
+        "FR": 2,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Donnerbüchse": {
+      "name": "Donnerbüchse",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 300,
+      "setting": "schwarzpulver",
+      "beschreibung": "Regeln wie Schrotflinte (SWAE S. 106). Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "1-3W6",
+        "Reichweite": "10/20/40",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Muskete": {
+      "name": "Muskete",
+      "kategorie": "Waffe",
+      "gewicht": 7.5,
+      "kosten": 300,
+      "setting": "schwarzpulver",
+      "beschreibung": "Schwere, lange Feuerwaffe. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W8",
+        "Reichweite": "10/20/40",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Armbrust, Leichte Repetier-": {
+      "name": "Armbrust, Leichte Repetier-",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 4,
+      "kosten": 250,
+      "setting": "mittelalterlich",
+      "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen. Verursacht einen Abzug für Rückstoß.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6",
+        "Reichweite": "10/20/40",
+        "FR": 1,
+        "Schuss": "5 (Kartusche)",
+        "PB": "2"
+      }
+    },
+    "Armbrust, Schwere Repetier-": {
+      "name": "Armbrust, Schwere Repetier-",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 6,
+      "kosten": 400,
+      "setting": "mittelalterlich",
+      "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "2W8",
+        "Reichweite": "15/30/60",
+        "FR": 1,
+        "Schuss": "5 (Kartusche)",
+        "PB": "2"
+      }
+    },
+    "Axt, Hand-": {
+      "name": "Axt, Hand-",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 1.5,
+      "kosten": 6,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "3/6/12",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Bogen, Komposit-": {
+      "name": "Bogen, Komposit-",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 1.5,
+      "kosten": 100,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "12/24/48",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Bogen, Kurz-": {
+      "name": "Bogen, Kurz-",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 1,
+      "kosten": 30,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6",
+        "Reichweite": "12/24/48",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Wurf-Chakram": {
+      "name": "Wurf-Chakram",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "4/8/16",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Dolch/Messer": {
+      "name": "Dolch/Messer",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "3/6/12",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Wurf-Dreizack": {
+      "name": "Wurf-Dreizack",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "3/6/12",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kurz-/Wurfspeer": {
+      "name": "Kurz-/Wurfspeer",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 1.5,
+      "kosten": 1,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "4/8/16",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Wurf-Speer": {
+      "name": "Wurf-Speer",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 3,
+      "kosten": 2,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "3/6/12",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Steinschlosspistole": {
+      "name": "Steinschlosspistole",
+      "kategorie": "Fernkampfwaffe",
+      "gewicht": 1.5,
+      "kosten": 150,
+      "setting": "mittelalterlich",
+      "beschreibung": "-",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": 1,
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Gegengift, Phiole": {
+      "name": "Gegengift, Phiole",
+      "kategorie": "Allgemein",
+      "gewicht": 0.25,
+      "kosten": 50,
+      "setting": "mittelalterlich",
+      "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
+      "aktiv": true
+    },
+    "Ledertunika": {
+      "name": "Ledertunika",
+      "kategorie": "Rüstung",
+      "gewicht": 5.5,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Tunika oder Wams aus Leder oder beschlagenem Leder",
+      "aktiv": true,
+      "torso": 2,
+      "arme": 2,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W6"
+    },
+    "Lederbeinlinge": {
+      "name": "Lederbeinlinge",
+      "kategorie": "Rüstung",
+      "gewicht": 4,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Beinlinge aus Leder",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 2,
+      "kopf": 0,
+      "mindeststaerke": "W6"
+    },
+    "Lederkappe": {
+      "name": "Lederkappe",
+      "kategorie": "Rüstung",
+      "gewicht": 0.5,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Kappe aus Leder",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 2,
+      "mindeststaerke": "W6"
+    },
+    "Kettenhemd": {
+      "name": "Kettenhemd",
+      "kategorie": "Rüstung",
+      "gewicht": 11,
+      "kosten": 100,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Hemd aus Kettenrüstung oder Schuppenrüstung",
+      "aktiv": true,
+      "torso": 3,
+      "arme": 3,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W8"
+    },
+    "Kettenbeinlinge": {
+      "name": "Kettenbeinlinge",
+      "kategorie": "Rüstung",
+      "gewicht": 2.5,
+      "kosten": 100,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Beinlinge aus Kettenrüstung",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 3,
+      "kopf": 0,
+      "mindeststaerke": "W8"
+    },
+    "Kettenhaube": {
+      "name": "Kettenhaube",
+      "kategorie": "Rüstung",
+      "gewicht": 1.5,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Kettenhaube oder Helm",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 3,
+      "mindeststaerke": "W8"
+    },
+    "Plattenbrustharnisch": {
+      "name": "Plattenbrustharnisch",
+      "kategorie": "Rüstung",
+      "gewicht": 15,
+      "kosten": 500,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Brustharnisch aus Plattenrüstung",
+      "aktiv": true,
+      "torso": 4,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W10"
+    },
+    "Plattenarmschienen": {
+      "name": "Plattenarmschienen",
+      "kategorie": "Rüstung",
+      "gewicht": 5,
+      "kosten": 250,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Armschienen aus Plattenrüstung",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 4,
+      "beine": 0,
+      "kopf": 0,
+      "mindeststaerke": "W10"
+    },
+    "Plattenbeinschienen": {
+      "name": "Plattenbeinschienen",
+      "kategorie": "Rüstung",
+      "gewicht": 5,
+      "kosten": 500,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Beinschienen aus Plattenrüstung",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 4,
+      "kopf": 0,
+      "mindeststaerke": "W10"
+    },
+    "Schwerer Helm": {
+      "name": "Schwerer Helm",
+      "kategorie": "Rüstung",
+      "gewicht": 2,
+      "kosten": 250,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwerer Helm aus Metall",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 4,
+      "mindeststaerke": "W10"
+    },
+    "Schwerer Helm umschließend": {
+      "name": "Schwerer Helm umschließend",
+      "kategorie": "Rüstung",
+      "gewicht": 4,
+      "kosten": 300,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwerer umschließender Helm. –1 auf Wahrnehmungsproben, die auf Sicht basieren",
+      "aktiv": true,
+      "torso": 0,
+      "arme": 0,
+      "beine": 0,
+      "kopf": 4,
+      "mindeststaerke": "W10"
+    },
+    "Rüstungsstacheln": {
+      "name": "Rüstungsstacheln",
+      "kategorie": "Rüstungsmodifikation",
+      "gewicht": 5,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "+1 Schaden beim Zerquetschen beim Ringen",
+      "aktiv": true
+    },
+    "Panzerhandschuh beriemt": {
+      "name": "Panzerhandschuh beriemt",
+      "kategorie": "Rüstungsmodifikation",
+      "gewicht": 2.5,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "+1 auf Stärkeproben gegen Entwaffnen (Ketten und Spangen erfordern eine Aktion zum Anziehen/Ausziehen)",
+      "aktiv": true
+    },
+    "Rossharnisch Leder": {
+      "name": "Rossharnisch Leder",
+      "kategorie": "Pferderüstung",
+      "gewicht": 25,
+      "kosten": 300,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Pferderüstung aus Leder (+2 Panzerung)",
+      "aktiv": true,
+      "panzerung": 2,
+      "mindeststaerke": "W8"
+    },
+    "Rossharnisch Kette": {
+      "name": "Rossharnisch Kette",
+      "kategorie": "Pferderüstung",
+      "gewicht": 55,
+      "kosten": 500,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Pferderüstung aus Kette (+3 Panzerung)",
+      "aktiv": true,
+      "panzerung": 3,
+      "mindeststaerke": "W10"
+    },
+    "Rossharnisch Platte": {
+      "name": "Rossharnisch Platte",
+      "kategorie": "Pferderüstung",
+      "gewicht": 65,
+      "kosten": 5000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Pferderüstung aus Platte (+4 Panzerung)",
+      "aktiv": true,
+      "panzerung": 4,
+      "mindeststaerke": "W12"
+    },
+    "Leichter Schild": {
+      "name": "Leichter Schild",
+      "kategorie": "Schild",
+      "gewicht": 2,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Leichter Schild für grundlegenden Schutz",
+      "aktiv": true,
+      "parade": 1,
+      "deckung": 0,
+      "mindeststaerke": "W6"
+    },
+    "Mittelschwerer Schild": {
+      "name": "Mittelschwerer Schild",
+      "kategorie": "Schild",
+      "gewicht": 4,
+      "kosten": 9,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Mittelschwerer Schild für besseren Schutz",
+      "aktiv": true,
+      "parade": 2,
+      "deckung": -2,
+      "mindeststaerke": "W8"
+    },
+    "Schwerer Schild": {
+      "name": "Schwerer Schild",
+      "kategorie": "Schild",
+      "gewicht": 6,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwerer Schild für maximalen Schutz. –1 Bewegungsweite",
+      "aktiv": true,
+      "parade": 2,
+      "deckung": -4,
+      "mindeststaerke": "W10"
+    },
+    "Schildstacheln": {
+      "name": "Schildstacheln",
+      "kategorie": "Schildmodifikation",
+      "gewicht": 0,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "+1 Schaden bei Angriffen mit dem Schild",
+      "aktiv": true
+    },
+    "Handarmbrust": {
+      "name": "Handarmbrust",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1, eine einhändige, pistolenartige Armbrust",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Hand-Repetierarmbrust": {
+      "name": "Hand-Repetierarmbrust",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 160,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Leichte Armbrust": {
+      "name": "Leichte Armbrust",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 35,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1, handgespannt",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6",
+        "Reichweite": "10/20/40",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Leichte Repetierarmbrust": {
+      "name": "Leichte Repetierarmbrust",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 250,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6",
+        "Reichweite": "10/20/40",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Schwere Armbrust": {
+      "name": "Schwere Armbrust",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "wird mit Winde gespannt, Nachladen 2",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W8",
+        "Reichweite": "15/30/60",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Schwere Repetierarmbrust": {
+      "name": "Schwere Repetierarmbrust",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 400,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 2 einzelnen Bolzen",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "2W8",
+        "Reichweite": "15/30/60",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Handaxt": {
+      "name": "Handaxt",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 6,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Bolas": {
+      "name": "Bolas",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Bolas haben eine Härte von 8.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Blasrohr": {
+      "name": "Blasrohr",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "W4-2",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kurzbogen": {
+      "name": "Kurzbogen",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6",
+        "Reichweite": "12/24/48",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Langbogen": {
+      "name": "Langbogen",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 75,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "2W6",
+        "Reichweite": "15/30/60",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Kompositbogen": {
+      "name": "Kompositbogen",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 100,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "12/24/48",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Dolch/Messer Fernkampf": {
+      "name": "Dolch/Messer",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Dreizack Fernkampf": {
+      "name": "Dreizack",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kurzspeer/Wurfspeer": {
+      "name": "Kurzspeer/Wurfspeer",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "4/8/16",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Netz (beschwert)": {
+      "name": "Netz (beschwert)",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Das Netz hat Härte 10.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "-",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Schleuder": {
+      "name": "Schleuder",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Athletik (Werfen)",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "4/8/16",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Shuriken": {
+      "name": "Shuriken",
+      "kategorie": "Waffe",
+      "gewicht": 0,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Speer Fernkampf": {
+      "name": "Speer",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Sternmesser Fernkampf": {
+      "name": "Sternmesser",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 28,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Handaxt Nahkampf": {
+      "name": "Handaxt",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 6,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitaxt": {
+      "name": "Streitaxt",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Zweihandaxt": {
+      "name": "Zweihandaxt",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 2, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W10",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Sense": {
+      "name": "Sense",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 18,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Sichel": {
+      "name": "Sichel",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 3,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Speer Nahkampf": {
+      "name": "Speer",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kurzer Speer": {
+      "name": "Kurzer Speer",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Einhändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Stachelkette": {
+      "name": "Stachelkette",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, ignoriert Schildbonus, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Sternmesser Nahkampf": {
+      "name": "Sternmesser",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 28,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Parade +1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitkolben leicht": {
+      "name": "Streitkolben, leicht",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitkolben schwer": {
+      "name": "Streitkolben, schwer",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 12,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Totschläger": {
+      "name": "Totschläger",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Betäubungsschaden",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Bolzen (10)": {
+      "name": "Bolzen (10)",
+      "kategorie": "Munition",
+      "gewicht": 0.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Bolzen für alle Arten von Armbrüsten. Eine Kartusche mit fünf Bolzen, die 1 Pfund wiegt, kann für +10 GM für eine Repetierarmbrust erworben werden.",
+      "aktiv": true
+    },
+    "Pfeil Blasrohr (10)": {
+      "name": "Pfeil Blasrohr (10)",
+      "kategorie": "Munition",
+      "gewicht": 0,
+      "kosten": 0.5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Pfeile für ein Blasrohr",
+      "aktiv": true
+    },
+    "Pfeile (20)": {
+      "name": "Pfeile (20)",
+      "kategorie": "Munition",
+      "gewicht": 1.5,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Pfeile für alle Arten von Bögen",
+      "aktiv": true
+    },
+    "Schleudersteine (10)": {
+      "name": "Schleudersteine (10)",
+      "kategorie": "Munition",
+      "gewicht": 0.5,
+      "kosten": 0.1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Polierte Steine",
+      "aktiv": true
+    },
+    "Dolch/Messer Nahkampf": {
+      "name": "Dolch/Messer",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Dreizack Nahkampf": {
+      "name": "Dreizack",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Reichweite 1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitflegel": {
+      "name": "Streitflegel",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "ignoriert Schildbonus",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Streitflegel schwer": {
+      "name": "Streitflegel, schwer",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "ignoriert Schildbonus, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Glefe": {
+      "name": "Glefe",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Reichweite 1, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Guisarme": {
+      "name": "Guisarme",
+      "kategorie": "Waffe",
+      "gewicht": 4.5,
+      "kosten": 12,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, Reichweite 1, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Hellebarde": {
+      "name": "Hellebarde",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, Reichweite 1, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Katana": {
+      "name": "Katana",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6+1",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kampfstab": {
+      "name": "Kampfstab",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 0,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Parade +1, Reichweite 1, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Keule leicht": {
+      "name": "Keule, leicht",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Keule schwer": {
+      "name": "Keule, schwer",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kriegshammer": {
+      "name": "Kriegshammer",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 12,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Krummsäbel": {
+      "name": "Krummsäbel",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Krummschwert": {
+      "name": "Krummschwert",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 75,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Lanze": {
+      "name": "Lanze",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 2 bei Sturmangriff, Reichweite 2, nur im berittenen Kampf verwendbar",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "2",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Morgenstern": {
+      "name": "Morgenstern",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 8,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Peitsche": {
+      "name": "Peitsche",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Parade –1, Reichweite 2. Bei einer Steigerung beim Angriffswurf ist das Opfer Festgehalten anstelle von Bonusschaden.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "2",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Pike": {
+      "name": "Pike",
+      "kategorie": "Waffe",
+      "gewicht": 9,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, wenn aufgesetzt, Reichweite 2, Zweihändig",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "2",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Ranseur": {
+      "name": "Ranseur",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, Reichweite 1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "1",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Rapier": {
+      "name": "Rapier",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Parade +1",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "Stä+W4",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Schlägel": {
+      "name": "Schlägel",
+      "kategorie": "Waffe",
+      "gewicht": 5,
+      "kosten": 12,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 2, Zweihändig, +2 Schaden zum Zerstören von Gegenständen",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W10",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Bastardschwert": {
+      "name": "Bastardschwert",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 35,
+      "setting": "savage_pathfinder",
+      "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "1"
+      }
+    },
+    "Kurzschwert": {
+      "name": "Kurzschwert",
+      "kategorie": "Waffe",
+      "gewicht": 1,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Langschwert": {
+      "name": "Langschwert",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Kanone Rundgeschoss": {
+      "name": "Kanone Rundgeschoss",
+      "kategorie": "Belagerungswaffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwere Waffe, Nachladen 8. Zwei Besatzungsmitglieder können gleichzeitig nachladen. Bei Erfolg prallt die Kugel bei geradem Würfelergebnis zu einem weiteren Opfer hinter dem ersten Ziel (innerhalb von 6\") ab.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "3W6+1",
+        "Reichweite": "50/100/200",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "4",
+        "Flächenschablone": "MFS"
+      }
+    },
+    "Balliste": {
+      "name": "Balliste",
+      "kategorie": "Belagerungswaffe",
+      "gewicht": 0,
+      "kosten": 500,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Einzelperson oder 2 Minuten für eine Mannschaft von 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "3W6",
+        "Reichweite": "15/30/60",
+        "FR": "Speziell",
+        "Schuss": "-",
+        "PB": "4"
+      }
+    },
+    "Belagerungsturm": {
+      "name": "Belagerungsturm",
+      "kategorie": "Belagerungsgerät",
+      "gewicht": 0,
+      "kosten": 2000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Keine Fernkampfwaffe, wird zum Erklimmen von Mauern verwendet; Schützen können aus den oberen Stockwerken feuern. Bewegungsweite 1 mit 8 Personen, verdoppelt mit 16 Personen.",
+      "aktiv": true
+    },
+    "Trebuchet": {
+      "name": "Trebuchet",
+      "kategorie": "Belagerungswaffe",
+      "gewicht": 0,
+      "kosten": 1000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "3W8",
+        "Reichweite": "30/60/120",
+        "FR": "Speziell",
+        "Schuss": "-",
+        "PB": "4",
+        "Flächenschablone": "MFS"
+      }
+    },
+    "Katapult": {
+      "name": "Katapult",
+      "kategorie": "Belagerungswaffe",
+      "gewicht": 0,
+      "kosten": 800,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "3W6",
+        "Reichweite": "24/48/96",
+        "FR": "Speziell",
+        "Schuss": "-",
+        "PB": "4",
+        "Flächenschablone": "MFS"
+      }
+    },
+    "Rammbock": {
+      "name": "Rammbock",
+      "kategorie": "Belagerungsgerät",
+      "gewicht": 1000,
+      "kosten": 1000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Keine Fernkampfwaffe, wird zum Zertrümmern von Objekten verwendet. Mindestens 2 Personen nötig, bis zu 8 können helfen.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "3W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Alchemistenfeuer": {
+      "name": "Alchemistenfeuer",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.5,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Eine klebrige, brennbare Flüssigkeit, die beim Aufschlag in Brand gerät. Schwere Waffe. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn sie nicht in Wasser untergetaucht werden. Ziel könnte in Brand geraten.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-",
+        "Flächenschablone": "KFS"
+      }
+    },
+    "Donnerstein": {
+      "name": "Donnerstein",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.5,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Ein verzauberter Felsen, der mit einem ohrenbetäubenden Knall explodiert. Alle in der Schablone müssen eine Konstitutionsprobe schaffen, um nicht Angeschlagen und für eine Stunde taub zu sein.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "-",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-",
+        "Flächenschablone": "MFS"
+      }
+    },
+    "Ewige Fackel": {
+      "name": "Ewige Fackel",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.5,
+      "kosten": 110,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Eine 'Fackel', die dauerhaft mit Licht verzaubert ist. Verbrennt nicht und gibt keine Hitze ab.",
+      "aktiv": true
+    },
+    "Gegengift Phiole": {
+      "name": "Gegengift, Phiole",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.25,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
+      "aktiv": true
+    },
+    "Rauchstab": {
+      "name": "Rauchstab",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.05,
+      "kosten": 20,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Ein alchemistisch behandelter Stock, der dichten Rauch (Dunkle Beleuchtung) in einer Mittleren Flächenschablone erzeugt. Er hält 1 Minute lang an und löst sich in starkem Wind innerhalb einer Runde auf.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "-",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-",
+        "Flächenschablone": "MFS"
+      }
+    },
+    "Säureflasche": {
+      "name": "Säureflasche",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.5,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Wird wie eine Granate geworfen. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn die Säure nicht abgewaschen wird.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-",
+        "Flächenschablone": "KFS"
+      }
+    },
+    "Sonnenzepter": {
+      "name": "Sonnenzepter",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.5,
+      "kosten": 2,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Ein Eisenstab mit Goldspitzen, der für sechs Stunden in einem Radius von 9 m normales Licht erzeugt. Es erhöht die Beleuchtungsstufe darüber hinaus für weitere 9\" um eine Stufe. Es gibt keine Hitze ab und zählt als Sonnenlicht.",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "1W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Verstrickungsbeutel": {
+      "name": "Verstrickungsbeutel",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 4,
+      "kosten": 50,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Ein Opfer mit Größe 3 oder weniger, das von diesem kleinen Beutel klebrigen Materials getroffen wird, ist für fünf Runden Abgelenkt und muss eine Athletikprobe schaffen, um nicht auch am Boden festzukleben (Festgehalten).",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "-",
+        "Reichweite": "1/2/4",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Heiliges Wasser": {
+      "name": "Heiliges Wasser",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0,
+      "kosten": 25,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Heiliges Wasser kann in einer Flasche geworfen oder auf eine angrenzende Kreatur gespritzt werden. Untote und bestimmte böse Kreaturen innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "-",
+        "PB": "-",
+        "Flächenschablone": "KFS"
+      }
+    },
+    "Zündholz": {
+      "name": "Zündholz",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.05,
+      "kosten": 1,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Ein dünnes Stäbchen, das eine Flamme erzeugt, wenn es hart gegen eine Oberfläche geschlagen wird. Dies ermöglicht es, Fackeln und andere brennbare Substanzen in einer Aktion zu entzünden.",
+      "aktiv": true
+    }
+  },
+  "settingregeln": {
+    "strahlschablone": false,
+    "große_hoehen": false,
+    "verrat": false,
+    "schwierige_heilung": false,
+    "freizeit": false,
+    "riesige_feinde,": false,
+    "schurkische_entschlossenheit": false,
+    "dynamischer_rueckschlag": false,
+    "entschlossenheit": false,
+    "fanatiker": false,
+    "fertigkeitsspezialisierungen": false,
+    "fieser_schaden": false,
+    "geborener_held": false,
+    "grosse_abenteuer": false,
+    "helden_sterben_nie": false,
+    "keine_machtpunkte": false,
+    "kreativer_kampf": false,
+    "mehr_fertigkeitspunkte": false,
+    "mehr_sprachen": false,
+    "narrenglueck": false,
+    "schnelle_genesung": false,
+    "schwere_entscheidungen": false,
+    "ungepanzerter_held": false,
+    "wundobergrenze": false
+  },
+  "startgeld": 300,
+  "waehrung": "GM"
 }


### PR DESCRIPTION
Neue Pathfinder-spezifische Handicaps (leicht/schwer):
- Ahnen-Schwäche (leicht/schwer): +2/+4 Schaden durch Feuer, Kälte oder Elektrizität
- Bevorzugte Klasse (leicht/schwer): Einschränkungen bei Klassen-Eigenschaften
- Hilflos (leicht/schwer): Abgelenkt/Verwundbar wenn Verbündeter eine Wunde erleidet
- Kurzsichtig (leicht/schwer): Einschränkungen bei Überzeugung und Sonderfähigkeiten

Neue Pathfinder-spezifische Handicaps (nur leicht):
- Akribisch: –4 auf ungelernte Fertigkeitsproben
- Eingeengt: Rüstungsbeschränkung (mittelschwer) für Klassen-Eigenschaften
- Feengeraubt: –2 gegen Krankheit/Gift und gegen Feenwesen-Fähigkeiten
- Gewöhnliche Sicht: Verlust von Dämmerungs- oder Nachtsicht
- Magischer Tollpatsch: Magische Gegenstände benötigen beschränkte Aktion
- Schattenentblößung: Kein oder monströser Schatten, schlechtere Reaktionen
- Schreckhaft: Schreckensprobe bei Wahrnehmung von Feenwesen/Außenseitern/Untoten
- Unaufmerksam: Halber Schaden statt kein Schaden bei erfolgreichem Ausweichmanöver

Neue Pathfinder-spezifische Handicaps (nur schwer):
- Befleckter Geist: Konstitutionswurf nach Kampf oder Erschöpfungsstufe
- Einzelgänger: Kein Überzahl-Bonus
- Verbittert: –2 auf Heilungsproben anderer Charaktere

https://claude.ai/code/session_012JnYyRAEQHbj41KbcnHqcA