### PR TITLE
feat: Savage Pathfinder Rassen-Hintergrundtalente hinzugefügt

### DIFF
--- a/functions/talent_funktionen.py
+++ b/functions/talent_funktionen.py
@@ -782,6 +782,20 @@ class TalentManager:
 
             return fehlermeldungen
 
+        # Handicap-Voraussetzung (z.B. "Handicap: Klein" oder "Handicap: Rüstungsbeschränkung")
+        if voraussetzung.startswith("Handicap: "):
+            handicap_prefix = voraussetzung[len("Handicap: "):]
+            hat_handicap = False
+            if hasattr(self.charakter, 'handicaps'):
+                for h_key, h_obj in self.charakter.handicaps.items():
+                    is_selected = getattr(h_obj, 'ausgewaehlt', False)
+                    if is_selected and h_key.startswith(handicap_prefix):
+                        hat_handicap = True
+                        break
+            if not hat_handicap:
+                fehlermeldungen.append(f"Handicap '{handicap_prefix}' wird vorausgesetzt.")
+            return fehlermeldungen
+
         # Volk-Voraussetzung (z.B. "Volk: Aasimars")
         if voraussetzung.startswith("Volk: "):
             volk_name = voraussetzung[len("Volk: "):]

--- a/functions/talent_funktionen.py
+++ b/functions/talent_funktionen.py
@@ -771,6 +771,29 @@ class TalentManager:
 
             return fehlermeldungen
 
+        # Volk-Voraussetzung (z.B. "Volk: Aasimars")
+        if voraussetzung.startswith("Volk: "):
+            volk_name = voraussetzung[len("Volk: "):]
+            if not hasattr(self.charakter, 'voelker_selected') or not self.charakter.voelker_selected.get(volk_name, False):
+                fehlermeldungen.append(f"Volk '{volk_name}' wird vorausgesetzt.")
+            return fehlermeldungen
+
+        # Volk-Eigenschaft-Voraussetzung (z.B. "Volk-Eigenschaft: dunkelsicht")
+        if voraussetzung.startswith("Volk-Eigenschaft: "):
+            eigenschaft_key = voraussetzung[len("Volk-Eigenschaft: "):]
+            hat_eigenschaft = False
+            if hasattr(self.charakter, 'voelker') and hasattr(self.charakter, 'voelker_selected'):
+                for v_name, ist_ausgewaehlt in self.charakter.voelker_selected.items():
+                    if ist_ausgewaehlt and v_name in self.charakter.voelker:
+                        volk_obj = self.charakter.voelker[v_name]
+                        spez = volk_obj.effects.get('spezielle_effekte', {})
+                        if spez.get(eigenschaft_key, False):
+                            hat_eigenschaft = True
+                            break
+            if not hat_eigenschaft:
+                fehlermeldungen.append(f"Volk-Eigenschaft '{eigenschaft_key}' wird vorausgesetzt.")
+            return fehlermeldungen
+
         # Talentvoraussetzung (z.B. "Glück")
         talent_name = voraussetzung  # Annahme: Wenn keine spezielle Formatierung, handelt es sich um ein Talent
 

