### PR TITLE
fix(android): Umlaute in Setting-Namen korrekt anzeigen

### DIFF
--- a/functions/setting_funktionen.py
+++ b/functions/setting_funktionen.py
@@ -36,7 +36,7 @@ import functions.ausruestung_funktionen as ausruestung_funktionen
 
 
 # Import centralized path utilities
-from utils.path_utils import get_application_root, get_settings_path, get_user_settings_path
+from utils.path_utils import get_application_root, get_settings_path, get_user_settings_path, safe_filename_stem
 
 
 class SetEncoder(json.JSONEncoder):
@@ -139,7 +139,7 @@ class CustomElementManager:
         try:
             with open(setting_file, 'r', encoding='utf-8') as f:
                 setting_data = json.load(f)
-                setting_name = setting_file.stem
+                setting_name = safe_filename_stem(setting_file)
                 self.settings[setting_name] = setting_data
                 if is_user:
                     self._user_settings.add(setting_name)

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -214,6 +214,28 @@ def get_templates_path(filename: str = "") -> str:
     else:
         return get_resource_path("templates")
 
+def safe_filename_stem(path) -> str:
+    """Gibt den Dateinamen ohne Extension zurück, korrekt als UTF-8 dekodiert.
+
+    Auf Android/Python-for-Android werden Dateinamen mit Nicht-ASCII-Zeichen
+    (Umlaute wie ä, ö, ü) manchmal als Surrogate-Escape-Sequenzen zurückgegeben,
+    wenn die Filesystem-Locale nicht auf UTF-8 gesetzt ist. Diese surrogates
+    können von keiner Schriftart gerendert werden und erscheinen als Kästchen.
+
+    Diese Funktion erkennt solche surrogates und konvertiert sie zurück zu den
+    ursprünglichen UTF-8-Bytes, um den korrekten Unicode-String zu erhalten.
+    """
+    stem = Path(path).stem
+    try:
+        stem.encode('utf-8')
+        return stem
+    except UnicodeEncodeError:
+        try:
+            return stem.encode('utf-8', errors='surrogatepass').decode('utf-8')
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            return stem
+
+
 # Für Backward-Kompatibilität
 def get_project_root() -> Path:
     """Alias für get_application_root()"""

--- a/views/charakter_verwaltung_widget.py
+++ b/views/charakter_verwaltung_widget.py
@@ -39,7 +39,7 @@ from manager.html_manager import HTMLManager
 from utils.custom_filemanager import CustomFileManager
 
 # KV-Datei laden mit Mobile-Unterstützung
-from utils.path_utils import get_application_root
+from utils.path_utils import get_application_root, safe_filename_stem
 from utils.platform_utils import is_mobile_layout, landscape_height
 import os
 
@@ -353,13 +353,13 @@ class CharakterVerwaltungWidget(MDBoxLayout):
         native_dir = Path(get_settings_path())
         if native_dir.exists():
             for f in native_dir.glob('*.json'):
-                settings_set.add(f.stem)
+                settings_set.add(safe_filename_stem(f))
 
         # Benutzer-Settings laden (persistentes Verzeichnis)
         user_dir = Path(get_user_settings_path())
         if user_dir.exists() and user_dir != native_dir:
             for f in user_dir.glob('*.json'):
-                settings_set.add(f.stem)
+                settings_set.add(safe_filename_stem(f))
 
         return sorted(settings_set)
 

--- a/views/setting_popup.py
+++ b/views/setting_popup.py
@@ -29,6 +29,7 @@ from kivymd.uix.dialog import (
     MDDialogButtonContainer
 )
 from utils.custom_filemanager import CustomFileManager
+from utils.path_utils import safe_filename_stem
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.label import MDLabel
 from kivymd.uix.button import MDButton, MDButtonText
@@ -124,7 +125,7 @@ class SettingsRepository:
                 raise FileNotFoundError("Keine gültige Datei ausgewählt")
             with open(setting_datei, "r", encoding="utf-8") as f:
                 setting_data = json.load(f)
-            setting_name = setting_data.get("name", setting_datei.stem)
+            setting_name = setting_data.get("name", safe_filename_stem(setting_datei))
             if controller and controller.charakter:
                 controller.charakter.custom_element_manager.reload_settings()
                 controller.charakter.custom_element_manager.set_active_setting(setting_name)
@@ -151,7 +152,7 @@ class SettingsRepository:
 
     def delete(self, filepath, controller):
         try:
-            setting_name = Path(filepath).stem
+            setting_name = safe_filename_stem(filepath)
             if controller and controller.charakter:
                 success = controller.charakter.custom_element_manager.delete_setting(setting_name)
                 if success:


### PR DESCRIPTION
Auf Android/Python-for-Android können Dateinamen mit Nicht-ASCII-Zeichen
(Umlaute wie ä, ö, ü) als Surrogate-Escape-Sequenzen zurückgegeben werden,
wenn die Filesystem-Locale nicht auf UTF-8 gesetzt ist. Diese surrogates
sind in keiner Schriftart enthalten und werden als Kästchen gerendert
(z.B. "Superkr☐☐te Kompendium" statt "Superkräfte Kompendium").

Lösung: Neue Hilfsfunktion safe_filename_stem() in path_utils.py, die
erkannte surrogates zurück in korrekte UTF-8-Bytes konvertiert. Eingesetzt
überall wo f.stem auf Setting-Dateipfaden aufgerufen wird.

https://claude.ai/code/session_01Br6NRnFELcJQDM6fA8FAMe