### PR TITLE
feat(savage-pathfinder): Schusswaffen (frühe & fortgeschrittene Feuerwaffen)

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -11184,6 +11184,330 @@
         "PB": "-"
       }
     },
+    "Blunderbuss": {
+      "name": "Blunderbuss",
+      "kategorie": "Waffe",
+      "gewicht": 4,
+      "kosten": 2000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Streuschuss. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Bucklergewehr": {
+      "name": "Bucklergewehr",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 750,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Muss zum Nachladen abgenommen werden. Immer Nebenhandabzug beim Schießen, Parade +1. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W4",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "2",
+        "PB": "2"
+      }
+    },
+    "Culverin": {
+      "name": "Culverin",
+      "kategorie": "Waffe",
+      "gewicht": 20,
+      "kosten": 4000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schießen ohne Unterstützung: –2. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W8",
+      "eigenschaften": {
+        "Schaden": "3W6",
+        "Reichweite": "10/20/40",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Doppelhakengewehr": {
+      "name": "Doppelhakengewehr",
+      "kategorie": "Waffe",
+      "gewicht": 9,
+      "kosten": 4000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schießen ohne Halterung: –2 und der Schütze wird zu Boden geworfen. Nachladen 3.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "3W8",
+        "Reichweite": "12/24/48",
+        "FR": "1",
+        "Schuss": "2",
+        "PB": "-"
+      }
+    },
+    "Muskete Pathfinder": {
+      "name": "Muskete",
+      "kategorie": "Waffe",
+      "gewicht": 4.5,
+      "kosten": 1500,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W10",
+        "Reichweite": "10/20/40",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "2"
+      }
+    },
+    "Muskete, Axt-/Kriegshammer-": {
+      "name": "Muskete, Axt-/Kriegshammer-",
+      "kategorie": "Waffe",
+      "gewicht": 3,
+      "kosten": 1600,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Als Nahkampfwaffe: entsprechende Waffenwerte. Bei Fehlfunktion: –1 auf Kämpfenproben bis zur Reparatur. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "8/16/32",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Muskete, doppelläufig": {
+      "name": "Muskete, doppelläufig",
+      "kategorie": "Waffe",
+      "gewicht": 5.5,
+      "kosten": 2500,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Doppelläufig. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W8+1",
+        "Reichweite": "10/20/40",
+        "FR": "1",
+        "Schuss": "2",
+        "PB": "2"
+      }
+    },
+    "Pfefferbüchse": {
+      "name": "Pfefferbüchse",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 3000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "6",
+        "PB": "1"
+      }
+    },
+    "Pistole": {
+      "name": "Pistole",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 1000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Pistole, Mantel-": {
+      "name": "Pistole, Mantel-",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 750,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W4+1",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Pistole, doppelläufig": {
+      "name": "Pistole, doppelläufig",
+      "kategorie": "Waffe",
+      "gewicht": 2.5,
+      "kosten": 1750,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Doppelläufig. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "2",
+        "PB": "1"
+      }
+    },
+    "Pistole, Drachen-": {
+      "name": "Pistole, Drachen-",
+      "kategorie": "Waffe",
+      "gewicht": 1.5,
+      "kosten": 1000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Streuschuss. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Stockdegenpistole": {
+      "name": "Stockdegenpistole",
+      "kategorie": "Waffe",
+      "gewicht": 0.5,
+      "kosten": 775,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Wahrnehmungsprobe erforderlich, um zu erkennen, dass es sich um mehr als einen Gehstock handelt. Nachladen 2.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W4+1",
+        "Reichweite": "3/6/12",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Revolver": {
+      "name": "Revolver",
+      "kategorie": "Waffe",
+      "gewicht": 2,
+      "kosten": 4000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W4",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "6",
+        "PB": "1"
+      }
+    },
+    "Gewehr": {
+      "name": "Gewehr",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 5000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W8+1",
+        "Reichweite": "20/40/80",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Gewehr, Pfefferbüchse": {
+      "name": "Gewehr, Pfefferbüchse",
+      "kategorie": "Waffe",
+      "gewicht": 7.5,
+      "kosten": 7000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nachladen 1.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W8+1",
+        "Reichweite": "20/40/80",
+        "FR": "1",
+        "Schuss": "4",
+        "PB": "1"
+      }
+    },
+    "Schrotflinte": {
+      "name": "Schrotflinte",
+      "kategorie": "Waffe",
+      "gewicht": 6,
+      "kosten": 5000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Streuschuss. Nachladen 1.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "1",
+        "PB": "1"
+      }
+    },
+    "Schrotflinte, doppelläufig": {
+      "name": "Schrotflinte, doppelläufig",
+      "kategorie": "Waffe",
+      "gewicht": 7.5,
+      "kosten": 7000,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Doppelläufig, Streuschuss. Nachladen 1.",
+      "aktiv": true,
+      "typ": "Fernkampf",
+      "mindeststaerke": "W6",
+      "eigenschaften": {
+        "Schaden": "2W6+1",
+        "Reichweite": "5/10/20",
+        "FR": "1",
+        "Schuss": "2",
+        "PB": "1"
+      }
+    },
     "Armbrust, Leichte Repetier-": {
       "name": "Armbrust, Leichte Repetier-",
       "kategorie": "Fernkampfwaffe",


### PR DESCRIPTION
## Zusammenfassung

18 Schusswaffen aus dem Pathfinder-Waffenkatalog für das Savage Pathfinder Setting ergänzt (`settings/Savage Pathfinder.json`).

### Frühe Feuerwaffen (Nachladen 2)

| Name | Englisch | Schaden | PB | Schuss | Reichweite | Kosten | Besonderheit |
|---|---|---|---|---|---|---|---|
| Blunderbuss | Blunderbuss | 2W6+1 | 1 | 1 | 3/6/12 | 2.000 | Streuschuss |
| Bucklergewehr | Buckler gun | 2W4 | 2 | 2 | 3/6/12 | 750 | Nebenhandabzug, Parade +1, muss abgenommen werden |
| Culverin | Culverin | 3W6 | 1 | 1 | 10/20/40 | 4.000 | –2 ohne Unterstützung |
| Doppelhakengewehr | Double hackbut | 3W8 | — | 2 | 12/24/48 | 4.000 | –2 und Sturz ohne Halterung |
| Muskete | Musket | 2W10 | 2 | 1 | 10/20/40 | 1.500 | |
| Muskete, Axt-/Kriegshammer- | Musket, axe/warhammer | 2W6+1 | 1 | 1 | 8/16/32 | 1.600 | Nahkampfoption, –1 Kämpfen bei Fehlfunktion |
| Muskete, doppelläufig | Musket, double-barreled | 2W8+1 | 2 | 2 | 10/20/40 | 2.500 | Doppelläufig |
| Pfefferbüchse | Pepperbox | 2W6+1 | 1 | 6 | 5/10/20 | 3.000 | |
| Pistole | Pistol | 2W6+1 | 1 | 1 | 5/10/20 | 1.000 | |
| Pistole, Mantel- | Pistol, coat | 2W4+1 | 1 | 1 | 3/6/12 | 750 | |
| Pistole, doppelläufig | Pistol, double-barreled | 2W6+1 | 1 | 2 | 5/10/20 | 1.750 | Doppelläufig |
| Pistole, Drachen- | Pistol, dragon | 2W6+1 | 1 | 1 | 5/10/20 | 1.000 | Streuschuss |
| Stockdegenpistole | Pistol, sword cane | 2W4+1 | 1 | 1 | 3/6/12 | 775 | Als Gehstock getarnt (Wahrnehmungsprobe) |

### Fortgeschrittene Feuerwaffen (Nachladen 1)

| Name | Englisch | Schaden | PB | Schuss | Reichweite | Kosten | Besonderheit |
|---|---|---|---|---|---|---|---|
| Revolver | Revolver | 2W6+1 | 1 | 6 | 5/10/20 | 4.000 | |
| Gewehr | Rifle | 2W8+1 | 1 | 1 | 20/40/80 | 5.000 | |
| Gewehr, Pfefferbüchse | Rifle, pepperbox | 2W8+1 | 1 | 4 | 20/40/80 | 7.000 | |
| Schrotflinte | Shotgun | 2W6+1 | 1 | 1 | 5/10/20 | 5.000 | Streuschuss |
| Schrotflinte, doppelläufig | Shotgun, double-barreled | 2W6+1 | 1 | 2 | 5/10/20 | 7.000 | Doppelläufig, Streuschuss |

## Hinweise

- Gewichte folgen der bestehenden Konvention im Projekt (halbe Pfundwerte ≈ kg)
- `setting: "savage_pathfinder"` für alle neuen Einträge
- Der bestehende `Muskete`-Eintrag (setting: `schwarzpulver`) bleibt unverändert; die Pathfinder-Muskete verwendet den Schlüssel `Muskete Pathfinder`

## Testplan

- [ ] App starten und Savage Pathfinder Setting laden
- [ ] Ausrüstungstab öffnen: alle 18 neuen Waffen sollten in der Kategorie „Waffe" sichtbar sein
- [ ] Waffe einem Charakter hinzufügen und Werte im Charakterbogen prüfen
- [ ] JSON-Validierung: `python3 -c "import json; json.load(open('settings/Savage Pathfinder.json'))"`

https://claude.ai/code/session_01VAKY7CqYstsP8SH5PXWDfJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAKY7CqYstsP8SH5PXWDfJ)_