--- a/functions/talent_funktionen.py
+++ b/functions/talent_funktionen.py
@@ -673,6 +673,17 @@ class TalentManager:
         """
         fehlermeldungen = []
 
+        # Rang-Voraussetzung (z.B. "A", "F", "V", "H", "L")
+        rang_hierarchie = {'A': 1, 'F': 2, 'V': 3, 'H': 4, 'L': 5}
+        if voraussetzung in rang_hierarchie:
+            charakter_rang = getattr(self.charakter, 'rang', 'A') or 'A'
+            charakter_rang_wert = rang_hierarchie.get(charakter_rang.upper()[0], 1)
+            erforderlicher_wert = rang_hierarchie[voraussetzung]
+            rang_namen = {'A': 'Anfänger', 'F': 'Fortgeschritten', 'V': 'Veteran', 'H': 'Held', 'L': 'Legendär'}
+            if charakter_rang_wert < erforderlicher_wert:
+                fehlermeldungen.append(f"Rang '{rang_namen[voraussetzung]}' wird vorausgesetzt.")
+            return fehlermeldungen
+
         # Spezialfall: "AH" oder "AH (beliebig)" - beliebiger Arkaner Hintergrund
         if voraussetzung == "AH" or voraussetzung == "AH (beliebig)":
             hat_arkanen_hintergrund = False

--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -4198,6 +4198,201 @@
       "ausgewaehlt": false,
       "aktiv": true
     },
+    "Rüstungsausbildung": {
+      "name": "Rüstungsausbildung",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Handicap: Rüstungsbeschränkung"
+      ],
+      "beschreibung": "Der Charakter ist im Umgang mit Rüstungen geübt: Die Abzüge durch Rüstungsbeschränkung werden um 2 reduziert (Rüstungsbeschränkung (leicht) → kein GES-Abzug; Rüstungsbeschränkung (mittelschwer) → Abzüge wie bei leichter Beschränkung).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Deckende Verteidigung": {
+      "name": "Deckende Verteidigung",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Wenn der Charakter den Verteidigungsmanöver einsetzt (beide Aktionen, +4 Parade), erhalten alle Verbündeten in Reichweite von 2'' ebenfalls +2 auf ihre Parade.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Lähmender Angriff": {
+      "name": "Lähmender Angriff",
+      "kategorie": "Kampf",
+      "rang": "H",
+      "voraussetzungen": [
+        "Lieblingswaffe"
+      ],
+      "beschreibung": "Mit einer Erhöhung bei einem Angriff mit der Lieblingswaffe wird die Bewegungsweite des Ziels um 2 reduziert (Minimum 1). Dieser Malus gilt bis zur Heilung oder bis zum Ende der Begegnung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Armbrustmeisterschaft": {
+      "name": "Armbrustmeisterschaft",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schnelles Nachladen",
+        "Schießen W8"
+      ],
+      "beschreibung": "Der Charakter schießt mit einer Armbrust so schnell wie mit einem Bogen (kein Nachteil durch Nachladezeit; Armbrust gilt als Nachladen 0). Zudem kann er eine Armbrust im Nahkampf als schwere Keule einsetzen (STÄ+W6 Schaden, kein Abzug).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystische Klauen": {
+      "name": "Mystische Klauen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Erfordert natürliche Klauenangriffe (z.B. Katzenkrallen). Die Klauen lösen Umgebungsschwächen von Kreaturen aus (z.B. Silber bei Werwölfen, Feuer bei Untoten) und gelten als magische Waffen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wilde Klauen": {
+      "name": "Wilde Klauen",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "STÄ W6"
+      ],
+      "beschreibung": "Erfordert natürliche Klauenangriffe (z.B. Katzenkrallen). Die Klauen verursachen erhöhten Schaden (STÄ+W6 statt STÄ+W4) und gelten als Panzerbrecher (AP 2).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Reißende Klauen": {
+      "name": "Reißende Klauen",
+      "kategorie": "Kampf",
+      "rang": "H",
+      "voraussetzungen": [
+        "Wilde Klauen",
+        "STÄ W8"
+      ],
+      "beschreibung": "Die Klauen des Charakters verursachen Reißende Angriffe: Bei einem Treffer mit einer Erhöhung muss das Ziel eine Konstitutionsprobe ablegen oder erleidet eine zusätzliche Wunde durch Blutung/Reißen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Heldenhafter Widerstand": {
+      "name": "Heldenhafter Widerstand",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "KON W8"
+      ],
+      "beschreibung": "Einmal pro Szene kann der Charakter als begrenzte freie Aktion automatisch einen der folgenden negativen Zustände aufheben: Erschüttert, Abgelenkt oder Erschöpft.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Geschossabwehr": {
+      "name": "Geschossabwehr",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [],
+      "beschreibung": "Der Charakter erhält +2 Robustheit gegen alle Fernkampfangriffe (Schießen, Athletik-Würfe für Wurfwaffen und ähnliche Distanzangriffe).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Berittener Schild": {
+      "name": "Berittener Schild",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [],
+      "beschreibung": "Der Charakter kann seinen Schildbonus (Parade und Robustheit) auf sein Reittier übertragen, solange er berittenen Kampf führt und das Schild hält.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Nahschussmeister": {
+      "name": "Nahschussmeister",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Schießen W10"
+      ],
+      "beschreibung": "Der Charakter erleidet keinen Abzug auf Schießen-Proben, wenn er sich im Nahkampf befindet oder angebunden ist. Zudem kann er im Nahkampf schießen, ohne einen automatischen Kritischen Fehlschlag zu riskieren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schattenangriff": {
+      "name": "Schattenangriff",
+      "kategorie": "Kampf",
+      "rang": "V",
+      "voraussetzungen": [
+        "Hinterhältiger Angriff",
+        "Kämpfen W6"
+      ],
+      "beschreibung": "Der Charakter kann den Hinterhältigen Angriff in Gebieten mit schlechter Beleuchtung (Düster oder Dunkel) einsetzen, auch ohne volle Deckung oder direkten Überraschungsangriff.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Berührung der Stille": {
+      "name": "Berührung der Stille",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "WIL W8",
+        "Waffenloser Schlag",
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Ki-Aktion (1 Machtpunkt): Bei einem erfolgreichen unbewaffneten Treffer muss das Ziel eine Willenskraftprobe ablegen oder kann bis zum Ende seines nächsten Zuges keine Aktionen ausführen (gilt als Erschöpft).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Stolperschlag": {
+      "name": "Stolperschlag",
+      "kategorie": "Kampf",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Mit einer Erhöhung bei einem Nahkampfangriff kann der Charakter das Ziel zu Boden werfen: Das Ziel fällt hin (Hingeworfen, –2 auf alle Proben; Angreifer erhalten +2 auf Angriffe gegen das Ziel).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Unter dem Riesen": {
+      "name": "Unter dem Riesen",
+      "kategorie": "Kampf",
+      "rang": "A",
+      "voraussetzungen": [
+        "Handicap: Klein",
+        "Athletik W8"
+      ],
+      "beschreibung": "Wenn ein Gegner der Größe 1 oder größer diesen Charakter angreift, kann der Charakter als freie Aktion eine Athletik-Probe ablegen. Bei Erfolg fällt der Gegner hin (Hingeworfen). Einmal pro Zug einsetzbar.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
     "Ausweichen": {
       "name": "Ausweichen",
       "kategorie": "Kampf",

--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -1545,6 +1545,443 @@
       "ausgewaehlt": false,
       "aktiv": true
     },
+    "Alchemist": {
+      "name": "Alchemist",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6"
+      ],
+      "beschreibung": "Alchemische Identifikation (+2 auf Proben zur Identifikation alchemischer Gegenstände), AH (Alchemist) [Arkane Fertigkeit: Alchemie], Behindernde Rüstung (leicht), Bomben (Aktion: wirf eine Bombe, 1W6 Schaden in Bereich), Extrakte (Tränke für Kraftvolle Heilung oder Eigenschaftsverbesserung), Mutagene (Konstitution für Stärke, Intelligenz für Ausdauer oder Geschicklichkeit für Abwehr tauschen).",
+      "neue_maechte": 3,
+      "machtpunkte": 15,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "AH (Alchemist)"
+      ],
+      "auto_handicaps": [
+        "Behindernde Rüstung_leicht"
+      ]
+    },
+    "Entdeckung": {
+      "name": "Entdeckung",
+      "kategorie": "Alchemist",
+      "rang": "F",
+      "voraussetzungen": [
+        "Alchemist"
+      ],
+      "beschreibung": "Der Alchemist wählt eine Entdeckung aus (z.B. verbesserte Bombe, verbessertes Mutagen, neue Extrakt-Formeln, Giftkunst, Schnellbomben). Kann einmal pro Rang genommen werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Fortgeschrittene Entdeckung": {
+      "name": "Fortgeschrittene Entdeckung",
+      "kategorie": "Alchemist",
+      "rang": "V",
+      "voraussetzungen": [
+        "Alchemist"
+      ],
+      "beschreibung": "Der Alchemist wählt eine Fortgeschrittene Entdeckung aus (mächtigere Varianten: Bombenregeneration, Großes Mutagen, Flüssiges Feuer, Verdauungssäure).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Große Entdeckung": {
+      "name": "Große Entdeckung",
+      "kategorie": "Alchemist",
+      "rang": "H",
+      "voraussetzungen": [
+        "Alchemist"
+      ],
+      "beschreibung": "Der Alchemist wählt eine Große Entdeckung aus (Höhepunkt der Alchemie: Wahres Elixier der Langlebigkeit, Stein der Weisen, Wahre Verwandlung, Unsterblichkeitselixier).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kavalier": {
+      "name": "Kavalier",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "GES W6",
+        "Kämpfen W6",
+        "Reiten W6"
+      ],
+      "beschreibung": "Herausforderung (einmal pro Begegnung: wähle einen Gegner – beide erhalten Wundabzüge des anderen nicht; der Kavalier erhält +2 Schaden gegen das Ziel), Mächtiger Ansturm (bei Ansturm mit Lanze +4 Schaden statt +2), Orden (tritt einem Ritterorden bei und erhält dessen Kenntnisse), Kavalier-Reittier (verbesserte Variante des Tiermeister-Begleiters).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Panier": {
+      "name": "Panier",
+      "kategorie": "Kavalier",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kavalier"
+      ],
+      "beschreibung": "Verbündete innerhalb von 12'' erhalten +1 auf Furcht-Proben. Bei einem Ansturm erhalten sie zusätzlich +2 auf Angriffswürfe, solange das Panier sichtbar ist.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ordensfähigkeit": {
+      "name": "Ordensfähigkeit",
+      "kategorie": "Kavalier",
+      "rang": "V",
+      "voraussetzungen": [
+        "Kavalier"
+      ],
+      "beschreibung": "Der Kavalier erhält eine besondere Fähigkeit seines Ordens (z.B. Orden des Stabs: +2 auf Wissenswürfe; Orden des Schwertes: +1 auf Kämpfen; Orden des Sterns: einmal täglich Gnadenbitte für sich selbst).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Fordernde Herausforderung": {
+      "name": "Fordernde Herausforderung",
+      "kategorie": "Kavalier",
+      "rang": "H",
+      "voraussetzungen": [
+        "Kavalier"
+      ],
+      "beschreibung": "Gegner, die durch die Herausforderung des Kavaliers gebunden sind, können keine Bennies ausgeben, um gegen den Kavalier gerichtete Würfe zu wiederholen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Überlegener Ansturm": {
+      "name": "Überlegener Ansturm",
+      "kategorie": "Kavalier",
+      "rang": "WC",
+      "voraussetzungen": [
+        "L",
+        "Kavalier",
+        "Mindestens zwei Kavalier-Talente"
+      ],
+      "beschreibung": "Wild Card. Der Kavalier verdoppelt den Schaden bei einem Ansturm mit einer Lanze (anstatt des normalen +4-Bonus). Erfordert Legendär-Rang und mindestens zwei weitere Kavalier-Talente.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Inquisitor": {
+      "name": "Inquisitor",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "Athletik W6 oder Kämpfen W6 oder Schießen W6",
+        "Okkultismus W4"
+      ],
+      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Urteil (einmal pro Begegnung: +1 auf Angriffs- oder Schadenswürfe, oder +2 auf Eigenschaftswürfe – Wahl bei Einsatz), Monsterkunde (+2 auf Allgemeinwissen-Proben über Monster, Dämonen und Untote).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_handicaps": [
+        "Rüstungsbeschränkung_mittelschwer"
+      ]
+    },
+    "Bann": {
+      "name": "Bann",
+      "kategorie": "Inquisitor",
+      "rang": "F",
+      "voraussetzungen": [
+        "Inquisitor"
+      ],
+      "beschreibung": "Der Inquisitor verzaubert seine Waffe mit Bann: Angriffe ignorieren den Übernatürlichen Schutz des Ziels und verursachen +2 Schaden gegen die gewählte Kreaturenart (festgelegt bei Aktivierung der Macht).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Brandmal": {
+      "name": "Brandmal",
+      "kategorie": "Inquisitor",
+      "rang": "F",
+      "voraussetzungen": [
+        "Inquisitor"
+      ],
+      "beschreibung": "Der Inquisitor brandmarkt einen Feind (Aktion, Berührungsangriff): Das Ziel gilt als Abgelenkt (-2 auf alle Proben) bis es eine Willenskraft-Probe schafft (einmal pro Runde am Ende des Zuges).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystische Mächte (Inquisitor)": {
+      "name": "Mystische Mächte (Inquisitor)",
+      "kategorie": "Inquisitor",
+      "rang": "V",
+      "voraussetzungen": [
+        "Inquisitor"
+      ],
+      "beschreibung": "Der Inquisitor erhält 10 gewidmete Machtpunkte für folgende Mächte: Eigenschaft erhöhen (Einschüchtern, Wahrnehmung oder Überleben), Dunkelsicht, Magie entdecken/verbergen und Aufheben. Alle Mächte wirken nur auf den Inquisitor selbst.",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Schwäche ausnutzen": {
+      "name": "Schwäche ausnutzen",
+      "kategorie": "Inquisitor",
+      "rang": "H",
+      "voraussetzungen": [
+        "Inquisitor"
+      ],
+      "beschreibung": "Der Inquisitor kann die Umgebungsschwächen von Kreaturen gezielt auslösen (z.B. Feuer bei Untoten, Silber bei Werwölfen): Der Inquisitor verursacht mit einem Angriff automatisch die Schwachstellen-Effekte der Kreatur.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Wahres Urteil": {
+      "name": "Wahres Urteil",
+      "kategorie": "Inquisitor",
+      "rang": "WC",
+      "voraussetzungen": [
+        "L",
+        "Inquisitor",
+        "Mindestens zwei Inquisitor-Talente"
+      ],
+      "beschreibung": "Wild Card. Der Inquisitor trifft sein Urteilsziel mit vernichtendem Schaden (automatischer Erfolg und eine Erhöhung auf den Angriff) und kann sofort einen neuen Feind als Urteilsziel wählen. Erfordert Legendär-Rang und mindestens zwei weitere Inquisitor-Talente.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Orakel": {
+      "name": "Orakel",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "WIL W6"
+      ],
+      "beschreibung": "AH (Orakel) [Arkane Fertigkeit: Glaube], Behindernde Rüstung (mittelschwer), Fluch (unvermeidliche Beeinträchtigung, die mit den Stufen stärker wird, z.B. Blindheit, Taubheit, Schwäche), Mysterium (wählt eine göttliche Verbindung, z.B. Tod, Flammen, Natur, Wasser).",
+      "neue_maechte": 3,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_handicaps": [
+        "Behindernde Rüstung_mittelschwer"
+      ]
+    },
+    "Offenbarung": {
+      "name": "Offenbarung",
+      "kategorie": "Orakel",
+      "rang": "F",
+      "voraussetzungen": [
+        "Orakel"
+      ],
+      "beschreibung": "Das Orakel kann eine Macht aus seinem Mysterium als begrenzte freie Aktion wirken (einmal pro Zug, ohne Machtpunkte-Abzug für die begrenzte freie Aktion). Kann mehrfach genommen werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Göttliche Meisterschaft": {
+      "name": "Göttliche Meisterschaft",
+      "kategorie": "Orakel",
+      "rang": "V",
+      "voraussetzungen": [
+        "Orakel"
+      ],
+      "beschreibung": "Das Orakel darf jetzt Epische Macht-Modifikatoren auf seine göttlichen Mächte anwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Große Offenbarung": {
+      "name": "Große Offenbarung",
+      "kategorie": "Orakel",
+      "rang": "H",
+      "voraussetzungen": [
+        "Orakel"
+      ],
+      "beschreibung": "Das Orakel schaltet seine finale Offenbarung frei – die mächtigste Fähigkeit seines Mysteriums (z.B. ewiges Feuer, Totenbeschwörung, Windkörper).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Beschwörer": {
+      "name": "Beschwörer",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6",
+        "Okkultismus W6"
+      ],
+      "beschreibung": "AH (Beschwörer) [Arkane Fertigkeit: Zaubern], Behindernde Rüstung (leicht), Eidolon (magisch beschworenes Wesen, das dem Beschwörer folgt, kämpft und mit Evolutionspunkten ausgebaut wird).",
+      "neue_maechte": 2,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_talente": [
+        "AH (Beschwörer)"
+      ],
+      "auto_handicaps": [
+        "Behindernde Rüstung_leicht"
+      ]
+    },
+    "Zusätzliche Evolution": {
+      "name": "Zusätzliche Evolution",
+      "kategorie": "Beschwörer",
+      "rang": "A",
+      "voraussetzungen": [
+        "Beschwörer"
+      ],
+      "beschreibung": "Das Eidolon des Beschwörers erhält 3 zusätzliche Evolutionspunkte für Verbesserungen (z.B. zusätzliche Gliedmaßen, natürlicher Rüstungsschutz, Flug). Kann einmal genommen werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ruf des Schöpfers": {
+      "name": "Ruf des Schöpfers",
+      "kategorie": "Beschwörer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Beschwörer"
+      ],
+      "beschreibung": "Der Beschwörer kann sein Eidolon per Aktion sofort zu sich teleportieren oder mit ihm den Platz tauschen (einmal pro Begegnung, keine Sichtlinie erforderlich).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Ruf des Beschwörers": {
+      "name": "Ruf des Beschwörers",
+      "kategorie": "Beschwörer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Beschwörer"
+      ],
+      "beschreibung": "Das Eidolon erhält +1 Würfeltyp auf Geschicklichkeit, Stärke und Konstitution (permanent).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Lebensband": {
+      "name": "Lebensband",
+      "kategorie": "Beschwörer",
+      "rang": "V",
+      "voraussetzungen": [
+        "Beschwörer"
+      ],
+      "beschreibung": "Solange das Eidolon in der Nähe ist (12''), kann der Beschwörer empfangenen Schaden (Wunden) auf das Eidolon übertragen. Das Eidolon kann nicht unter diesen Schaden fallen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Aspekt": {
+      "name": "Aspekt",
+      "kategorie": "Beschwörer",
+      "rang": "H",
+      "voraussetzungen": [
+        "Beschwörer"
+      ],
+      "beschreibung": "Der Beschwörer kann Evolutionspunkte des Eidolons nutzen, um sich selbst zu transformieren und körperliche Eigenschaften des Eidolons zu übernehmen (z.B. Klauen, Panzerung, Flug).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zwillingseidolon": {
+      "name": "Zwillingseidolon",
+      "kategorie": "Beschwörer",
+      "rang": "WC",
+      "voraussetzungen": [
+        "L",
+        "Beschwörer",
+        "Mindestens zwei Beschwörer-Talente"
+      ],
+      "beschreibung": "Wild Card. Der Beschwörer kann sich vollständig in sein Eidolon verwandeln – alle Eigenschaftspunkte und Fähigkeiten des Eidolons werden für den Beschwörer übernommen. Erfordert Legendär-Rang und mindestens zwei weitere Beschwörer-Talente.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Hexe": {
+      "name": "Hexe",
+      "kategorie": "Klasse",
+      "rang": "A",
+      "voraussetzungen": [
+        "VER W6",
+        "Okkultismus W4"
+      ],
+      "beschreibung": "AH (Hexe) [Arkane Fertigkeit: Zaubern], Behindernde Rüstung (jede), Vertrauter (magisch verbundenes Tier, das Patron-Zauber speichert; tägliche Kommunikation erforderlich), Hex (wählt einen Hex aus der Hexen-Liste, z.B. Böser Blick, Schlaf, Heilung, Verfluchung).",
+      "neue_maechte": 3,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true,
+      "auto_handicaps": [
+        "Behindernde Rüstung_jede"
+      ]
+    },
+    "Zusätzlicher Hex": {
+      "name": "Zusätzlicher Hex",
+      "kategorie": "Hexe",
+      "rang": "F",
+      "voraussetzungen": [
+        "Hexe"
+      ],
+      "beschreibung": "Die Hexe schaltet einen zusätzlichen Hex frei. Kann einmal pro Rang genommen werden. Hexen (Auswahl): Agonie, Verhexung, Schlaf, Kichern, Heilung, Böser Blick, Verfluchung.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Großer Hex": {
+      "name": "Großer Hex",
+      "kategorie": "Hexe",
+      "rang": "V",
+      "voraussetzungen": [
+        "Hexe"
+      ],
+      "beschreibung": "Die Hexe erhält Zugang zu einem Großen Hex (mächtigere Variante der normalen Hexen-Fähigkeiten). Auswahl: Vettelnauge, Albträume, Langlebigkeit, Wachsabbild, Wetterkontrolle.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Arkane Meisterschaft (Hexe)": {
+      "name": "Arkane Meisterschaft (Hexe)",
+      "kategorie": "Hexe",
+      "rang": "H",
+      "voraussetzungen": [
+        "Hexe"
+      ],
+      "beschreibung": "Die Hexe darf jetzt Epische Macht-Modifikatoren auf ihre Zaubern-Mächte anwenden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Grandioser Hex": {
+      "name": "Grandioser Hex",
+      "kategorie": "Hexe",
+      "rang": "WC",
+      "voraussetzungen": [
+        "L",
+        "Hexe",
+        "Mindestens zwei Hexen-Talente"
+      ],
+      "beschreibung": "Wild Card. Die Hexe schaltet einen Grandiosen Hex frei – die mächtigste Form ihrer Hexerei (z.B. ewiger Schlaf, Todesfluch, Seelenstehlen). Erfordert Legendär-Rang und mindestens zwei weitere Hexen-Talente.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
     "Bevorzugte Mächte (Zauberer)": {
       "name": "Bevorzugte Mächte (Zauberer)",
       "kategorie": "Zauberer",

--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -1982,6 +1982,168 @@
       "ausgewaehlt": false,
       "aktiv": true
     },
+    "Aura der Gerechtigkeit": {
+      "name": "Aura der Gerechtigkeit",
+      "kategorie": "Paladin",
+      "rang": "F",
+      "voraussetzungen": [
+        "Paladin"
+      ],
+      "beschreibung": "Der Paladin teilt seine Fähigkeit Böses Niederstrecken mit Verbündeten in Sichtweite (12''). Betroffene Verbündete erhalten dieselben Angriffsboni wie der Paladin gegen das gewählte Ziel für eine Runde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Versteinerungsschlag": {
+      "name": "Versteinerungsschlag",
+      "kategorie": "Mönch",
+      "rang": "F",
+      "voraussetzungen": [
+        "WIL W8",
+        "Mönch",
+        "Kämpfen W8"
+      ],
+      "beschreibung": "Ki-Aktion (1 Machtpunkt): Bei einem Treffer mit einer Erhöhung muss das Ziel eine Konstitutionsprobe ablegen oder gilt als Erschöpft und beginnt zu versteinen. Misslingt die Probe mit einer Erhöhung, ist das Ziel sofort Kampfunfähig (Versteinerung).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Kreuzblütig": {
+      "name": "Kreuzblütig",
+      "kategorie": "Zauberer",
+      "rang": "H",
+      "voraussetzungen": [
+        "AH (Zauberer)"
+      ],
+      "beschreibung": "Der Zauberer erhält Zugang zu einer zweiten Blutlinie und kann deren Blutlinienfähigkeiten nutzen. Er erleidet jedoch –1 auf alle Zaubern-Proben (Konzentrationsschwierigkeiten durch zwei konkurrierende Blutlinien).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Störende Wut": {
+      "name": "Störende Wut",
+      "kategorie": "Barbar",
+      "rang": "V",
+      "voraussetzungen": [
+        "WIL W8",
+        "Barbar",
+        "Okkultismus W6"
+      ],
+      "beschreibung": "Befindet sich der Barbar im Kampfrausch und wirkt ein Ziel in Nahkampfreichweite (2'') eine Macht, kann der Barbar als freie Aktion sofort einen einzelnen Nahkampfangriff gegen dieses Ziel ausführen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zusätzliche Domäne": {
+      "name": "Zusätzliche Domäne",
+      "kategorie": "Kleriker",
+      "rang": "F",
+      "voraussetzungen": [
+        "AH (Kleriker)"
+      ],
+      "beschreibung": "Der Kleriker wählt eine zusätzliche Götterdomäne und erhält die damit verbundene Domänenmacht als neue arkane Macht (+1 neue Macht, +5 Machtpunkte).",
+      "neue_maechte": 1,
+      "machtpunkte": 5,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bevorzugte Mächte": {
+      "name": "Bevorzugte Mächte",
+      "kategorie": "Hintergrund",
+      "rang": "F",
+      "voraussetzungen": [
+        {"oder": ["AH (Zauberer)", "AH (Magier)"]}
+      ],
+      "beschreibung": "Einmal pro Zug kann der Charakter bei einer Probe für eine Macht seiner Schule oder Blutlinie bis zu 2 Punkte Abzüge ignorieren.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Jägerverbund": {
+      "name": "Jägerverbund",
+      "kategorie": "Waldläufer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Waldläufer"
+      ],
+      "beschreibung": "Der Waldläufer teilt per freier Aktion seinen Erzfeind-Bonus einmal pro Runde mit allen Verbündeten in Sichtweite (12'') für eine Runde.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Inspiration der Größe": {
+      "name": "Inspiration der Größe",
+      "kategorie": "Barde",
+      "rang": "V",
+      "voraussetzungen": [
+        "Heldentum inspirieren"
+      ],
+      "beschreibung": "Der Barde kann jetzt 7 Inspirations-Marker pro Einsatz generieren (statt 5). Zudem erhalten alle Verbündeten mit aktiven Inspirations-Markern +1 auf ihre Robustheit.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Mystische Mächte (Schurke)": {
+      "name": "Mystische Mächte (Schurke)",
+      "kategorie": "Schurke",
+      "rang": "F",
+      "voraussetzungen": [
+        "Schurke"
+      ],
+      "beschreibung": "Der Schurke erhält 10 gewidmete Machtpunkte für folgende Mächte: Eigenschaft erhöhen (Athletik, Heimlichkeit oder Diebeskunst), Dunkelsicht, Lärm/Stille und Wandläufer. Alle Mächte wirken nur auf den Schurken selbst.",
+      "neue_maechte": 0,
+      "machtpunkte": 10,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bebende Handfläche": {
+      "name": "Bebende Handfläche",
+      "kategorie": "Mönch",
+      "rang": "H",
+      "voraussetzungen": [
+        "Mönch",
+        "Kämpfen W10"
+      ],
+      "beschreibung": "Ki-Aktion (2 Machtpunkte): Bei einem Treffer pflanzt der Mönch vibrierende Energie ins Ziel. Zu einem beliebigen späteren Zeitpunkt (innerhalb derselben Szene) kann der Mönch die Energie auslösen: Das Ziel legt sofort eine Konstitutionsprobe mit –2 ab oder gilt als Kampfunfähig.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zeitloser Körper": {
+      "name": "Zeitloser Körper",
+      "kategorie": "Druide",
+      "rang": "F",
+      "voraussetzungen": [
+        "KON W8",
+        "AH (Druide)"
+      ],
+      "beschreibung": "Der Druide altert nicht mehr (Alterungseffekte gelten nicht). Zudem wird er immun gegen Gift und Krankheiten jeder Art.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Waffenspezialisierung": {
+      "name": "Waffenspezialisierung",
+      "kategorie": "Kämpfer",
+      "rang": "F",
+      "voraussetzungen": [
+        "Kämpfer"
+      ],
+      "beschreibung": "Der Kämpfer wählt eine bevorzugte Waffe. Misslingt ein Angriff mit dieser Waffe und trifft das Ziel nicht mindestens Erschüttert, kann der Kämpfer den Schadenswurf einmal kostenlos wiederholen. Kann mehrfach für verschiedene Waffenarten genommen werden.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
     "Bevorzugte Mächte (Zauberer)": {
       "name": "Bevorzugte Mächte (Zauberer)",
       "kategorie": "Zauberer",

--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -3424,6 +3424,181 @@
       "ausgewaehlt": false,
       "aktiv": true
     },
+    "Engelsschwingen": {
+      "name": "Engelsschwingen",
+      "kategorie": "Hintergrund",
+      "rang": "F",
+      "voraussetzungen": [
+        "Volk: Aasimars"
+      ],
+      "beschreibung": "Der Charakter wächst Flügel aus göttlichem Licht. Er erhält eine Flug-Bewegungsweite von 6\" und muss sich pro Runde mindestens 1\" fortbewegen oder landen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Rüstung des Abgrunds": {
+      "name": "Rüstung des Abgrunds",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Tieflinge"
+      ],
+      "beschreibung": "+2 natürlicher Rüstungsschutz sowie Umgebungsresistenz gegen Kälte, Elektrizität oder Feuer (Wahl bei Erwerb des Talents).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Naturverbundenheit": {
+      "name": "Naturverbundenheit",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Elf"
+      ],
+      "beschreibung": "Im bevorzugten Gelände (aus dem Talent Bevorzugtes Gelände) kann der Charakter jede 24 Stunden einen natürlichen Heilungswurf mit +2 Bonus ablegen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Bluttrinker": {
+      "name": "Bluttrinker",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Dhampire"
+      ],
+      "beschreibung": "Der Charakter kann einen natürlichen Heilungswurf durchführen, wenn er Blut trinkt (erfordert eine Aktion und einen willigen oder wehrlosen Spender).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Brenn! Brenn! Brenn!": {
+      "name": "Brenn! Brenn! Brenn!",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Goblin",
+        "Diebeskunst W6"
+      ],
+      "beschreibung": "Der Charakter verursacht mit natürlichem Feuer erhöhten Schaden: Brennende Gegenstände, Fackeln und ähnliche Lichtquellen fügen in seiner Hand +1 Würfeltyp Schaden zu.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Lässiger Illusionist": {
+      "name": "Lässiger Illusionist",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Gnom"
+      ],
+      "beschreibung": "Durch Ausgabe von Machtpunkten erhält der Charakter einen Bonus auf Täuschen- oder Heimlichkeitsproben: 1 MP für +1, 2 MP für +2, bis zu +4.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Himmlischer Diener": {
+      "name": "Himmlischer Diener",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Aasimars",
+        "Tiermeister"
+      ],
+      "beschreibung": "Der Begleiter des Aasimars erhält einen himmlischen Segen: +2 auf alle Eigenschaftswürfe und der Begleiter gilt als übernatürliches Wesen mit entsprechenden Widerstandsboni.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Krallensturz": {
+      "name": "Krallensturz",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Katzenfolk",
+        "GES W6",
+        "STÄ W6"
+      ],
+      "beschreibung": "Erfordert die Alternativfähigkeit Katzenkrallen. Bei einem Rücksichtslosen Angriff mit Klauen erhält der Charakter +2 Schaden zusätzlich zum normalen Bonus des Rücksichtslosen Angriffs.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Tiefblick": {
+      "name": "Tiefblick",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        {"oder": ["Volk-Eigenschaft: dunkelsicht", "Volk-Eigenschaft: nachtsicht"]}
+      ],
+      "beschreibung": "Der Charakter verbessert seine Sehfähigkeit im Dunkeln: Er ignoriert alle Beleuchtungsabzüge vollständig (entspricht Nachtsicht auf höchster Stufe).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Glücklicher Halbling": {
+      "name": "Glücklicher Halbling",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Halbling",
+        "Selbstlos"
+      ],
+      "beschreibung": "Der Charakter kann einen Benny ausgeben, um einem Verbündeten in Sichtweite eine Wiederholung für eine Eigenschaftsprobe mit +2 Bonus zu ermöglichen.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Flinker Angreifer": {
+      "name": "Flinker Angreifer",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk-Eigenschaft: sprinter",
+        "GES W8"
+      ],
+      "beschreibung": "Der Charakter erleidet keinen Abzug, wenn er in derselben Runde rennt und eine einzelne Aktion ausführt.",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Klingenzahn": {
+      "name": "Klingenzahn",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Halbork"
+      ],
+      "beschreibung": "Der Charakter erhält durch seine verlängerten Stoßzähne einen Biss als natürliche Waffe (Stärke+W4 Schaden, gilt als natürliche Waffe nach Pathfinder-Regeln).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
+    "Zauberbrecher": {
+      "name": "Zauberbrecher",
+      "kategorie": "Hintergrund",
+      "rang": "A",
+      "voraussetzungen": [
+        "Volk: Zwerg"
+      ],
+      "beschreibung": "Der Charakter kann als begrenzte freie Aktion (einmal pro Zug) versuchen, eine aktive Macht in Nahkampfreichweite aufzuheben (wie der Zauber Aufheben, mit STÄ als arkaner Fertigkeit).",
+      "neue_maechte": 0,
+      "machtpunkte": 0,
+      "ausgewaehlt": false,
+      "aktiv": true
+    },
     "Ausweichen": {
       "name": "Ausweichen",
       "kategorie": "Kampf",


### PR DESCRIPTION
13 neue Hintergrund-Talente (Background Edges) für Savage Pathfinder
mit Rassen-Voraussetzungen übersetzt und eingetragen:
- Engelsschwingen (Angel Wings) – Aasimars, F
- Rüstung des Abgrunds (Armor of the Pit) – Tieflinge, A
- Naturverbundenheit (Attuned to the Wild) – Elf, A
- Bluttrinker (Blood Drinker) – Dhampire, A
- Brenn! Brenn! Brenn! (Burn! Burn! Burn!) – Goblin, A
- Lässiger Illusionist (Casual Illusionist) – Gnom, A
- Himmlischer Diener (Celestial Servant) – Aasimars, A
- Krallensturz (Claw Pounce) – Katzenfolk, A
- Tiefblick (Deepsight) – Dunkelsicht/Nachtsicht, A
- Glücklicher Halbling (Lucky Halfling) – Halbling, A
- Flinker Angreifer (Nimble Striker) – Sprinter-Volk, A
- Klingenzahn (Razor Tusk) – Halbork, A
- Zauberbrecher (Shatterspell) – Zwerg, A

Voraussetzungsprüfung erweitert: „Volk: X" prüft ob Charakter vom
angegebenen Volk ist; „Volk-Eigenschaft: X" prüft spezielle_effekte
des ausgewählten Volks (z.B. dunkelsicht, nachtsicht, sprinter).

https://claude.ai/code/session_017REWRYznUTQMbN8RTNfK3u