### PR TITLE
feat(savage-pathfinder): Schusswaffenmunition und alchemistische Kartuschen

### DIFF
--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -12271,6 +12271,78 @@
       "beschreibung": "Kein Schaden. Platziert eine Kleine Explosionsschablone am Auftreffpunkt. Die Beleuchtung innerhalb der Schablone wird um eine Stufe verringert. Die Wolke hält zwei Runden an.",
       "aktiv": true
     },
+    "Kugeln, Feuerwaffe (30)": {
+      "name": "Kugeln, Feuerwaffe (30)",
+      "kategorie": "Munition",
+      "gewicht": 0.25,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Munition für Schusswaffen. Für Kugeln aus Spezialmaterialien siehe Pathfinder for Savage Worlds.",
+      "aktiv": true
+    },
+    "Kugeln, gerillt (1)": {
+      "name": "Kugeln, gerillt (1)",
+      "kategorie": "Munition",
+      "gewicht": 0,
+      "kosten": 5,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Speziell gefertigte Kugel, auf die Gift aufgetragen werden kann. Nicht kompatibel mit alchemistischen Kartuschen.",
+      "aktiv": true
+    },
+    "Schrot (30)": {
+      "name": "Schrot (30)",
+      "kategorie": "Munition",
+      "gewicht": 0.25,
+      "kosten": 30,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Schrot für Streuschusswaffen. Kieselsteine oder anderer Schutt können stattdessen verwendet werden, verursachen aber –1 auf Schießenproben.",
+      "aktiv": true
+    },
+    "Alchemistische Kartusche, Drachenatem": {
+      "name": "Alchemistische Kartusche, Drachenatem",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0,
+      "kosten": 40,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nur für Streuschusswaffen. Kein Schießenwurf: Alle unter der Kleinen Kegelschablone legen eine Ausweichen-Probe ab. 2W6 nichtmagischer Feuerschaden. Kritischer Fehlschlag wenn beide Schadenswürfel eine 1 zeigen.",
+      "aktiv": true
+    },
+    "Alchemistische Kartusche, Fesselschuss": {
+      "name": "Alchemistische Kartusche, Fesselschuss",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0,
+      "kosten": 40,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Nur für Streuschusswaffen. Verringert den Waffenschaden um einen Würfeltyp. Jede getroffene Kreatur muss eine Ausweichen-Probe ablegen oder wird Verstrickt.",
+      "aktiv": true
+    },
+    "Alchemistische Kartusche, Leuchtspur": {
+      "name": "Alchemistische Kartusche, Leuchtspur",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0,
+      "kosten": 10,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Verringert den Schaden um einen Würfeltyp. Eine getroffene Kreatur wird für eine Runde geblendet. Auch als Signalrakete verwendbar. Kann nur gegen einzelne Kreaturen eingesetzt werden.",
+      "aktiv": true
+    },
+    "Alchemistische Kartusche, Metall": {
+      "name": "Alchemistische Kartusche, Metall",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0,
+      "kosten": 15,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Macht Kugel und Schwarzpulver wasserdicht.",
+      "aktiv": true
+    },
+    "Alchemistische Kartusche, Salzschrot": {
+      "name": "Alchemistische Kartusche, Salzschrot",
+      "kategorie": "Alchemistischer Gegenstand",
+      "gewicht": 0.25,
+      "kosten": 12,
+      "setting": "savage_pathfinder",
+      "beschreibung": "Kann in Streuschusswaffen geladen werden. Verursacht betäubenden Schaden.",
+      "aktiv": true
+    },
     "Doppelarmbrust": {
       "name": "Doppelarmbrust",
       "kategorie": "Waffe",


### PR DESCRIPTION
## Zusammenfassung

8 neue Einträge für das Savage Pathfinder Setting: 3 Munitionstypen für Schusswaffen sowie 5 alchemistische Kartuschen (`settings/Savage Pathfinder.json`).

### Munition (`kategorie: "Munition"`)

| Name | Englisch | Kosten | Gewicht | Besonderheit |
|---|---|---|---|---|
| Kugeln, Feuerwaffe (30) | Bullet (firearm) | 30 GM | 0,25 kg | Standardmunition; Spezialmaterialien laut PFSW-Regelwerk |
| Kugeln, gerillt (1) | Bullet, pitted | 5 GM | — | Giftapplikation möglich; nicht mit alchemistischen Kartuschen |
| Schrot (30) | Pellets | 30 GM | 0,25 kg | Für Streuschusswaffen; Schutt als Ersatz: –1 auf Schießen |

### Alchemistische Kartuschen (`kategorie: "Alchemistischer Gegenstand"`)

| Name | Englisch | Kosten | Besonderheit |
|---|---|---|---|
| Alch. Kartusche, Drachenatem | Dragon's breath | 40 GM | Nur Streuschuss; Kleine Kegelschablone; 2W6 Feuer; Ausweichen-Probe statt Schießen; Krit. Fehlschlag bei doppelter 1 |
| Alch. Kartusche, Fesselschuss | Entangling shot | 40 GM | Nur Streuschuss; Schaden –1 Würfeltyp; getroffene Kreaturen: Ausweichen oder Verstrickt |
| Alch. Kartusche, Leuchtspur | Flare | 10 GM | Schaden –1 Würfeltyp; Ziel geblendet 1 Runde; nutzbar als Signalrakete; nur Einzelziel |
| Alch. Kartusche, Metall | Metal cartridge | 15 GM | Macht Kugel und Schwarzpulver wasserdicht |
| Alch. Kartusche, Salzschrot | Salt shot | 12 GM | Für Streuschusswaffen; betäubender Schaden |

## Testplan

- [ ] App starten und Savage Pathfinder Setting laden
- [ ] Ausrüstungstab: alle 8 neuen Einträge in den Kategorien „Munition" / „Alchemistischer Gegenstand" prüfen
- [ ] JSON-Validierung: `python3 -c "import json; json.load(open('settings/Savage Pathfinder.json'))"`

https://claude.ai/code/session_01VAKY7CqYstsP8SH5PXWDfJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAKY7CqYstsP8SH5PXWDfJ)_