### PR TITLE
feat(charakter): Größe als eigenständigen abgeleiteten Wert einführen

### DIFF
--- a/config/volkseigenarten_config.json
+++ b/config/volkseigenarten_config.json
@@ -384,7 +384,7 @@
             "max_auswahl": 3,
             "beschreibung": "Die Kreatur ist größer als normal. Jeder Punkt Größe wird direkt auf die Robustheit angerechnet und erhöht die maximale Stärke um einen Schritt.",
             "effekt_typ": "spezieller_effekt",
-            "effekt": {"groesse_punkt": 1, "robustheit_bonus": 1}
+            "effekt": {"groesse_punkt": 1}
         },
         {
             "id": "hoerner",
@@ -612,7 +612,7 @@
             "max_auswahl": 1,
             "beschreibung": "Die Wesenheit ist kleiner als der Durchschnitt, was ihre Größe und Robustheit um -1 verringert (siehe Größentabelle).",
             "effekt_typ": "spezieller_effekt",
-            "effekt": {"groesse_punkt": -1, "robustheit_bonus": -1}
+            "effekt": {"groesse_punkt": -1}
         },
         {
             "id": "abhaengigkeit",

--- a/functions/abgeleitete_werte.py
+++ b/functions/abgeleitete_werte.py
@@ -113,44 +113,55 @@ def berechne_abgeleitete_werte(charakter):
         else:
             konstitution_wert = 4  # Standardwert, wenn Konstitution nicht vorhanden
 
-        # Talent-Boni für Robustheit/Größe
+        # Größe und Robustheit getrennt führen:
+        # - groesse: Mensch = 0; Volks-Größe + Größe-relevante Talente/Handicaps
+        # - robustheit_bonus: echte Robustheit-Boni (Talente Raufbold/Schläger/Jünger Erthas, Fettleibig, Cyberware, Volk-Rest)
+        # Endformel: robustheit_basis = (KON//2) + 2 + groesse + robustheit_bonus
+        groesse = 0
         robustheit_bonus = 0
-        
+
+        # Talent-Effekte
         if "Kräftig" in charakter.selected_talente:
-            robustheit_bonus += 1  # Kräftig: +1 Robustheit durch erhöhte Größe
+            groesse += 1  # Kräftig erhöht die Größe (und damit Robustheit) um 1
 
         if "Raufbold" in charakter.selected_talente:
-            robustheit_bonus += 1  # Raufbold: +1 Robustheit
+            robustheit_bonus += 1  # Raufbold: +1 Robustheit (kein Größe-Effekt)
 
         if "Schläger" in charakter.selected_talente:
-            robustheit_bonus += 1  # Schläger: +1 Robustheit
+            robustheit_bonus += 1  # Schläger: +1 Robustheit (kein Größe-Effekt)
 
         if "Jünger Erthas" in charakter.selected_talente:
             robustheit_bonus += 1  # Jünger Erthas (Hellfrost): +1 Robustheit
 
-        # Handicap-Effekte für Robustheit
+        # Handicap-Effekte
         for handicap_name in charakter.selected_handicaps:
             if handicap_name in charakter.handicaps:
                 handicap = charakter.handicaps[handicap_name]
-                
-                # Fettleibig (leicht)
-                if "Fettleibig" in handicap.name and handicap.stufe == "leicht":
-                    robustheit_bonus += 1  # Fettleibig: +1 Robustheit
-                
-                # Klein (leicht)
-                elif "Klein" in handicap.name and handicap.stufe == "leicht":
-                    robustheit_bonus -= 1  # Klein: -1 Robustheit
 
-        # 3. Völker-Effekte für Robustheit (Größe/Basis-Modifikationen)
+                # Fettleibig (leicht): +1 Robustheit (Körperfett, kein Größenwachstum)
+                if "Fettleibig" in handicap.name and handicap.stufe == "leicht":
+                    robustheit_bonus += 1
+
+                # Klein (leicht): -1 Größe (und damit -1 Robustheit)
+                elif "Klein" in handicap.name and handicap.stufe == "leicht":
+                    groesse -= 1
+
+        # Völker-Effekte: Größe und Robustheit-Bonus getrennt
+        voelker_groesse = _berechne_voelker_groesse(charakter)
+        groesse += voelker_groesse
+
         voelker_robustheit_bonus = _berechne_voelker_robustheit_bonus(charakter)
         robustheit_bonus += voelker_robustheit_bonus
 
-        # 3b. Cyberware-Effekte für Robustheit
+        # Cyberware-Effekte für Robustheit (kein Größe-Effekt)
         cyberware_robustheit_bonus = _berechne_cyberware_robustheit_bonus(charakter)
         robustheit_bonus += cyberware_robustheit_bonus
-        
-        # Basis-Robustheit ohne Rüstung: (Konstitution/2) + 2 + Boni
-        charakter.robustheit_basis = (konstitution_wert // 2) + 2 + robustheit_bonus
+
+        # Größe als abgeleiteten Wert speichern
+        charakter.groesse = groesse
+
+        # Basis-Robustheit ohne Rüstung: (Konstitution/2) + 2 + Größe + Robustheit-Bonus
+        charakter.robustheit_basis = (konstitution_wert // 2) + 2 + groesse + robustheit_bonus
 
         # Gesamtrüstungsschutz berechnen (inklusive natürlicher Panzerung)
         from functions.ausruestung_funktionen import berechne_gesamt_ruestungsschutz
@@ -222,6 +233,7 @@ def berechne_abgeleitete_werte(charakter):
         abgeleitete_werte = {
             'Bewegungsweite': bewegungsweite,
             'Parade': charakter.parade,
+            'Größe': groesse,
             'Robustheit': f"{charakter.robustheit} ({gesamt_torso})",
             'Machtpunkte': machtpunkte,
             'Wunden': wunden,
@@ -271,16 +283,16 @@ def _berechne_voelker_bewegungsweite_bonus(charakter):
 
 def _berechne_voelker_robustheit_bonus(charakter):
     """
-    Berechnet den Robustheit-Bonus durch das ausgewählte Volk (nur Basis-Modifikationen wie Größe).
-    
+    Berechnet den echten Robustheit-Bonus des ausgewählten Volks (ohne Größe-Anteil).
+
     Args:
         charakter: Das Charakterobjekt
-        
+
     Returns:
         int: Robustheit-Bonus (kann negativ sein)
     """
     robustheit_bonus = 0
-    
+
     try:
         # Finde das ausgewählte Volk
         ausgewaehltes_volk = None
@@ -288,15 +300,55 @@ def _berechne_voelker_robustheit_bonus(charakter):
             if ist_ausgewaehlt and volk_name in charakter.voelker:
                 ausgewaehltes_volk = charakter.voelker[volk_name]
                 break
-        
+
         if ausgewaehltes_volk:
             robustheit_bonus = ausgewaehltes_volk.get_robustheit_bonus()
+            groesse_mod = ausgewaehltes_volk.get_groesse_modifikator()
             Logger.debug(f"Völker-Robustheit-Bonus von {ausgewaehltes_volk.name}: {robustheit_bonus}")
-    
+            # Sanity-Check: doppelte Codierung detektieren (rb != 0 UND groesse != 0)
+            if robustheit_bonus != 0 and groesse_mod != 0:
+                Logger.warning(
+                    f"Volk {ausgewaehltes_volk.name} hat sowohl robustheit_bonus={robustheit_bonus} "
+                    f"als auch groesse_modifikator={groesse_mod}. Beide werden auf Robustheit "
+                    f"addiert (legitim z.B. bei Vampir/Flickenmonster). Falls das eine Doppelung "
+                    f"durch Altdaten ist, bitte Setting-JSON migrieren."
+                )
+
     except Exception as e:
         Logger.error(f"Fehler bei Völker-Robustheit-Berechnung: {e}")
-    
+
     return robustheit_bonus
+
+
+def _berechne_voelker_groesse(charakter):
+    """
+    Berechnet den Größe-Modifikator durch das ausgewählte Volk.
+    Mensch = 0, Halbling = -1, Halbriese = +3 etc.
+
+    Args:
+        charakter: Das Charakterobjekt
+
+    Returns:
+        int: Größe-Modifikator (kann negativ sein)
+    """
+    groesse_modifikator = 0
+
+    try:
+        ausgewaehltes_volk = None
+        for volk_name, ist_ausgewaehlt in charakter.voelker_selected.items():
+            if ist_ausgewaehlt and volk_name in charakter.voelker:
+                ausgewaehltes_volk = charakter.voelker[volk_name]
+                break
+
+        if ausgewaehltes_volk:
+            groesse_modifikator = ausgewaehltes_volk.get_groesse_modifikator()
+            if groesse_modifikator != 0:
+                Logger.debug(f"Völker-Größe-Modifikator von {ausgewaehltes_volk.name}: {groesse_modifikator:+d}")
+
+    except Exception as e:
+        Logger.error(f"Fehler bei Völker-Größe-Berechnung: {e}")
+
+    return groesse_modifikator
 
 
 def _berechne_voelker_natuerliche_panzerung(charakter):

--- a/functions/statblock_generator.py
+++ b/functions/statblock_generator.py
@@ -35,6 +35,7 @@ def generate_character_statblock(charakter):
         pace = charakter.bewegungsweite
         parry = charakter.parade
         toughness = charakter.robustheit
+        size = charakter.groesse
         
         # Handicaps formatieren
         handicaps_text = _format_handicaps(charakter)
@@ -61,7 +62,7 @@ def generate_character_statblock(charakter):
         statblock_lines.extend([
             f"Attribute: {attribute_text}",
             f"Fertigkeiten: {fertigkeiten_text}",
-            f"Bewegungsweite: {pace}; Parade: {parry}; Robustheit: {toughness}"
+            f"Bewegungsweite: {pace}; Parade: {parry}; Größe: {size:+d}; Robustheit: {toughness}"
         ])
         
         # Nur hinzufügen wenn vorhanden

--- a/functions/volkseigenarten_funktionen.py
+++ b/functions/volkseigenarten_funktionen.py
@@ -559,13 +559,20 @@ def eigenart_zu_effekte(positive_eigenarten, negative_eigenarten):
                           'keine_lebenswichtigen_organe', 'waermesicht', 'schlafbedarf',
                           'doppelt_so_weit_springen', 'springer_schadensbonus',
                           'widerstand_naturgewalten', 'anfaelligkeit_naturgewalten',
-                          'halbe_bewegungsweite_graben', 'groesse_punkt',
+                          'halbe_bewegungsweite_graben',
                           'wahrnehmung_w8', 'natuerlicher_kaempfer', 'eiserner_wille',
                           'schnelle_heilung', 'grundfertigkeit_weniger', 'springer',
                           'furcht', 'immunisierung', 'ruestung_anpassung',
                           'sprache_eingeschraenkt', 'wuchtig', 'volle_bewegungsweite_schwimmen',
                           'atmen_unter_wasser_minuten']:
                     effects['spezielle_effekte'].append({'typ': key, 'wert': value})
+                elif key == 'groesse_punkt':
+                    # Größe-Punkt direkt in groesse_modifikator aggregieren (addiert sich
+                    # automatisch auf Robustheit). Zusätzlich für Backward-Compat als
+                    # spezieller Effekt belassen.
+                    if isinstance(value, (int, float)):
+                        effects['groesse_modifikator'] = effects.get('groesse_modifikator', 0) + value
+                    effects['spezielle_effekte'].append({'typ': 'groesse_punkt', 'wert': value})
                 elif key in ['bewegungsweite_bonus', 'robustheit_bonus', 'bewegungsweite_flug',
                              'sozialer_malus', 'athletik_malus', 'ueberreden_malus',
                              'koerpersprache_malus', 'verstand_malus', 'erholung_malus',

--- a/models/charakter_properties.py
+++ b/models/charakter_properties.py
@@ -89,6 +89,7 @@ class CharakterProperties:
     robustheit = NumericProperty(3)
     robustheit_basis = NumericProperty(3)
     robustheit_mit_ruestung = StringProperty("")
+    groesse = NumericProperty(0)
     
     # Attribute und Fertigkeiten
     attribute = DictProperty({})

--- a/models/volk.py
+++ b/models/volk.py
@@ -30,7 +30,8 @@ class Volk(EventDispatcher):
         # Strukturierte Effekte direkt setzen (kein Text-Parsing mehr nötig)
         self.effects = effects or {
             'attribute_bonuses': {},      # {'Stärke': 2} = W4 -> W6
-            'robustheit_bonus': 0,        # +1 oder -1
+            'robustheit_bonus': 0,        # +1 oder -1 (echter Robustheit-Bonus, nicht Größe)
+            'groesse_modifikator': 0,     # +1/-1/-4 etc. (z.B. Halbling -1, Halbriese +3); addiert sich auf Robustheit
             'bewegungsweite_bonus': 0,    # +1 oder -1
             'fertigkeits_startboni': {},   # {'Wahrnehmung': 2} = W4-2 -> W4+0
             'fertigkeits_startmalus': {}, # {'Allgemeinwissen': -2} = W4 -> W4-2
@@ -50,7 +51,8 @@ class Volk(EventDispatcher):
         if not self.effects:
             self.effects = {
                 'attribute_bonuses': {},      # {'Stärke': 2} = W4 -> W6
-                'robustheit_bonus': 0,        # +1 oder -1
+                'robustheit_bonus': 0,        # +1 oder -1 (echter Robustheit-Bonus, nicht Größe)
+                'groesse_modifikator': 0,     # +1/-1/-4 etc.; addiert sich auf Robustheit
                 'bewegungsweite_bonus': 0,    # +1 oder -1
                 'fertigkeits_startboni': {},   # {'Wahrnehmung': 2} = W4-2 -> W4+0
                 'fertigkeits_startmalus': {},  # {'Allgemeinwissen': -2} = W4 -> W4-2
@@ -72,15 +74,16 @@ class Volk(EventDispatcher):
 
     def _parse_einzeleffekt(self, text, ist_handicap=False):
         """Parst einen einzelnen Effekt aus dem Text."""
+        import re
         text_lower = text.lower()
-        
+
         # Attribut-Boni erkennen (auch in Klammern)
         attribute = ['stärke', 'geschicklichkeit', 'konstitution', 'verstand', 'willenskraft']
         for attr in attribute:
             if f"{attr} w6 statt w4" in text_lower:
                 attr_name = attr.capitalize()
                 self.effects['attribute_bonuses'][attr_name] = 2
-                
+
         # Fertigkeits-Boni erkennen (auch in Klammern)
         fertigkeiten = ['wahrnehmung', 'athletik', 'einschüchtern', 'kämpfen']
         for fert in fertigkeiten:
@@ -91,17 +94,26 @@ class Volk(EventDispatcher):
                 fert_name = fert.capitalize()
                 self.effects['fertigkeits_startboni'][fert_name] = 0  # W4-2 -> W4
 
-        # Robustheit-Effekte (verschiedene Formulierungen)
-        if any(phrase in text_lower for phrase in [
-            "robustheit um 1", "-1 robustheit", "(-1 robustheit", 
-            "reduzierte robustheit um 1", "größe -1"
-        ]):
-            if ist_handicap or any(neg in text_lower for neg in ["-1", "reduzierte", "schlank"]):
-                self.effects['robustheit_bonus'] -= 1
-            else:
+        # Größe-Effekte: "Größe +1", "Größe -1", "Größe -4" etc. → groesse_modifikator
+        groesse_match = re.search(r'größe\s*([+-]?\d+)', text_lower)
+        groesse_aus_text = 0
+        if groesse_match:
+            groesse_aus_text = int(groesse_match.group(1))
+            self.effects['groesse_modifikator'] = self.effects.get('groesse_modifikator', 0) + groesse_aus_text
+
+        # Robustheit-Effekte: nur wenn nicht schon durch Größe abgedeckt
+        # (Größe addiert sich automatisch auf Robustheit, daher kein doppelter robustheit_bonus)
+        if groesse_aus_text == 0:
+            if any(phrase in text_lower for phrase in [
+                "robustheit um 1", "-1 robustheit", "(-1 robustheit",
+                "reduzierte robustheit um 1"
+            ]):
+                if ist_handicap or any(neg in text_lower for neg in ["-1", "reduzierte", "schlank"]):
+                    self.effects['robustheit_bonus'] -= 1
+                else:
+                    self.effects['robustheit_bonus'] += 1
+            elif any(phrase in text_lower for phrase in ["+1 robustheit", "orkische wildheit"]):
                 self.effects['robustheit_bonus'] += 1
-        elif any(phrase in text_lower for phrase in ["+1 robustheit", "orkische wildheit"]):
-            self.effects['robustheit_bonus'] += 1
 
         # Bewegungsweite-Effekte (verschiedene Formulierungen)
         if any(phrase in text_lower for phrase in [
@@ -146,8 +158,12 @@ class Volk(EventDispatcher):
         return self.effects.get('fertigkeits_startboni', {}).get(fertigkeits_name, 0)
 
     def get_robustheit_bonus(self):
-        """Gibt den Robustheit-Bonus zurück."""
+        """Gibt den echten Robustheit-Bonus zurück (ohne Größe-Anteil)."""
         return self.effects.get('robustheit_bonus', 0)
+
+    def get_groesse_modifikator(self):
+        """Gibt den Größe-Modifikator des Volks zurück (Mensch = 0)."""
+        return self.effects.get('groesse_modifikator', 0)
 
     def get_bewegungsweite_bonus(self):
         """Gibt den Bewegungsweite-Bonus zurück."""
@@ -313,12 +329,15 @@ class Volk(EventDispatcher):
                                 charakter.selected_maechte.append(macht_name)
                             Logger.info(f"Volk {self.name}: Macht '{macht_name}' erhalten (Macht-Volk)")
 
-            # Robustheit und Bewegungsweite werden in abgeleitete_werte.py berechnet
+            # Robustheit, Größe und Bewegungsweite werden in abgeleitete_werte.py berechnet
             robustheit_bonus = self.effects.get('robustheit_bonus', 0)
+            groesse_modifikator = self.effects.get('groesse_modifikator', 0)
             bewegungsweite_bonus = self.effects.get('bewegungsweite_bonus', 0)
-            
+
             if robustheit_bonus != 0:
                 Logger.info(f"Volk {self.name}: Robustheit-Bonus {robustheit_bonus:+d}")
+            if groesse_modifikator != 0:
+                Logger.info(f"Volk {self.name}: Größe {groesse_modifikator:+d}")
             if bewegungsweite_bonus != 0:
                 Logger.info(f"Volk {self.name}: Bewegungsweite-Bonus {bewegungsweite_bonus:+d}")
 

--- a/scripts/migrate_groesse_modifikator.py
+++ b/scripts/migrate_groesse_modifikator.py
@@ -1,0 +1,125 @@
+"""
+Migrationsskript: Trennt 'effects.groesse_modifikator' von 'effects.robustheit_bonus'
+in allen settings/*.json.
+
+Hintergrund: Bisher wurde der Größeneffekt (Mensch=0, Halbling=-1, Halbriese=+3, etc.)
+direkt im Feld 'robustheit_bonus' codiert. Mit der Einführung von 'groesse' als eigenem
+abgeleiteten Wert wird Größe jetzt sauber in 'groesse_modifikator' geführt; Robustheit
+addiert die Größe automatisch dazu.
+
+Vorgehen pro Volk-Eintrag:
+  1. Suche im konkatenierten Text aus 'besonderheiten' und 'handicaps' nach
+     "Größe ±N" (regex r'größe\\s*([+-]?\\d+)').
+  2. Wenn gefunden: setze effects.groesse_modifikator = N und reduziere
+     effects.robustheit_bonus um N.
+  3. Wenn nicht gefunden oder groesse_modifikator bereits gesetzt: überspringen.
+
+Das Skript ist idempotent. Es schreibt vor jeder Änderung ein *.json.bak Backup.
+"""
+
+import json
+import re
+import shutil
+from pathlib import Path
+
+
+GROESSE_PATTERN = re.compile(r'größe\s*([+-]?\d+)', re.IGNORECASE)
+
+
+def extrahiere_groesse_aus_text(volk: dict) -> int | None:
+    """Extrahiert Größenwert aus Besonderheiten/Handicaps. None falls nicht gefunden."""
+    texte = []
+    for key in ('besonderheiten', 'handicaps'):
+        wert = volk.get(key, [])
+        if isinstance(wert, list):
+            texte.extend(str(t) for t in wert)
+        elif isinstance(wert, str):
+            texte.append(wert)
+    text_kombiniert = ' | '.join(texte)
+    match = GROESSE_PATTERN.search(text_kombiniert)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def migriere_setting(pfad: Path) -> tuple[int, list[str]]:
+    """Migriert eine Setting-Datei. Returns (anzahl_geaendert, log_zeilen)."""
+    with pfad.open('r', encoding='utf-8') as f:
+        daten = json.load(f)
+
+    log_zeilen = []
+    voelker = daten.get('voelker', {})
+    if not isinstance(voelker, dict):
+        return 0, [f"  (kein 'voelker'-Block gefunden)"]
+
+    geaendert = 0
+    for volk_name, volk in voelker.items():
+        if not isinstance(volk, dict):
+            continue
+        effects = volk.get('effects')
+        if not isinstance(effects, dict):
+            continue
+
+        # Schritt 1: rb → groesse_modifikator (idempotent)
+        if effects.get('groesse_modifikator', 0) == 0:
+            groesse = extrahiere_groesse_aus_text(volk)
+            if groesse is not None and groesse != 0:
+                alter_rb = effects.get('robustheit_bonus', 0)
+                effects['groesse_modifikator'] = groesse
+                effects['robustheit_bonus'] = alter_rb - groesse
+                log_zeilen.append(
+                    f"  {volk_name}: groesse={groesse:+d}, "
+                    f"robustheit_bonus {alter_rb:+d} → {effects['robustheit_bonus']:+d}"
+                )
+                geaendert += 1
+
+        # Schritt 2: Doppelung mit auto_handicaps 'Klein'/'Riesig' entfernen.
+        # Wenn Volk schon einen Größen-Modifikator hat, ist das auto-applizierte
+        # Klein/Riesig redundant (Größe wird sonst doppelt gezählt).
+        groesse_mod = effects.get('groesse_modifikator', 0)
+        auto_handicaps = effects.get('auto_handicaps', [])
+        if groesse_mod < 0 and 'Klein' in auto_handicaps:
+            auto_handicaps.remove('Klein')
+            effects['auto_handicaps'] = auto_handicaps
+            log_zeilen.append(f"  {volk_name}: auto_handicap 'Klein' entfernt (redundant zu groesse_mod {groesse_mod:+d})")
+            geaendert += 1
+        if groesse_mod > 0 and 'Riesig' in auto_handicaps:
+            auto_handicaps.remove('Riesig')
+            effects['auto_handicaps'] = auto_handicaps
+            log_zeilen.append(f"  {volk_name}: auto_handicap 'Riesig' entfernt (redundant zu groesse_mod {groesse_mod:+d})")
+            geaendert += 1
+
+    if geaendert > 0:
+        backup = pfad.with_suffix(pfad.suffix + '.bak')
+        if not backup.exists():
+            shutil.copy2(pfad, backup)
+        with pfad.open('w', encoding='utf-8') as f:
+            json.dump(daten, f, indent=4, ensure_ascii=False)
+            f.write('\n')
+
+    return geaendert, log_zeilen
+
+
+def main():
+    settings_dir = Path(__file__).resolve().parents[1] / 'settings'
+    if not settings_dir.is_dir():
+        raise SystemExit(f"settings-Verzeichnis nicht gefunden: {settings_dir}")
+
+    gesamt_geaendert = 0
+    print(f"Migriere settings/*.json in {settings_dir}\n")
+    for pfad in sorted(settings_dir.glob('*.json')):
+        anzahl, log = migriere_setting(pfad)
+        if anzahl > 0:
+            print(f"{pfad.name}: {anzahl} Volk/Völker migriert")
+            for zeile in log:
+                print(zeile)
+            print()
+            gesamt_geaendert += anzahl
+        else:
+            print(f"{pfad.name}: keine Änderung")
+
+    print(f"\nFertig. Gesamt: {gesamt_geaendert} Volk/Völker migriert.")
+
+
+if __name__ == '__main__':
+    main()

--- a/settings/50 Fathoms.json
+++ b/settings/50 Fathoms.json
@@ -102,7 +102,7 @@
                     "Stärke": 4,
                     "Konstitution": 2
                 },
-                "robustheit_bonus": 1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -2,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -114,7 +114,8 @@
                     "speckschicht": true,
                     "halbaquatisch": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Kehana": {
@@ -1691,8 +1692,7 @@
             "name": "Böe",
             "kategorie": "Kampf",
             "rang": "F",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Mächtige Flügelschläge können Gegner in einem Kegel Angeschlagen machen oder Betäuben, wenn ein Joker gezogen wird.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -2101,8 +2101,7 @@
             "name": "Schnelle Verwandlung",
             "kategorie": "Übersinnlich",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Erlaubt eine Formveränderung als begrenzte Aktion statt der üblichen 10 Minuten.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -3740,8 +3739,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -3859,8 +3857,7 @@
             "name": "Krakenknochenschwert und -rüstung",
             "kategorie": "Hintergrund",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Der Krake besitzt ein Krakenknochenschwert (Stä+W10, 2 kg) und eine Krakenknochenrüstung (+3 Panzerung Torso/Arme/Kopf, 7,5 kg). Für Nichtkraken nur Stä+W6 und +1 Panzerung.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -3871,8 +3868,7 @@
             "name": "Natürlicher Schwimmer",
             "kategorie": "Hintergrund",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "+2 auf Athletikproben (Schwimmen), +1 auf Schwimmbewegungsweite, kann 50% länger den Atem anhalten.",
             "neue_maechte": 0,
             "machtpunkte": 0,

--- a/settings/Fantasy Kompendium.json
+++ b/settings/Fantasy Kompendium.json
@@ -322,7 +322,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": -4,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -334,7 +334,8 @@
                     "neugierig": true,
                     "zwei_linke_haende": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -4
             }
         },
         "Gestaltwandler": {
@@ -403,7 +404,7 @@
                 "attribute_bonuses": {
                     "Verstand": 2
                 },
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {
                     "Wahrnehmung": 2
@@ -416,7 +417,8 @@
                     "nachtsicht": true,
                     "geschaerfte_sinne": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
             }
         },
         "Goblin": {
@@ -442,7 +444,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {
                     "Heimlichkeit": 2
@@ -455,7 +457,8 @@
                 },
                 "wahlmoeglichkeiten": {
                     "freies_anfaenger_talent": true
-                }
+                },
+                "groesse_modifikator": -1
             }
         },
         "Golem": {
@@ -484,7 +487,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": 2,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "fertigkeits_startmalus": {
@@ -502,7 +505,8 @@
                     "weniger_grundfertigkeiten": true,
                     "wuchtig": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 2
             }
         },
         "Grabgeborener": {
@@ -613,14 +617,15 @@
                 "attribute_bonuses": {
                     "Willenskraft": 2
                 },
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
                     "Glück"
                 ],
                 "spezielle_effekte": {},
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
             }
         },
         "Halbork": {
@@ -685,7 +690,7 @@
                     "Stärke": 4,
                     "Konstitution": 4
                 },
-                "robustheit_bonus": 3,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -696,7 +701,8 @@
                     "verpeilt": true,
                     "wuchtig": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 3
             }
         },
         "Himmlischer": {
@@ -841,7 +847,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": -4,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
@@ -854,7 +860,8 @@
                     "sanftmuetig": true,
                     "winzig": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -4
             }
         },
         "Mensch": {
@@ -913,7 +920,7 @@
                     "Stärke": 4,
                     "Konstitution": 2
                 },
-                "robustheit_bonus": 1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -924,7 +931,8 @@
                     "ungebildet": true,
                     "wuchtig": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Oger": {
@@ -959,7 +967,7 @@
                     "Stärke": 4,
                     "Konstitution": 4
                 },
-                "robustheit_bonus": 1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
@@ -972,7 +980,8 @@
                     "verpeilt": true,
                     "wuchtig": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Ork": {
@@ -1001,7 +1010,7 @@
                     "Stärke": 2,
                     "Konstitution": 2
                 },
-                "robustheit_bonus": 1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -1010,7 +1019,8 @@
                     "aussenseiter_schwer": true,
                     "brutal": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Rakashaner": {
@@ -1086,7 +1096,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
@@ -1102,7 +1112,8 @@
                     "feige": true,
                     "gierig_leicht": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
             }
         },
         "Saurianer": {
@@ -1208,7 +1219,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": 1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 4,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -1217,7 +1228,8 @@
                     "abhaengigkeit_freier_himmel": true,
                     "ungewoehnliche_form": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Zwerg": {
@@ -4192,8 +4204,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,

--- a/settings/Hellfrost.json
+++ b/settings/Hellfrost.json
@@ -29,15 +29,14 @@
                 "attribute_bonuses": {
                     "Willenskraft": 2
                 },
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
                     "Glück"
                 ],
                 "auto_handicaps": [
-                    "Außenseiter",
-                    "Klein"
+                    "Außenseiter"
                 ],
                 "spezielle_effekte": {
                     "aussenseiter": true,
@@ -55,7 +54,8 @@
                         "bonus": 2,
                         "beschreibung": "Beginne mit Heimlichkeit oder Diebeskunst auf W6"
                     }
-                }
+                },
+                "groesse_modifikator": -1
             }
         },
         "Frostblut": {
@@ -2155,8 +2155,7 @@
             "name": "Böe",
             "kategorie": "Kampf",
             "rang": "F",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Mächtige Flügelschläge können Gegner in einem Kegel Angeschlagen machen oder Betäuben, wenn ein Joker gezogen wird.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -2568,8 +2567,7 @@
             "name": "Schnelle Verwandlung",
             "kategorie": "Übersinnlich",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Erlaubt eine Formveränderung als begrenzte Aktion statt der üblichen 10 Minuten.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -4210,8 +4208,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,
@@ -4301,8 +4298,7 @@
             "name": "AH (Druidentum)",
             "kategorie": "Hintergrund",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Arkane Fertigkeit: Druidenmagie (Verstand). Startmächte: 3. Druiden ziehen an den Fäden der Naturmagie und manipulieren Pflanzen und Tiere. In Wildnis +1 auf Druidenmagie, in Städten -1.",
             "neue_maechte": 3,
             "machtpunkte": 0,
@@ -4324,8 +4320,7 @@
             "name": "AH (Heahmagie)",
             "kategorie": "Hintergrund",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Arkane Fertigkeit: Heahmagie (Verstand). Startmächte: 3. Heahmagier schöpfen ihre Macht durch magische Stäbe. Ohne Stab -2 auf alle Heahmagiewürfe. Der Stab verursacht Stä+W4 Schaden.",
             "neue_maechte": 3,
             "machtpunkte": 0,
@@ -4347,8 +4342,7 @@
             "name": "AH (Runenmagie)",
             "kategorie": "Hintergrund",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Runenmagier ritzen Runen der Macht auf Steintafeln. Jede Rune hat eine eigene arkane Fertigkeit und ist mit drei Zaubersprüchen verknüpft. Beginnt mit einer Rune.",
             "neue_maechte": 3,
             "machtpunkte": 0,
@@ -4709,8 +4703,7 @@
             "name": "Bücherei",
             "kategorie": "Hintergrund",
             "rang": "A",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Besitzt Wissensbände. Erhält Punkte gleich halbem Verstandwürfel, verteilt auf Bände (max +3 pro Band), die Boni auf Wissensfertigkeiten geben.",
             "neue_maechte": 0,
             "machtpunkte": 0,

--- a/settings/Horror Kompendium.json
+++ b/settings/Horror Kompendium.json
@@ -194,7 +194,7 @@
                     "Stärke": 2,
                     "Konstitution": 2
                 },
-                "robustheit_bonus": 2,
+                "robustheit_bonus": 1,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
@@ -216,7 +216,8 @@
                     "schwaeche_elektrizitaet": true,
                     "max_geschicklichkeit_w8": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Phantom": {
@@ -2186,8 +2187,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,

--- a/settings/SWAE.json
+++ b/settings/SWAE.json
@@ -229,14 +229,15 @@
                 "attribute_bonuses": {
                     "Willenskraft": 2
                 },
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
                     "Glück"
                 ],
                 "spezielle_effekte": {},
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
             }
         },
         "Mensch": {
@@ -2252,8 +2253,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,

--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -1,13675 +1,13675 @@
 {
-  "name": "Savage Pathfinder",
-  "description": "Savage Pathfinder",
-  "voelker": {
-    "Elf": {
-      "name": "Elf",
-      "handicaps": [
-        "Schlank (-1 Robustheit, -1 auf Konstitutionsproben)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
-        "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Intelligenz (Verstand W6 statt W4, Maximum W12+1)",
-        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
-        "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Elfisch"
-      ],
-      "altersspanne": "Erwachsen mit 115, Alt mit 263, maximales Alter 350–750",
-      "groesse_maennlich": "1,65-2,05m, 52-72kg (Durchschnitt 1,85m, 58kg)",
-      "groesse_weiblich": "1,65-1,95m, 44-57kg (Durchschnitt 1,85m, 53kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2,
-          "Verstand": 2
+    "name": "Savage Pathfinder",
+    "description": "Savage Pathfinder",
+    "voelker": {
+        "Elf": {
+            "name": "Elf",
+            "handicaps": [
+                "Schlank (-1 Robustheit, -1 auf Konstitutionsproben)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
+                "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Intelligenz (Verstand W6 statt W4, Maximum W12+1)",
+                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
+                "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Elfisch"
+            ],
+            "altersspanne": "Erwachsen mit 115, Alt mit 263, maximales Alter 350–750",
+            "groesse_maennlich": "1,65-2,05m, 52-72kg (Durchschnitt 1,85m, 58kg)",
+            "groesse_weiblich": "1,65-1,95m, 44-57kg (Durchschnitt 1,85m, 53kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2,
+                    "Verstand": 2
+                },
+                "robustheit_bonus": -1,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {
+                    "Wahrnehmung": 2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Schlank"
+                ],
+                "spezielle_effekte": {
+                    "elfenmagie": true,
+                    "nachtsicht": true,
+                    "geschaerfte_sinne": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {
-          "Wahrnehmung": 2
+        "Gnom": {
+            "name": "Gnom",
+            "handicaps": [
+                "Größe -1 (Reduzierte Robustheit um 1)",
+                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)",
+                "Zwanghaft (Beginnt mit einer verstandsbasierten Fertigkeit auf W4)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Gnomenmagie (Kann Zaubertricks wirken: Licht, Geräusch, Telekinese, Tierfreund mit 1 Machtpunkt)",
+                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
+                "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
+                "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1)"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Gnomisch",
+                "Sylvanisch"
+            ],
+            "altersspanne": "Erwachsen mit 45, Alt mit 150, maximales Alter 200-500",
+            "groesse_maennlich": "95-110cm, 17-19kg (Durchschnitt 100cm, 18kg)",
+            "groesse_weiblich": "90-105cm, 14-17kg (Durchschnitt 95cm, 16kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Konstitution": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": -1,
+                "fertigkeits_startboni": {
+                    "Wahrnehmung": 2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Langsam_leicht",
+                    "Größe -1 (Reduzierte Robustheit)",
+                    "Verringerte Bewegungsweite (Typ)",
+                    "Zwanghaft"
+                ],
+                "spezielle_effekte": {
+                    "gnomenmagie": true,
+                    "nachtsicht": true,
+                    "geschaerfte_sinne": true
+                },
+                "wahlmoeglichkeiten": {
+                    "freie_verstandsfertigkeit": true
+                },
+                "groesse_modifikator": -1
+            }
         },
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Schlank"
-        ],
-        "spezielle_effekte": {
-          "elfenmagie": true,
-          "nachtsicht": true,
-          "geschaerfte_sinne": true
+        "Halbelf": {
+            "name": "Halbelf",
+            "handicaps": [],
+            "talente": [],
+            "besonderheiten": [
+                "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
+                "Flexibilität (Beginnt mit W6 in einem Attribut statt W4, erhöht Maximum nicht)",
+                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Elfisch"
+            ],
+            "altersspanne": "Erwachsen mit 22, Alt mit 93, maximales Alter 125–185",
+            "groesse_maennlich": "1,60-2,00m, 50-82kg (Durchschnitt 1,80m, 70kg)",
+            "groesse_weiblich": "1,55-1,90m, 45-77kg (Durchschnitt 1,75m, 61kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {},
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "spezielle_effekte": {
+                    "elfenmagie": true,
+                    "nachtsicht": true
+                },
+                "wahlmoeglichkeiten": {
+                    "freies_attribut": true
+                }
+            }
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Gnom": {
-      "name": "Gnom",
-      "handicaps": [
-        "Größe -1 (Reduzierte Robustheit um 1)",
-        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)",
-        "Zwanghaft (Beginnt mit einer verstandsbasierten Fertigkeit auf W4)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Gnomenmagie (Kann Zaubertricks wirken: Licht, Geräusch, Telekinese, Tierfreund mit 1 Machtpunkt)",
-        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
-        "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
-        "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1)"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Gnomisch",
-        "Sylvanisch"
-      ],
-      "altersspanne": "Erwachsen mit 45, Alt mit 150, maximales Alter 200-500",
-      "groesse_maennlich": "95-110cm, 17-19kg (Durchschnitt 100cm, 18kg)",
-      "groesse_weiblich": "90-105cm, 14-17kg (Durchschnitt 95cm, 16kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Konstitution": 2
+        "Halbling": {
+            "name": "Halbling",
+            "handicaps": [
+                "Größe -1 (Reduzierte Robustheit um 1)",
+                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)"
+            ],
+            "talente": [
+                "Glück (Zusätzlicher Benny pro Spielsitzung)"
+            ],
+            "besonderheiten": [
+                "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
+                "Wendig (Athletik W6 statt W4, Maximum W12+1)"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Halblingisch"
+            ],
+            "altersspanne": "Erwachsen mit 22, Alt mit 75, maximales Alter 100–200",
+            "groesse_maennlich": "95-100cm, 14-17kg (Durchschnitt 95cm, 16kg)",
+            "groesse_weiblich": "85-95cm, 12-15kg (Durchschnitt 98cm, 14kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": -1,
+                "fertigkeits_startboni": {
+                    "Wahrnehmung": 2,
+                    "Athletik": 2
+                },
+                "auto_talente": [
+                    "Glück"
+                ],
+                "auto_handicaps": [
+                    "Langsam_leicht",
+                    "Größe -1 (Reduzierte Robustheit)",
+                    "Verringerte Bewegungsweite (Typ)"
+                ],
+                "spezielle_effekte": {
+                    "geschaerfte_sinne": true
+                },
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
+            }
         },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": -1,
-        "fertigkeits_startboni": {
-          "Wahrnehmung": 2
+        "Halbork": {
+            "name": "Halbork",
+            "handicaps": [
+                "Außenseiter (leicht, -2 auf Überredenproben, werden oft abgelehnt oder verspottet)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Einschüchternd (Beginnt mit W4 in Einschüchtern, Maximum W12+1)",
+                "Orkische Wildheit (+1 Robustheit)",
+                "Stark (Stärke W6 statt W4, Maximum W12+1)"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Orkisch"
+            ],
+            "altersspanne": "Erwachsen mit 15, Alt mit 45, maximales Alter 60–80",
+            "groesse_maennlich": "1,50-2,05m, 74-144kg (Durchschnitt 1,80m, 109kg)",
+            "groesse_weiblich": "1,40-1,95m, 56-126kg (Durchschnitt 1,70m, 91kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Stärke": 2
+                },
+                "robustheit_bonus": 1,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Außenseiter_leicht"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
         },
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Klein",
-          "Langsam_leicht",
-          "Größe -1 (Reduzierte Robustheit)",
-          "Verringerte Bewegungsweite (Typ)",
-          "Zwanghaft"
-        ],
-        "spezielle_effekte": {
-          "gnomenmagie": true,
-          "nachtsicht": true,
-          "geschaerfte_sinne": true
+        "Mensch": {
+            "name": "Mensch",
+            "handicaps": [],
+            "talente": [],
+            "besonderheiten": [
+                "Anpassungsfähigkeit (Freies Talent und W6 in einem Attribut statt W4, erhöht Maximum nicht)"
+            ],
+            "sprachen": [
+                "Gemeinsprache"
+            ],
+            "altersspanne": "Erwachsen mit 17, Alt mit 53, maximales Alter 70–110",
+            "groesse_maennlich": "1,50-1,95m, 54-100kg (Durchschnitt 1,70m, 79kg)",
+            "groesse_weiblich": "1,50-1,85m, 43-84kg (Durchschnitt 1,60m, 64kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {},
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {},
+                "wahlmoeglichkeiten": {
+                    "freies_talent": true,
+                    "freies_attribut": true
+                }
+            }
         },
-        "wahlmoeglichkeiten": {
-          "freie_verstandsfertigkeit": true
+        "Zwerg": {
+            "name": "Zwerg",
+            "handicaps": [
+                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Eiserne Konstitution (+1 beim Widerstand gegen Gift, +1 zum Widerstand oder zur Erholung von Mächten)",
+                "Steingespür (+2 auf Wahrnehmungsproben bei ungewöhnlich bearbeitetem Stein innerhalb von 3m)",
+                "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1, Stärke um einen Würfel höher für Belastung und Mindeststärke)"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Zwergisch"
+            ],
+            "altersspanne": "Erwachsen mit 45, Alt mit 188, maximales Alter 250–450",
+            "groesse_maennlich": "1,20-1,35m, 74-93kg (Durchschnitt 1,30m, 84kg)",
+            "groesse_weiblich": "1,15-1,30m, 61-80kg (Durchschnitt 1,20m, 75kg)",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Konstitution": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": -1,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Langsam_leicht",
+                    "Verringerte Bewegungsweite (Schritt)"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "eiserne_konstitution": true,
+                    "steingespür": true,
+                    "staerke_bonus_traglast": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Ifrits": {
+            "name": "Ifrits",
+            "handicaps": [],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Elementarzauberei (Ifrit-Zauberer mit dem Talent Elementarblut [Feuer] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+                "Angeborene Macht: Ausbruch / Brennende Hände (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Wüstenspiegelung: +1 auf Proben gegen Hunger und Durst; ersetzt Elementarzauberei",
+                "Alternativfähigkeit – Efrit-Magie: Angeborene Macht wird Wachsen/Schrumpfen (selbst, zwei Größenstufen) statt Ausbruch; modifiziert Angeborene Macht",
+                "Alternativfähigkeit – Feuer im Blut: Schnelle Regeneration für 2 Runden wenn durch Feuer Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Beweglich"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Ignanisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); oft spitze Ohren, rote oder gefleckte Hörner, flammenartiges Haar",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit messingfarbener Haut oder anthrazitfarbenen Schuppen",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "elementarzauberei_feuer": true,
+                    "angeborene_macht_feuer": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Oreads": {
+            "name": "Oreads",
+            "handicaps": [
+                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Stark (Stärke W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Granitene Haut (Felsige Wucherungen gewähren +2 Rüstung)",
+                "Elementarzauberei (Oread-Zauberer mit dem Talent Elementarblut [Erde] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+                "Angeborene Macht: Blitz / Magischer Stein (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Eisenwuchs: 1×/Tag kann ein berührtes nicht-magisches Eisen- oder Stahlstück zu einem Gegenstand bis 4,5 kg wachsen (10 Minuten); ersetzt Angeborene Macht",
+                "Alternativfähigkeit – Stein im Blut (Schnell): Schnelle Regeneration für 2 Runden wenn durch Säure Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Stark; schließt Stein im Blut (Langsam) aus",
+                "Alternativfähigkeit – Stein im Blut (Langsam): Langsame Regeneration wenn durch Säure Erschüttert oder Verwundet; ersetzt Elementarzauberei; schließt Stein im Blut (Schnell) aus",
+                "Alternativfähigkeit – Tückische Erde: 1×/Tag kann der Oread eine große Schablone (Reichweite Verstand) in schweres Gelände verwandeln (Erde, Stein oder Sand); Dauer in Minuten je nach Rang: Anfänger 1, Erfahren 2, Veteran 3, Held 4, Legendär 5; ersetzt Granitene Haut"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Terranisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut und Haar in steinigen Tönen (Schwarz, Braun, Grau, Weiß)",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit glänzender Obsidian-Haut, Gesteinsvorsprüngen oder kristallinen Haarspitzen",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Stärke": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": -1,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Langsam_leicht",
+                    "Verringerte Bewegungsweite (Schritt)"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "granit_haut": true,
+                    "elementarzauberei_erde": true,
+                    "angeborene_macht_erde": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Sylphen": {
+            "name": "Sylphen",
+            "handicaps": [
+                "Zerbrechlich (-1 Robustheit)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Intelligent (Verstand W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Elementarzauberei (Sylph-Zauberer mit dem Talent Elementarblut [Luft] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+                "Federfall (1×/Tag kann der Sylph jeden Schaden durch einen Fall verhindern)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Wie der Wind: Bewegungsweite +2; ersetzt Beweglich",
+                "Alternativfähigkeit – Himmelssprecher: Angeborene Macht Tierfreund mit Geistesreiter (Vögel und andere fliegende Tiere, 1×/Tag); ersetzt Elementarzauberei",
+                "Alternativfähigkeit – Sturm im Blut: Schnelle Regeneration für 2 Runden wenn durch Elektrizität Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Intelligent"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Auranisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); blass und schlank, blaue spiralförmige Markierungen auf der Haut",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); eine leichte Brise begleitet sie stets als Zeichen ihrer elementaren Abstammung",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2,
+                    "Verstand": 2
+                },
+                "robustheit_bonus": -1,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Zerbrechlich"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "federfall": true,
+                    "elementarzauberei_luft": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Undinen": {
+            "name": "Undinen",
+            "handicaps": [
+                "Verringerte Stärke (-1 auf alle Stärkeproben)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Lebhaft (Willenskraft W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Elementarzauberei (Undinen-Zauberer mit dem Talent Elementarblut [Wasser] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
+                "Anmutige Schwimmer (Können sich im Wasser stets mit ihrer vollen Bewegungsweite bewegen)",
+                "Angeborene Macht: Verheerung / Hydraulischer Stoß (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Säureatem: Angeborene Macht wird Ausbruch (Säureatem) statt Verheerung; modifiziert Angeborene Macht",
+                "Alternativfähigkeit – Hydrierte Vitalität (Schnell): Schnelle Regeneration für 2 Runden wenn mind. 10 Min vollständig in Wasser untergetaucht (max. 2 Wunden/Tag); ersetzt Beweglich; schließt Hydrierte Vitalität (Langsam) aus",
+                "Alternativfähigkeit – Hydrierte Vitalität (Langsam): Langsame Regeneration wenn mind. 10 Min vollständig in Wasser untergetaucht; ersetzt Elementarzauberei; schließt Hydrierte Vitalität (Schnell) aus",
+                "Alternativfähigkeit – Wasserwahrnehmung: Blindwahrnehmung 10\"/20 Meter im Wasser durch Vibrationssinn; ersetzt Dunkelsicht"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Aquanisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut in Türkis- bis Meeresgrüntönen, flossartige Ohren, Schwimmhäute an Händen und Füßen",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); Augen immer hellblau, Haar etwas dunkler als die Hautfarbe",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2,
+                    "Willenskraft": 2,
+                    "Stärke": -1
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Verringerte Stärke"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "anmutige_schwimmer": true,
+                    "elementarzauberei_wasser": true,
+                    "angeborene_macht_wasser": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Weinranken-Leshy": {
+            "name": "Weinranken-Leshy",
+            "handicaps": [
+                "Größe -1 (Reduzierte Größe und Robustheit um 1)",
+                "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)",
+                "Verringerte Fertigkeiten (Beginnen nicht mit W4 in Allgemeinwissen und Wahrnehmung – diese starten auf W4-2)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Lebhaft (Willenskraft W6 statt W4, Maximum W12+1)",
+                "Zäh (Konstitution W6 statt W4, Maximum W12+1)",
+                "Heimlich (Heimlichkeit W6 statt W4, Maximum W12+1)",
+                "Nachtsicht (Ignoriert alle Beleuchtungsabzüge)",
+                "Gestalt wandeln (Als eingeschränkte freie Aktion [Willenskraftprobe]: verwandelt sich in eine gesunde kleine Weinrebe oder zurück in die wahre Form)",
+                "Leshypflanze (Typus ist Pflanze statt Humanoid; keine normalen Pflanzenimmunitäten; kann mit Weinreben sprechen)",
+                "Üppiger Ausbruch (Beim Tod: Explosion mit großer Schablone; Pflanzenwesen in der Schablone heilen 1 Wunde; Gebiet wird für 24h zu schwerem Gelände, wenn die Umgebung Weinreben unterstützt)",
+                "Alternativfähigkeit – Weinrebe: 1×/Tag Macht Heilung wirken (Willenskraftprobe); ersetzt Heimlich",
+                "Alternativfähigkeit – Giftig: Als eingeschränkte freie Aktion können die Ranken mit mildem Gift belegt werden; der nächste unbewaffnete Treffer wirkt mildes Gift auf das Ziel; ersetzt Heimlich",
+                "Alternativfähigkeit – Sumpf-Leshy: Gewinnt Aquatisch; Nachtsicht wird durch Dunkelsicht (10\"/20 Meter) ersetzt; ändert Nachtsicht"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Sylvanisch"
+            ],
+            "altersspanne": "Unbekannt; als Pflanzenwesen kehrt der Geist beim Tod in die Natur zurück und kann einen neuen Körper bewohnen",
+            "groesse_maennlich": "Kleinwüchsig (~60-90cm, 10-20kg); Körper aus verflochtenen Ranken und Blättern, manchmal mit Blüten und Früchten",
+            "groesse_weiblich": "Kleinwüchsig (~60-90cm, 10-20kg); Gesicht aus Blättern mit runden Augen, kleinem Mund, ohne sichtbare Nase",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Willenskraft": 2,
+                    "Konstitution": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": -1,
+                "fertigkeits_startboni": {
+                    "Heimlichkeit": 2
+                },
+                "fertigkeits_startmalus": {
+                    "Allgemeinwissen": -2,
+                    "Wahrnehmung": -2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Langsam_leicht",
+                    "Größe -1 (Reduzierte Größe und Robustheit)",
+                    "Verringerte Bewegungsweite (Schritt)",
+                    "Verringerte Fertigkeiten"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "gestalt_wandeln": true,
+                    "leshy_pflanze": true,
+                    "uppiger_ausbruch": true
+                },
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
+            }
+        },
+        "Aasimars": {
+            "name": "Aasimars",
+            "handicaps": [],
+            "talente": [],
+            "besonderheiten": [
+                "Lebhaft (Willenskraft W6 statt W4, Maximum W12+1)",
+                "Diplomatisch (Überreden W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Tageslicht (1×/Tag als eingeschränkte freie Aktion: geringes Licht als Angeborene Macht wirken)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Himmlischer Kreuzritter: Gewinnt Bevorzugter Feind (Außenseiter) wie das Waldläufer-Klassentalent; ersetzt Diplomatisch",
+                "Alternativfähigkeit – Erhöhter Widerstand: Gewinnt das Talent Arkaner Widerstand auch ohne Voraussetzungen; ersetzt Lebhaft",
+                "Alternativfähigkeit – Heiligenschein: Tageslicht erzeugt einen heiligenscheinförmigen Lichtkreis um den Kopf; bei aktivem Heiligenschein freie Wiederholung bei Testen gegen böse Kreaturen; ersetzt Dunkelsicht"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Himmlisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); häufig metallisch glänzendes Haar, juwelenförmige Augen oder schimmernder Teint",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche besitzen einen leuchtenden goldenen Heiligenschein als sichtbares Zeichen ihrer himmlischen Abstammung",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Willenskraft": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {
+                    "Überreden": 2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "tageslicht": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Katzenfolk": {
+            "name": "Katzenfolk",
+            "handicaps": [],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
+                "Katzenglück (Freie Wiederholung bei fehlgeschlagenen Ausweichproben)",
+                "Sprinter (Sprintwürfel um einen Typ erhöht)",
+                "Alternativfähigkeit – Katzenkrallen: Natürliche Waffe, Stärke+W4 Schaden (Natürliche Waffen laut Pathfinder für Savage Worlds); ersetzt Beweglich",
+                "Alternativfähigkeit – Sicherer Fall: Landet stets auf den Füßen; reduziert Fallschaden um 1W6+1; ersetzt Sprinter",
+                "Alternativfähigkeit – Geruchssinn: Ignoriert bis zu 4 Punkte Abzüge bei Angriffen gegen durch magische Dunkelheit, Unsichtbarkeit o.ä. verborgene Gegner; ersetzt Nachtsicht"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Katzenfolk"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–100)",
+            "groesse_maennlich": "Zwischen Zwerg und Mensch (~1,30-1,65m, 45-65kg); schlanker Körper mit feinem Fell, Schlitzpupillen, Katzenohren und schlankem Schwanz",
+            "groesse_weiblich": "Zwischen Zwerg und Mensch (~1,25-1,60m, 40-58kg); einziehbare Krallen; Fell-, Haar- und Augenfarbe stark variierend",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [],
+                "spezielle_effekte": {
+                    "nachtsicht": true,
+                    "katzenglueck": true,
+                    "sprinter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Dhampire": {
+            "name": "Dhampire",
+            "handicaps": [
+                "Lichtempfindlich (-1 auf Eigenschaftswürfe bei Sichterfordernissen im hellen Licht)",
+                "Verringerte Vitalität (-1 Robustheit)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Nachtsicht (Ignoriert alle Beleuchtungsabzüge)",
+                "Untote spüren (Als eingeschränkte Aktion: Untote innerhalb von 20\"/40 Meter erspüren; als eingeschränkte freie Aktion: Anzahl und ungefähre Stärke der Untoten ermitteln)",
+                "Untotenresistenz (Freie Wiederholung beim Widerstand gegen Krankheiten; immun gegen Energieentzug)",
+                "Alternativfähigkeit – Tageskind: Nicht durch Tageslicht beeinträchtigt; verliert Lichtempfindlichkeit; Nachtsicht wird durch Nachtsicht (nur Düster/Dunkel) ersetzt",
+                "Alternativfähigkeit – Fangzähne: Natürliche Waffe Biss, Stärke+W4 Schaden (Natürliche Waffen laut Pathfinder für Savage Worlds); ersetzt Untotenresistenz",
+                "Alternativfähigkeit – Vampirische Empathie: Kann mit Fledermäusen, Ratten und Wölfen kommunizieren; freie Wiederholung bei fehlgeschlagenen Überreden-Proben mit diesen Tieren; ersetzt Untote spüren"
+            ],
+            "sprachen": [
+                "Gemeinsprache"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110), jedoch mit übernatürlicher Langlebigkeit ähnlich wie Elfen",
+            "groesse_maennlich": "Hochgewachsen und schlank (1,70-2,00m, 60-85kg); unheimlich schöne Züge, verlängerte Eckzähne, oft gespenstische Blässe im Tageslicht",
+            "groesse_weiblich": "Hochgewachsen und schlank (1,65-1,90m, 55-75kg); übernatürlich flüssige Bewegungen; dunkle Haut wirkt manchmal wie ein Bluterguss",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2
+                },
+                "robustheit_bonus": -1,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Lichtempfindlich",
+                    "Verringerte Vitalität"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "lichtempfindlich": true,
+                    "untote_spueren": true,
+                    "untotenresistenz": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Tieflinge": {
+            "name": "Tieflinge",
+            "handicaps": [
+                "Außenseiter (leicht, -2 auf Überredenproben, werden oft abgelehnt oder verspottet)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
+                "Intelligent (Verstand W6 statt W4, Maximum W12+1)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Dunkelheit (1×/Tag als eingeschränkte freie Aktion: geringes Dunkel als Angeborene Macht wirken)",
+                "Teuflische Zauberei (Tieflinge-Zauberer mit Abgrundsblut oder Infernalblut reduzieren die Ranganforderung für Fortgeschrittenes Blut auf Veteran)",
+                "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
+                "Alternativfähigkeit – Teuflischer Sprinter: Gewinnt das Talent Schnell (Fleet-Footed); ersetzt Intelligent",
+                "Alternativfähigkeit – Greifbarer Schwanz: Kann mit dem Schwanz verstaute Gegenstände als freie Aktion hervorholen; ersetzt Teuflische Zauberei",
+                "Alternativfähigkeit – Verkümmerte Flügel: Fliegen mit Bewegungsweite 6; am Ende jeder Flug-Runde Konstitutionsprobe oder Erschöpfung; ersetzt Teuflische Zauberei"
+            ],
+            "sprachen": [
+                "Abyssalisch",
+                "Gemeinsprache",
+                "Infernalisch"
+            ],
+            "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
+            "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); individuelle teuflische Merkmale wie Hörner, gezackter Schwanz, unnatürlich gefärbte Augen, Klauen oder kleine Flügel",
+            "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); kein Tieflinge gleicht dem anderen – von seltsam schön bis erschreckend fremdländisch",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 2,
+                    "Verstand": 2
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {},
+                "fertigkeits_modifier_boni": {
+                    "Überreden": -2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Außenseiter_leicht"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true,
+                    "dunkelheit_macht": true,
+                    "teuflische_zauberei": true,
+                    "heimischer_aussenseiter": true
+                },
+                "wahlmoeglichkeiten": {}
+            }
+        },
+        "Goblin": {
+            "name": "Goblin",
+            "handicaps": [
+                "Größe -1 (Reduzierte Größe und Robustheit um 1)",
+                "Außenseiter (Schwer) (-2 auf alle Überreden-Proben; werden von anderen oft gemobbt)"
+            ],
+            "talente": [],
+            "besonderheiten": [
+                "Flink (Geschicklichkeit W8 statt W4, Maximum W12+2)",
+                "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
+                "Fähiger Reiter (Beginnt mit W4 in Reiten)",
+                "Heimlich (Heimlichkeit W6 statt W4, Maximum W12+1)",
+                "Alternativfähigkeit – Alles essen: Freie Wiederholung bei Überleben-Proben zur Nahrungssuche; +2 bei Konstitutionsproben gegen toxische Substanzen; ersetzt Fähiger Reiter",
+                "Alternativfähigkeit – Harter Schädel, große Zähne: Natürliche Waffe Biss, Stärke+W4 Schaden; ersetzt Heimlich",
+                "Alternativfähigkeit – Übergroße Ohren: Wahrnehmung W6 statt W4, Maximum W12+1; ersetzt Fähiger Reiter"
+            ],
+            "sprachen": [
+                "Gemeinsprache",
+                "Goblinisch"
+            ],
+            "altersspanne": "Jugend mit 3, Erwachsen mit 7–8, maximales Alter 50+ (selten über 20 ohne Beschützer)",
+            "groesse_maennlich": "Klein (~85-100cm, 17-22kg); knochige Gestalt, übergroßer kahler Schädel, riesige Ohren, kleine rote oder gelbe Augen",
+            "groesse_weiblich": "Klein (~80-95cm, 15-20kg); Hautfarbe variiert: Grün, Grau, Blau, Schwarz oder Blassgrau; riesiges Maul mit zackigen Zähnen",
+            "aktiv": true,
+            "custom": false,
+            "effects": {
+                "attribute_bonuses": {
+                    "Geschicklichkeit": 4
+                },
+                "robustheit_bonus": 0,
+                "bewegungsweite_bonus": 0,
+                "fertigkeits_startboni": {
+                    "Heimlichkeit": 2,
+                    "Reiten": 2
+                },
+                "fertigkeits_modifier_boni": {
+                    "Überreden": -2
+                },
+                "auto_talente": [],
+                "auto_handicaps": [
+                    "Größe -1 (Reduzierte Größe und Robustheit)"
+                ],
+                "spezielle_effekte": {
+                    "dunkelsicht": true
+                },
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
+            }
         }
-      }
     },
-    "Halbelf": {
-      "name": "Halbelf",
-      "handicaps": [],
-      "talente": [],
-      "besonderheiten": [
-        "Elfenmagie (Freie Wiederholung gegen gegnerische Mächte)",
-        "Flexibilität (Beginnt mit W6 in einem Attribut statt W4, erhöht Maximum nicht)",
-        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Elfisch"
-      ],
-      "altersspanne": "Erwachsen mit 22, Alt mit 93, maximales Alter 125–185",
-      "groesse_maennlich": "1,60-2,00m, 50-82kg (Durchschnitt 1,80m, 70kg)",
-      "groesse_weiblich": "1,55-1,90m, 45-77kg (Durchschnitt 1,75m, 61kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {},
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "spezielle_effekte": {
-          "elfenmagie": true,
-          "nachtsicht": true
+    "voelker_selected": {
+        "Elf": false,
+        "Gnom": false,
+        "Halbelf": false,
+        "Halbling": false,
+        "Halbork": false,
+        "Ifrits": false,
+        "Mensch": true,
+        "Oreads": false,
+        "Zwerg": false
+    },
+    "attribute": {
+        "Geschicklichkeit": {
+            "attribut_name": "Geschicklichkeit",
+            "wert": 4,
+            "modifier": 0
         },
-        "wahlmoeglichkeiten": {
-          "freies_attribut": true
+        "Verstand": {
+            "attribut_name": "Verstand",
+            "wert": 4,
+            "modifier": 0
+        },
+        "Stärke": {
+            "attribut_name": "Stärke",
+            "wert": 4,
+            "modifier": 0
+        },
+        "Konstitution": {
+            "attribut_name": "Konstitution",
+            "wert": 4,
+            "modifier": 0
+        },
+        "Willenskraft": {
+            "attribut_name": "Willenskraft",
+            "wert": 4,
+            "modifier": 0
         }
-      }
     },
-    "Halbling": {
-      "name": "Halbling",
-      "handicaps": [
-        "Größe -1 (Reduzierte Robustheit um 1)",
-        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert)"
-      ],
-      "talente": [
-        "Glück (Zusätzlicher Benny pro Spielsitzung)"
-      ],
-      "besonderheiten": [
-        "Geschickt (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Geschärfte Sinne (Wahrnehmung W6 statt W4, Maximum W12+1)",
-        "Wendig (Athletik W6 statt W4, Maximum W12+1)"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Halblingisch"
-      ],
-      "altersspanne": "Erwachsen mit 22, Alt mit 75, maximales Alter 100–200",
-      "groesse_maennlich": "95-100cm, 14-17kg (Durchschnitt 95cm, 16kg)",
-      "groesse_weiblich": "85-95cm, 12-15kg (Durchschnitt 98cm, 14kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2
-        },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": -1,
-        "fertigkeits_startboni": {
-          "Wahrnehmung": 2,
-          "Athletik": 2
-        },
-        "auto_talente": [
-          "Glück"
+    "fertigkeiten_daten": {
+        "Allgemeinwissen": [
+            "Verstand"
         ],
-        "auto_handicaps": [
-          "Klein",
-          "Langsam_leicht",
-          "Größe -1 (Reduzierte Robustheit)",
-          "Verringerte Bewegungsweite (Typ)"
+        "Athletik": [
+            "Geschicklichkeit"
         ],
-        "spezielle_effekte": {
-          "geschaerfte_sinne": true
-        },
-        "wahlmoeglichkeiten": {}
-      }
+        "Heimlichkeit": [
+            "Geschicklichkeit"
+        ],
+        "Überreden": [
+            "Willenskraft"
+        ],
+        "Wahrnehmung": [
+            "Verstand"
+        ],
+        "Kämpfen": [
+            "Geschicklichkeit"
+        ],
+        "Schießen": [
+            "Geschicklichkeit"
+        ],
+        "Diebeskunst": [
+            "Geschicklichkeit"
+        ],
+        "Überleben": [
+            "Verstand"
+        ],
+        "Reiten": [
+            "Geschicklichkeit"
+        ],
+        "Fahren": [
+            "Geschicklichkeit"
+        ],
+        "Seefahrt": [
+            "Geschicklichkeit"
+        ],
+        "Pilot": [
+            "Geschicklichkeit"
+        ],
+        "Darbietung": [
+            "Willenskraft"
+        ],
+        "Einschüchtern": [
+            "Willenskraft"
+        ],
+        "Glaube": [
+            "Willenskraft"
+        ],
+        "Heilen": [
+            "Verstand"
+        ],
+        "Provozieren": [
+            "Verstand"
+        ],
+        "Reparieren": [
+            "Verstand"
+        ],
+        "Glücksspiel": [
+            "Verstand"
+        ],
+        "Kriegskunst": [
+            "Verstand"
+        ],
+        "Okkultismus": [
+            "Verstand"
+        ],
+        "Geisteswissenschaften": [
+            "Verstand"
+        ],
+        "Naturwissenschaften": [
+            "Verstand"
+        ],
+        "Zaubern": [
+            "Verstand"
+        ],
+        "Zaubern (Zauberer)": [
+            "Willenskraft"
+        ],
+        "Verrückte Wissenschaft": [
+            "Verstand"
+        ],
+        "Alchemie": [
+            "Verstand"
+        ],
+        "Fokus": [
+            "Willenskraft"
+        ]
     },
-    "Halbork": {
-      "name": "Halbork",
-      "handicaps": [
-        "Außenseiter (leicht, -2 auf Überredenproben, werden oft abgelehnt oder verspottet)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Einschüchternd (Beginnt mit W4 in Einschüchtern, Maximum W12+1)",
-        "Orkische Wildheit (+1 Robustheit)",
-        "Stark (Stärke W6 statt W4, Maximum W12+1)"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Orkisch"
-      ],
-      "altersspanne": "Erwachsen mit 15, Alt mit 45, maximales Alter 60–80",
-      "groesse_maennlich": "1,50-2,05m, 74-144kg (Durchschnitt 1,80m, 109kg)",
-      "groesse_weiblich": "1,40-1,95m, 56-126kg (Durchschnitt 1,70m, 91kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Stärke": 2
+    "talente": {
+        "Berserker": {
+            "name": "Berserker",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Erhöhe Stärke um einen Würfeltyp. Du musst einen Rücksichtslosen Angriff ausführen, wenn möglich.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
         },
-        "robustheit_bonus": 1,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Außenseiter_leicht"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true
+        "Barbar": {
+            "name": "Barbar",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W6",
+                "KON W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (mittelschwer), Behände (Bewegungsweite +2), Kampfrausch (siehe Text)",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Berserker",
+                "Behände",
+                "Kampfrausch"
+            ],
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_mittelschwer"
+            ]
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Mensch": {
-      "name": "Mensch",
-      "handicaps": [],
-      "talente": [],
-      "besonderheiten": [
-        "Anpassungsfähigkeit (Freies Talent und W6 in einem Attribut statt W4, erhöht Maximum nicht)"
-      ],
-      "sprachen": [
-        "Gemeinsprache"
-      ],
-      "altersspanne": "Erwachsen mit 17, Alt mit 53, maximales Alter 70–110",
-      "groesse_maennlich": "1,50-1,95m, 54-100kg (Durchschnitt 1,70m, 79kg)",
-      "groesse_weiblich": "1,50-1,85m, 43-84kg (Durchschnitt 1,60m, 64kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {},
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [],
-        "spezielle_effekte": {},
-        "wahlmoeglichkeiten": {
-          "freies_talent": true,
-          "freies_attribut": true
+        "Kraftvoller Schlag": {
+            "name": "Kraftvoller Schlag",
+            "kategorie": "Barbar",
+            "rang": "F",
+            "voraussetzungen": [
+                "Barbar"
+            ],
+            "beschreibung": "Rücksichtslose Angriffe verursachen +4 Schaden anstatt +2.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Einschüchterndes Niederstarren": {
+            "name": "Einschüchterndes Niederstarren",
+            "kategorie": "Barbar",
+            "rang": "V",
+            "voraussetzungen": [
+                "Barbar"
+            ],
+            "beschreibung": "Der Barbar kann eine Einschüchternprobe als freie Aktion ausführen, wenn ihm im Kampf ein Bube oder besser ausgeteilt wird.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kraftrausch": {
+            "name": "Kraftrausch",
+            "kategorie": "Barbar",
+            "rang": "H",
+            "voraussetzungen": [
+                "Barbar"
+            ],
+            "beschreibung": "Die Stärke des Helden wird um zwei Würfeltypen erhöht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Barde)": {
+            "name": "AH (Barde)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "Allgemeinwissen W6"
+            ],
+            "beschreibung": "AH (Barde), Behindernde Rüstung (leicht), Scharfzüngig (kann Darbietung zum Provozieren verwenden)",
+            "neue_maechte": 3,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Scharfzüngig"
+            ],
+            "auto_handicaps": [
+                "Behindernde Rüstung_leicht"
+            ]
+        },
+        "Bannlied": {
+            "name": "Bannlied",
+            "kategorie": "Barde",
+            "rang": "V",
+            "voraussetzungen": [
+                "Barde"
+            ],
+            "beschreibung": "Verbündete innerhalb von 5'' erhalten eine Wurfwiederholung, wenn sie feindlichen Zaubereffekten widerstehen oder sich von ihnen erholen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Klagelied": {
+            "name": "Klagelied",
+            "kategorie": "Barde",
+            "rang": "H",
+            "voraussetzungen": [
+                "Barde"
+            ],
+            "beschreibung": "Feindliche Wildcards innerhalb von 10'' ziehen –2 vom Gesamtwert ab, wenn sie einen Benny ausgeben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Druide)": {
+            "name": "AH (Druide)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "Überleben W6"
+            ],
+            "beschreibung": "AH (Druide), Behindernde Rüstung (leicht), Bindung mit der Natur, Naturgespür",
+            "neue_maechte": 3,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Bindung mit der Natur",
+                "Naturgespür"
+            ],
+            "auto_handicaps": [
+                "Schwur_schwer",
+                "Behindernde Rüstung_leicht"
+            ]
+        },
+        "Tiergestalt": {
+            "name": "Tiergestalt",
+            "kategorie": "Druide",
+            "rang": "F",
+            "voraussetzungen": [
+                "Druide"
+            ],
+            "beschreibung": "Der Druide erhält Gestaltwandeln. Wirkungsdauer ist eine Stunde, und er wirkt den Zauber mit einem Rang höher als normal.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bevorzugte Mächte (Druide)": {
+            "name": "Bevorzugte Mächte (Druide)",
+            "kategorie": "Druide",
+            "rang": "V",
+            "voraussetzungen": [
+                "Druide"
+            ],
+            "beschreibung": "Als begrenzte freie Aktion kann der Druide bis zu zwei Punkte Abzüge ignorieren, wenn er Schutz, Verstricken oder Waffe verbessern wirkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Göttliche Meisterschaft (Druide)": {
+            "name": "Göttliche Meisterschaft (Druide)",
+            "kategorie": "Druide",
+            "rang": "H",
+            "voraussetzungen": [
+                "Druide"
+            ],
+            "beschreibung": "Der Druide kann Epische Machtmodifikatoren verwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kämpfer": {
+            "name": "Kämpfer",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W6",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Kriegerische Anpassungsfähigkeit (kann einmal pro Begegnung ein Kampftalent erhalten)",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Kriegerische Anpassungsfähigkeit"
+            ],
+            "auto_handicaps": []
+        },
+        "Tödlicher Hieb": {
+            "name": "Tödlicher Hieb",
+            "kategorie": "Kämpfer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfer"
+            ],
+            "beschreibung": "Der Kämpfer addiert +1 auf alle Angriffe, die Schaden verursachen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verbesserte kriegerische Anpassungsfähigkeit": {
+            "name": "Verbesserte kriegerische Anpassungsfähigkeit",
+            "kategorie": "Kämpfer",
+            "rang": "V",
+            "voraussetzungen": [
+                "Kämpfer"
+            ],
+            "beschreibung": "Der Kämpfer kann jetzt zwei Kampftalente pro Begegnung wählen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kämpferisches Können": {
+            "name": "Kämpferisches Können",
+            "kategorie": "Kämpfer",
+            "rang": "H",
+            "voraussetzungen": [
+                "Kämpfer"
+            ],
+            "beschreibung": "Der Kämpfer erhält eine freie Wiederholung bei jeder misslungenen Kämpfenprobe.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Kleriker)": {
+            "name": "AH (Kleriker)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "Okkultismus W6"
+            ],
+            "beschreibung": "AH (Kleriker), Energie fokussieren (kann mit Reichweite von Willenskraft heilen)",
+            "neue_maechte": 3,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Gnade",
+                "Energie fokussieren"
+            ],
+            "auto_handicaps": [
+                "Schwur_schwer"
+            ]
+        },
+        "Bevorzugte Mächte (Kleriker)": {
+            "name": "Bevorzugte Mächte (Kleriker)",
+            "kategorie": "Kleriker",
+            "rang": "V",
+            "voraussetzungen": [
+                "Kleriker"
+            ],
+            "beschreibung": "Als begrenzte freie Aktion kann der Kleriker bis zu zwei Punkte Abzüge ignorieren, wenn er Heiligtum, Heilung oder Waffe verbessern wirkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Göttliche Meisterschaft (Kleriker)": {
+            "name": "Göttliche Meisterschaft (Kleriker)",
+            "kategorie": "Kleriker",
+            "rang": "H",
+            "voraussetzungen": [
+                "Kleriker"
+            ],
+            "beschreibung": "Der Kleriker kann Epische Machtmodifikatoren verwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Magier)": {
+            "name": "AH (Magier)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6",
+                "Okkultismus W6"
+            ],
+            "beschreibung": "AH (Magier) Arkane Verbindung (Verbindung mit einem Gegenstand für +1 Zaubern oder ein Vertrauter), Behindernde Rüstung (jede), Schule, Zauberbücher",
+            "neue_maechte": 3,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Zauberbücher",
+                "Arkane Verbindung",
+                "Schule"
+            ],
+            "auto_handicaps": [
+                "Behindernde Rüstung_jede"
+            ]
+        },
+        "Bevorzugte Mächte (Magier)": {
+            "name": "Bevorzugte Mächte (Magier)",
+            "kategorie": "Magier",
+            "rang": "F",
+            "voraussetzungen": [
+                "Magier"
+            ],
+            "beschreibung": "Als begrenzte freie Aktion kann der Magier bis zu zwei Punkte Abzüge ignorieren, wenn er Abwehren, Arkanen Schutz oder Aufheben wirkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Meisterschaft (Magier)": {
+            "name": "Arkane Meisterschaft (Magier)",
+            "kategorie": "Magier",
+            "rang": "V",
+            "voraussetzungen": [
+                "Magier"
+            ],
+            "beschreibung": "Der Magier kann Epische Machtmodifikatoren verwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mönch": {
+            "name": "Mönch",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W6",
+                "WIL W6",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (jede), Betäubende Fäuste, Beweglichkeit, Kämpferische Disziplin, Waffenloser Schlag",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Betäubende Fäuste",
+                "Beweglichkeit",
+                "Kämpferische Disziplin",
+                "Waffenloser Schlag"
+            ],
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_jede"
+            ]
+        },
+        "Mystische Mächte (Mönch)": {
+            "name": "Mystische Mächte (Mönch)",
+            "kategorie": "Mönch",
+            "rang": "F",
+            "voraussetzungen": [
+                "Mönch"
+            ],
+            "beschreibung": "Der Mönch hat 10 gewidmete Machtpunkte, die er verwenden kann, um Abwehren, Beschleunigung, Eigenschaft erhöhen (Geschicklichkeit, Athletik, Kämpfen oder Heimlichkeit) oder Waffe verbessern zu wirken. Alle wirken nur auf den Mönch selbst.",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mächtiges Ki": {
+            "name": "Mächtiges Ki",
+            "kategorie": "Mönch",
+            "rang": "V",
+            "voraussetzungen": [
+                "Mönch",
+                "Mystische Mächte (Mönch)"
+            ],
+            "beschreibung": "Zu den mystischen Mächten des Mönchs gehören jetzt Eigenschaft erhöhen (Stärke), Kriegersegen, Schutz, Wandkrabbler.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unversehrtheit des Körpers": {
+            "name": "Unversehrtheit des Körpers",
+            "kategorie": "Mönch",
+            "rang": "H",
+            "voraussetzungen": [
+                "Mönch",
+                "Mystische Mächte (Mönch)"
+            ],
+            "beschreibung": "Der Mönch kann 2 Machtpunkte ausgeben, um auf Schaden wegstecken zu würfeln. Dies wird nicht behandelt, als hätte er einen Benny ausgegeben",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Paladin": {
+            "name": "Paladin",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "STÄ W6"
+            ],
+            "beschreibung": "Aura der Tapferkeit (+1 auf Furchtproben innerhalb von 10''), Ehrenkodex, Böses entdecken, Böses niederstrecken (freie Wiederholung bei Angriffswürfen gegen einen gewählten bösen Gegner pro Begegnung)",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Aura der Tapferkeit",
+                "Böses Entdecken",
+                "Böses Niederstrecken"
+            ],
+            "auto_handicaps": [
+                "Ehrenkodex"
+            ]
+        },
+        "Mystische Mächte (Paladin)": {
+            "name": "Mystische Mächte (Paladin)",
+            "kategorie": "Paladin",
+            "rang": "F",
+            "voraussetzungen": [
+                "Paladin"
+            ],
+            "beschreibung": "Der Paladin hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Kämpfen, Stärke, Konstitution), Heilung, Linderung, Waffe verbessern nutzen kann. Alle außer Heilung und Linderung wirken nur auf den Paladin selbst.",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gnade (Paladin)": {
+            "name": "Gnade (Paladin)",
+            "kategorie": "Paladin",
+            "rang": "V",
+            "voraussetzungen": [
+                "Paladin"
+            ],
+            "beschreibung": "Der Paladin kann Abgelenkt, Verwundbar, Angeschlagen bei einem Verbündeten in Willenskraft-Reichweite aufheben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Reittier (Paladin)": {
+            "name": "Reittier (Paladin)",
+            "kategorie": "Paladin",
+            "rang": "H",
+            "voraussetzungen": [
+                "Paladin"
+            ],
+            "beschreibung": "Der Held erhält ein loyales leichtes oder schweres Pferd als Wildcard.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schurke": {
+            "name": "Schurke",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W6",
+                "Wahrnehmung W6",
+                "Heimlichkeit W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (leicht), Hinterhältiger Angriff",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Hinterhältiger Angriff"
+            ],
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_leicht"
+            ]
+        },
+        "Reflexbewegung": {
+            "name": "Reflexbewegung",
+            "kategorie": "Schurke",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schurke"
+            ],
+            "beschreibung": "Der Schurke ignoriert den üblichen Abzug von –2 beim Wegspringen und kann versuchen, bei jedem Flächenangriff wegzuspringen, der dies normalerweise nicht erlaubt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Opportunist": {
+            "name": "Opportunist",
+            "kategorie": "Schurke",
+            "rang": "H",
+            "voraussetzungen": [
+                "Schurke"
+            ],
+            "beschreibung": "Der Schurke erhält einen freien Angriff gegen einen Feind, der sich aus dem Nahkampf zurückzieht, auch wenn dieser Rückzug besitzt. Wenn er nicht über Rückzug verfügt, zählt der Gegner als Verwundbar.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Waldläufer": {
+            "name": "Waldläufer",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "Athletik W6, Kämpfen oder Schießen W6",
+                "Überleben W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (mittelschwer), Erzfeind, Bevorzugtes Gelände, Wildnis durchqueren",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Erzfeind",
+                "Bevorzugtes Gelände",
+                "Wildnis durchqueren"
+            ],
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_mittelschwer"
+            ]
+        },
+        "Beute": {
+            "name": "Beute",
+            "kategorie": "Waldläufer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Waldläufer"
+            ],
+            "beschreibung": "Der Waldläufer wählt einen zusätzlichen Gegner- und Geländetyp für Erzfeind und Bevorzugtes Gelände.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystische Mächte (Waldläufer)": {
+            "name": "Mystische Mächte (Waldläufer)",
+            "kategorie": "Waldläufer",
+            "rang": "V",
+            "voraussetzungen": [
+                "Waldläufer"
+            ],
+            "beschreibung": "Der Waldläufer hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Athletik, Kämpfen, Schießen), Kriegersegen, Tierfreund, Verstricken nutzen kann. Alle bis auf Verstricken wirken nur auf den Waldläufer selbst.",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterjäger": {
+            "name": "Meisterjäger",
+            "kategorie": "Waldläufer",
+            "rang": "H",
+            "voraussetzungen": [
+                "Waldläufer"
+            ],
+            "beschreibung": "Der Jäger addiert zusätzliche W6 Schaden, wenn er einen erfolgreichen Angriff mit Athletik (Werfen), Kämpfen oder Schießen gegen einen Erzfeind ausführt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Zauberer)": {
+            "name": "AH (Zauberer)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6",
+                "WIL W6"
+            ],
+            "beschreibung": "AH (Zauberer), Behindernde Rüstung (jede), Blutlinie",
+            "neue_maechte": 2,
+            "machtpunkte": 15,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Blutlinie"
+            ],
+            "auto_handicaps": [
+                "Behindernde Rüstung_jede"
+            ]
+        },
+        "AH (Hexenmeister)": {
+            "name": "AH (Hexenmeister)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6",
+                "Okkultismus W4"
+            ],
+            "beschreibung": "AH (Hexenmeister), Behindernde Rüstung (jede), Vertrauter, Hexerei (1 freie Hexerei aus der Liste). Arkane Fertigkeit: Zaubern. Startet mit 2 Mächten aus der Hexenmeister-Liste. Der Vertraute speichert die Zauber des Patrons; tägliche Kommunikation mit dem Vertrauten erforderlich.",
+            "neue_maechte": 2,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "Vertrauter"
+            ],
+            "auto_handicaps": [
+                "Behindernde Rüstung_jede"
+            ]
+        },
+        "Weitere Hexerei": {
+            "name": "Weitere Hexerei",
+            "kategorie": "Hexenmeister",
+            "rang": "F",
+            "voraussetzungen": [
+                "Hexenmeister"
+            ],
+            "beschreibung": "Der:ie Hexenmeister:in kann eine neue Hexerei auswählen. Kann einmal pro Rang genommen werden. Hexereien (Auswahl): Agonie, Verstärkung, Verfluchen, Kichern, Verzaubern, Böser Blick, Heilung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Starke Hexerei": {
+            "name": "Starke Hexerei",
+            "kategorie": "Hexenmeister",
+            "rang": "V",
+            "voraussetzungen": [
+                "Hexenmeister"
+            ],
+            "beschreibung": "Der:ie Hexenmeister:in kann eine Starke Hexerei auswählen. Kann einmal pro Rang genommen werden. Starke Hexereien (Auswahl): Vettelnauge, Albträume, Vision, Wachsabbild, Wetterkontrolle.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Meisterschaft (Hexenmeister)": {
+            "name": "Arkane Meisterschaft (Hexenmeister)",
+            "kategorie": "Hexenmeister",
+            "rang": "H",
+            "voraussetzungen": [
+                "Hexenmeister"
+            ],
+            "beschreibung": "Durch ihren finsteren Patron erschließt die Hexe die Geheimnisse ihrer mystischen Kräfte. Erhält Zugriff auf alle Epischen Machtmodifikatoren ihrer Mächte.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mächtige Hexerei": {
+            "name": "Mächtige Hexerei",
+            "kategorie": "Hexenmeister",
+            "rang": "L",
+            "voraussetzungen": [
+                "Hexenmeister",
+                "Mindestens zwei Hexenmeister-Vorteile"
+            ],
+            "beschreibung": "Wild Card. Der:ie Hexenmeister:in kann eine Mächtige Hexerei auswählen. Kann einmal pro Rang genommen werden. Mächtige Hexereien (Auswahl): Todesfluch, Ewiger Schlaf, Erzwungene Wiedergeburt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Alchemist": {
+            "name": "Alchemist",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Alchemische Identifikation (+2 auf Proben zur Identifikation alchemischer Gegenstände), AH (Alchemist) [Arkane Fertigkeit: Alchemie], Behindernde Rüstung (leicht), Bomben (Aktion: wirf eine Bombe, 1W6 Schaden in Bereich), Extrakte (Tränke für Kraftvolle Heilung oder Eigenschaftsverbesserung), Mutagene (Konstitution für Stärke, Intelligenz für Ausdauer oder Geschicklichkeit für Abwehr tauschen).",
+            "neue_maechte": 3,
+            "machtpunkte": 15,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_talente": [
+                "AH (Alchemist)"
+            ],
+            "auto_handicaps": [
+                "Behindernde Rüstung_leicht"
+            ]
+        },
+        "Entdeckung": {
+            "name": "Entdeckung",
+            "kategorie": "Alchemist",
+            "rang": "F",
+            "voraussetzungen": [
+                "Alchemist"
+            ],
+            "beschreibung": "Der Alchemist wählt eine Entdeckung aus (z.B. verbesserte Bombe, verbessertes Mutagen, neue Extrakt-Formeln, Giftkunst, Schnellbomben). Kann einmal pro Rang genommen werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Fortgeschrittene Entdeckung": {
+            "name": "Fortgeschrittene Entdeckung",
+            "kategorie": "Alchemist",
+            "rang": "V",
+            "voraussetzungen": [
+                "Alchemist"
+            ],
+            "beschreibung": "Der Alchemist wählt eine Fortgeschrittene Entdeckung aus (mächtigere Varianten: Bombenregeneration, Großes Mutagen, Flüssiges Feuer, Verdauungssäure).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Große Entdeckung": {
+            "name": "Große Entdeckung",
+            "kategorie": "Alchemist",
+            "rang": "H",
+            "voraussetzungen": [
+                "Alchemist"
+            ],
+            "beschreibung": "Der Alchemist wählt eine Große Entdeckung aus (Höhepunkt der Alchemie: Wahres Elixier der Langlebigkeit, Stein der Weisen, Wahre Verwandlung, Unsterblichkeitselixier).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kavalier": {
+            "name": "Kavalier",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W6",
+                "Kämpfen W6",
+                "Reiten W6"
+            ],
+            "beschreibung": "Herausforderung (einmal pro Begegnung: wähle einen Gegner – beide erhalten Wundabzüge des anderen nicht; der Kavalier erhält +2 Schaden gegen das Ziel), Mächtiger Ansturm (bei Ansturm mit Lanze +4 Schaden statt +2), Orden (tritt einem Ritterorden bei und erhält dessen Kenntnisse), Kavalier-Reittier (verbesserte Variante des Tiermeister-Begleiters).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Panier": {
+            "name": "Panier",
+            "kategorie": "Kavalier",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kavalier"
+            ],
+            "beschreibung": "Verbündete innerhalb von 12'' erhalten +1 auf Furcht-Proben. Bei einem Ansturm erhalten sie zusätzlich +2 auf Angriffswürfe, solange das Panier sichtbar ist.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ordensfähigkeit": {
+            "name": "Ordensfähigkeit",
+            "kategorie": "Kavalier",
+            "rang": "V",
+            "voraussetzungen": [
+                "Kavalier"
+            ],
+            "beschreibung": "Der Kavalier erhält eine besondere Fähigkeit seines Ordens (z.B. Orden des Stabs: +2 auf Wissenswürfe; Orden des Schwertes: +1 auf Kämpfen; Orden des Sterns: einmal täglich Gnadenbitte für sich selbst).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Fordernde Herausforderung": {
+            "name": "Fordernde Herausforderung",
+            "kategorie": "Kavalier",
+            "rang": "H",
+            "voraussetzungen": [
+                "Kavalier"
+            ],
+            "beschreibung": "Gegner, die durch die Herausforderung des Kavaliers gebunden sind, können keine Bennies ausgeben, um gegen den Kavalier gerichtete Würfe zu wiederholen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Überlegener Ansturm": {
+            "name": "Überlegener Ansturm",
+            "kategorie": "Kavalier",
+            "rang": "WC",
+            "voraussetzungen": [
+                "L",
+                "Kavalier",
+                "Mindestens zwei Kavalier-Talente"
+            ],
+            "beschreibung": "Wild Card. Der Kavalier verdoppelt den Schaden bei einem Ansturm mit einer Lanze (anstatt des normalen +4-Bonus). Erfordert Legendär-Rang und mindestens zwei weitere Kavalier-Talente.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Inquisitor": {
+            "name": "Inquisitor",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "Athletik W6 oder Kämpfen W6 oder Schießen W6",
+                "Okkultismus W4"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (mittelschwer), Urteil (einmal pro Begegnung: +1 auf Angriffs- oder Schadenswürfe, oder +2 auf Eigenschaftswürfe – Wahl bei Einsatz), Monsterkunde (+2 auf Allgemeinwissen-Proben über Monster, Dämonen und Untote).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_mittelschwer"
+            ]
+        },
+        "Bann": {
+            "name": "Bann",
+            "kategorie": "Inquisitor",
+            "rang": "F",
+            "voraussetzungen": [
+                "Inquisitor"
+            ],
+            "beschreibung": "Der Inquisitor verzaubert seine Waffe mit Bann: Angriffe ignorieren den Übernatürlichen Schutz des Ziels und verursachen +2 Schaden gegen die gewählte Kreaturenart (festgelegt bei Aktivierung der Macht).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Brandmal": {
+            "name": "Brandmal",
+            "kategorie": "Inquisitor",
+            "rang": "F",
+            "voraussetzungen": [
+                "Inquisitor"
+            ],
+            "beschreibung": "Der Inquisitor brandmarkt einen Feind (Aktion, Berührungsangriff): Das Ziel gilt als Abgelenkt (-2 auf alle Proben) bis es eine Willenskraft-Probe schafft (einmal pro Runde am Ende des Zuges).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystische Mächte (Inquisitor)": {
+            "name": "Mystische Mächte (Inquisitor)",
+            "kategorie": "Inquisitor",
+            "rang": "V",
+            "voraussetzungen": [
+                "Inquisitor"
+            ],
+            "beschreibung": "Der Inquisitor erhält 10 gewidmete Machtpunkte für folgende Mächte: Eigenschaft erhöhen (Einschüchtern, Wahrnehmung oder Überleben), Dunkelsicht, Magie entdecken/verbergen und Aufheben. Alle Mächte wirken nur auf den Inquisitor selbst.",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schwäche ausnutzen": {
+            "name": "Schwäche ausnutzen",
+            "kategorie": "Inquisitor",
+            "rang": "H",
+            "voraussetzungen": [
+                "Inquisitor"
+            ],
+            "beschreibung": "Der Inquisitor kann die Umgebungsschwächen von Kreaturen gezielt auslösen (z.B. Feuer bei Untoten, Silber bei Werwölfen): Der Inquisitor verursacht mit einem Angriff automatisch die Schwachstellen-Effekte der Kreatur.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wahres Urteil": {
+            "name": "Wahres Urteil",
+            "kategorie": "Inquisitor",
+            "rang": "WC",
+            "voraussetzungen": [
+                "L",
+                "Inquisitor",
+                "Mindestens zwei Inquisitor-Talente"
+            ],
+            "beschreibung": "Wild Card. Der Inquisitor trifft sein Urteilsziel mit vernichtendem Schaden (automatischer Erfolg und eine Erhöhung auf den Angriff) und kann sofort einen neuen Feind als Urteilsziel wählen. Erfordert Legendär-Rang und mindestens zwei weitere Inquisitor-Talente.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Orakel)": {
+            "name": "AH (Orakel)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6"
+            ],
+            "beschreibung": "AH (Orakel) [Arkane Fertigkeit: Glaube], Behindernde Rüstung (mittelschwer), Fluch (unvermeidliche Beeinträchtigung, die mit den Stufen stärker wird, z.B. Blindheit, Taubheit, Schwäche), Mysterium (wählt eine göttliche Verbindung, z.B. Tod, Flammen, Natur, Wasser).",
+            "neue_maechte": 3,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Behindernde Rüstung_mittelschwer"
+            ]
+        },
+        "Offenbarung": {
+            "name": "Offenbarung",
+            "kategorie": "Orakel",
+            "rang": "F",
+            "voraussetzungen": [
+                "Orakel"
+            ],
+            "beschreibung": "Das Orakel kann eine Macht aus seinem Mysterium als begrenzte freie Aktion wirken (einmal pro Zug, ohne Machtpunkte-Abzug für die begrenzte freie Aktion). Kann mehrfach genommen werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Göttliche Meisterschaft": {
+            "name": "Göttliche Meisterschaft",
+            "kategorie": "Orakel",
+            "rang": "V",
+            "voraussetzungen": [
+                "Orakel"
+            ],
+            "beschreibung": "Das Orakel darf jetzt Epische Macht-Modifikatoren auf seine göttlichen Mächte anwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Große Offenbarung": {
+            "name": "Große Offenbarung",
+            "kategorie": "Orakel",
+            "rang": "H",
+            "voraussetzungen": [
+                "Orakel"
+            ],
+            "beschreibung": "Das Orakel schaltet seine finale Offenbarung frei – die mächtigste Fähigkeit seines Mysteriums (z.B. ewiges Feuer, Totenbeschwörung, Windkörper).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Beschwörer)": {
+            "name": "AH (Beschwörer)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+            "neue_maechte": 5,
+            "machtpunkte": 15,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zusätzliche Evolution": {
+            "name": "Zusätzliche Evolution",
+            "kategorie": "Beschwörer",
+            "rang": "A",
+            "voraussetzungen": [
+                "Beschwörer"
+            ],
+            "beschreibung": "Das Eidolon des Beschwörers erhält 3 zusätzliche Evolutionspunkte für Verbesserungen (z.B. zusätzliche Gliedmaßen, natürlicher Rüstungsschutz, Flug). Kann einmal genommen werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ruf des Schöpfers": {
+            "name": "Ruf des Schöpfers",
+            "kategorie": "Beschwörer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Beschwörer"
+            ],
+            "beschreibung": "Der Beschwörer kann sein Eidolon per Aktion sofort zu sich teleportieren oder mit ihm den Platz tauschen (einmal pro Begegnung, keine Sichtlinie erforderlich).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ruf des Beschwörers": {
+            "name": "Ruf des Beschwörers",
+            "kategorie": "Beschwörer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Beschwörer"
+            ],
+            "beschreibung": "Das Eidolon erhält +1 Würfeltyp auf Geschicklichkeit, Stärke und Konstitution (permanent).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Lebensband": {
+            "name": "Lebensband",
+            "kategorie": "Beschwörer",
+            "rang": "V",
+            "voraussetzungen": [
+                "Beschwörer"
+            ],
+            "beschreibung": "Solange das Eidolon in der Nähe ist (12''), kann der Beschwörer empfangenen Schaden (Wunden) auf das Eidolon übertragen. Das Eidolon kann nicht unter diesen Schaden fallen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Aspekt": {
+            "name": "Aspekt",
+            "kategorie": "Beschwörer",
+            "rang": "H",
+            "voraussetzungen": [
+                "Beschwörer"
+            ],
+            "beschreibung": "Der Beschwörer kann Evolutionspunkte des Eidolons nutzen, um sich selbst zu transformieren und körperliche Eigenschaften des Eidolons zu übernehmen (z.B. Klauen, Panzerung, Flug).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zwillingseidolon": {
+            "name": "Zwillingseidolon",
+            "kategorie": "Beschwörer",
+            "rang": "WC",
+            "voraussetzungen": [
+                "L",
+                "Beschwörer",
+                "Mindestens zwei Beschwörer-Talente"
+            ],
+            "beschreibung": "Wild Card. Der Beschwörer kann sich vollständig in sein Eidolon verwandeln – alle Eigenschaftspunkte und Fähigkeiten des Eidolons werden für den Beschwörer übernommen. Erfordert Legendär-Rang und mindestens zwei weitere Beschwörer-Talente.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Hexe)": {
+            "name": "AH (Hexe)",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6",
+                "Okkultismus W4"
+            ],
+            "beschreibung": "AH (Hexe) [Arkane Fertigkeit: Zaubern], Behindernde Rüstung (jede), Vertrauter (magisch verbundenes Tier, das Patron-Zauber speichert; tägliche Kommunikation erforderlich), Hex (wählt einen Hex aus der Hexen-Liste, z.B. Böser Blick, Schlaf, Heilung, Verfluchung).",
+            "neue_maechte": 3,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Behindernde Rüstung_jede"
+            ]
+        },
+        "Zusätzlicher Hex": {
+            "name": "Zusätzlicher Hex",
+            "kategorie": "Hexe",
+            "rang": "F",
+            "voraussetzungen": [
+                "Hexe"
+            ],
+            "beschreibung": "Die Hexe schaltet einen zusätzlichen Hex frei. Kann einmal pro Rang genommen werden. Hexen (Auswahl): Agonie, Verhexung, Schlaf, Kichern, Heilung, Böser Blick, Verfluchung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Großer Hex": {
+            "name": "Großer Hex",
+            "kategorie": "Hexe",
+            "rang": "V",
+            "voraussetzungen": [
+                "Hexe"
+            ],
+            "beschreibung": "Die Hexe erhält Zugang zu einem Großen Hex (mächtigere Variante der normalen Hexen-Fähigkeiten). Auswahl: Vettelnauge, Albträume, Langlebigkeit, Wachsabbild, Wetterkontrolle.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Meisterschaft (Hexe)": {
+            "name": "Arkane Meisterschaft (Hexe)",
+            "kategorie": "Hexe",
+            "rang": "H",
+            "voraussetzungen": [
+                "Hexe"
+            ],
+            "beschreibung": "Die Hexe darf jetzt Epische Macht-Modifikatoren auf ihre Zaubern-Mächte anwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Grandioser Hex": {
+            "name": "Grandioser Hex",
+            "kategorie": "Hexe",
+            "rang": "WC",
+            "voraussetzungen": [
+                "L",
+                "Hexe",
+                "Mindestens zwei Hexen-Talente"
+            ],
+            "beschreibung": "Wild Card. Die Hexe schaltet einen Grandiosen Hex frei – die mächtigste Form ihrer Hexerei (z.B. ewiger Schlaf, Todesfluch, Seelenstehlen). Erfordert Legendär-Rang und mindestens zwei weitere Hexen-Talente.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Aura der Gerechtigkeit": {
+            "name": "Aura der Gerechtigkeit",
+            "kategorie": "Paladin",
+            "rang": "F",
+            "voraussetzungen": [
+                "Paladin"
+            ],
+            "beschreibung": "Der Paladin teilt seine Fähigkeit Böses Niederstrecken mit Verbündeten in Sichtweite (12''). Betroffene Verbündete erhalten dieselben Angriffsboni wie der Paladin gegen das gewählte Ziel für eine Runde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Versteinerungsschlag": {
+            "name": "Versteinerungsschlag",
+            "kategorie": "Mönch",
+            "rang": "F",
+            "voraussetzungen": [
+                "WIL W8",
+                "Mönch",
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Ki-Aktion (1 Machtpunkt): Bei einem Treffer mit einer Erhöhung muss das Ziel eine Konstitutionsprobe ablegen oder gilt als Erschöpft und beginnt zu versteinen. Misslingt die Probe mit einer Erhöhung, ist das Ziel sofort Kampfunfähig (Versteinerung).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kreuzblütig": {
+            "name": "Kreuzblütig",
+            "kategorie": "Zauberer",
+            "rang": "H",
+            "voraussetzungen": [
+                "AH (Zauberer)"
+            ],
+            "beschreibung": "Der Zauberer erhält Zugang zu einer zweiten Blutlinie und kann deren Blutlinienfähigkeiten nutzen. Er erleidet jedoch –1 auf alle Zaubern-Proben (Konzentrationsschwierigkeiten durch zwei konkurrierende Blutlinien).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Störende Wut": {
+            "name": "Störende Wut",
+            "kategorie": "Barbar",
+            "rang": "V",
+            "voraussetzungen": [
+                "WIL W8",
+                "Barbar",
+                "Okkultismus W6"
+            ],
+            "beschreibung": "Befindet sich der Barbar im Kampfrausch und wirkt ein Ziel in Nahkampfreichweite (2'') eine Macht, kann der Barbar als freie Aktion sofort einen einzelnen Nahkampfangriff gegen dieses Ziel ausführen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zusätzliche Domäne": {
+            "name": "Zusätzliche Domäne",
+            "kategorie": "Kleriker",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Kleriker)"
+            ],
+            "beschreibung": "Der Kleriker wählt eine zusätzliche Götterdomäne und erhält die damit verbundene Domänenmacht als neue arkane Macht (+1 neue Macht, +5 Machtpunkte).",
+            "neue_maechte": 1,
+            "machtpunkte": 5,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bevorzugte Mächte": {
+            "name": "Bevorzugte Mächte",
+            "kategorie": "Hintergrund",
+            "rang": "F",
+            "voraussetzungen": [
+                {
+                    "oder": [
+                        "AH (Zauberer)",
+                        "AH (Magier)"
+                    ]
+                }
+            ],
+            "beschreibung": "Einmal pro Zug kann der Charakter bei einer Probe für eine Macht seiner Schule oder Blutlinie bis zu 2 Punkte Abzüge ignorieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Jägerverbund": {
+            "name": "Jägerverbund",
+            "kategorie": "Waldläufer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Waldläufer"
+            ],
+            "beschreibung": "Der Waldläufer teilt per freier Aktion seinen Erzfeind-Bonus einmal pro Runde mit allen Verbündeten in Sichtweite (12'') für eine Runde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Inspiration der Größe": {
+            "name": "Inspiration der Größe",
+            "kategorie": "Barde",
+            "rang": "V",
+            "voraussetzungen": [
+                "Heldentum inspirieren"
+            ],
+            "beschreibung": "Der Barde kann jetzt 7 Inspirations-Marker pro Einsatz generieren (statt 5). Zudem erhalten alle Verbündeten mit aktiven Inspirations-Markern +1 auf ihre Robustheit.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystische Mächte (Schurke)": {
+            "name": "Mystische Mächte (Schurke)",
+            "kategorie": "Schurke",
+            "rang": "F",
+            "voraussetzungen": [
+                "Schurke"
+            ],
+            "beschreibung": "Der Schurke erhält 10 gewidmete Machtpunkte für folgende Mächte: Eigenschaft erhöhen (Athletik, Heimlichkeit oder Diebeskunst), Dunkelsicht, Lärm/Stille und Wandläufer. Alle Mächte wirken nur auf den Schurken selbst.",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bebende Handfläche": {
+            "name": "Bebende Handfläche",
+            "kategorie": "Mönch",
+            "rang": "H",
+            "voraussetzungen": [
+                "Mönch",
+                "Kämpfen W10"
+            ],
+            "beschreibung": "Ki-Aktion (2 Machtpunkte): Bei einem Treffer pflanzt der Mönch vibrierende Energie ins Ziel. Zu einem beliebigen späteren Zeitpunkt (innerhalb derselben Szene) kann der Mönch die Energie auslösen: Das Ziel legt sofort eine Konstitutionsprobe mit –2 ab oder gilt als Kampfunfähig.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zeitloser Körper": {
+            "name": "Zeitloser Körper",
+            "kategorie": "Druide",
+            "rang": "F",
+            "voraussetzungen": [
+                "KON W8",
+                "AH (Druide)"
+            ],
+            "beschreibung": "Der Druide altert nicht mehr (Alterungseffekte gelten nicht). Zudem wird er immun gegen Gift und Krankheiten jeder Art.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Waffenspezialisierung": {
+            "name": "Waffenspezialisierung",
+            "kategorie": "Kämpfer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfer"
+            ],
+            "beschreibung": "Der Kämpfer wählt eine bevorzugte Waffe. Misslingt ein Angriff mit dieser Waffe und trifft das Ziel nicht mindestens Erschüttert, kann der Kämpfer den Schadenswurf einmal kostenlos wiederholen. Kann mehrfach für verschiedene Waffenarten genommen werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bevorzugte Mächte (Zauberer)": {
+            "name": "Bevorzugte Mächte (Zauberer)",
+            "kategorie": "Zauberer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Zauberer"
+            ],
+            "beschreibung": "Als begrenzte freie Aktion kann der Zauberer bis zu zwei Punkte von Abzügen ignorieren, wenn er Geschoss, Elementarmanipulation oder Schutz wirkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Meisterschaft (Zauberer)": {
+            "name": "Arkane Meisterschaft (Zauberer)",
+            "kategorie": "Zauberer",
+            "rang": "V",
+            "voraussetzungen": [
+                "Zauberer"
+            ],
+            "beschreibung": "Der Zauberer kann Epische Machtmodifikatoren verwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mächtige Blutlinie": {
+            "name": "Mächtige Blutlinie",
+            "kategorie": "Zauberer",
+            "rang": "H",
+            "voraussetzungen": [
+                "Zauberer"
+            ],
+            "beschreibung": "Der Zauberer erhält die mächtige Fähigkeit seiner Blutlinie.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Formationskämpfer": {
+            "name": "Formationskämpfer",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Erhöht Überzahlbonus um zusätzlich +1 (Maximum +4).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kampf mit zwei Waffen": {
+            "name": "Kampf mit zwei Waffen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Mach einen zusätzlichen Kämpfen- oder Athletik-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelles Nachladen": {
+            "name": "Schnelles Nachladen",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Schießen W6"
+            ],
+            "beschreibung": "Verringere den Nachlade-Wert der Waffe um 1.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelles Schießen": {
+            "name": "Schnelles Schießen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Schießen W6"
+            ],
+            "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verbessertes Schießen": {
+            "name": "Verbessertes Schießen",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schnelles Schießen"
+            ],
+            "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Rüstung": {
+            "name": "Arkane Rüstung",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Die Behindernde Rüstung des Charakters wird um eine Stufe verbessert (beispielsweise von mittelschwer auf leicht)",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkaner Bogenschütze": {
+            "name": "Arkaner Bogenschütze",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH oder MM",
+                "Schießen W8"
+            ],
+            "beschreibung": "Pfeile verstärken für +1 Schießen und Schaden, oder Pfeile erhalten eine Ausprägung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkaner Bogenschütze II": {
+            "name": "Arkaner Bogenschütze II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Arkaner Bogenschütze"
+            ],
+            "beschreibung": "Phasenpfeile durchdringen Barrieren, oder Pfeilhagel gilt in großer Flächenschablone.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkaner Bogenschütze III": {
+            "name": "Arkaner Bogenschütze III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Arkaner Bogenschütze II"
+            ],
+            "beschreibung": "Ermächtigter Pfeil mit Flächeneffekt-Macht einmal pro Zug, oder Todespfeil einmal pro Tag (Opfer das durch Pfeil Angeschlagen wird oder eine Wunde erleidet, muss Konstitutionsprobe schaffen, oder es stirbt)",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkaner Betrüger": {
+            "name": "Arkaner Betrüger",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH",
+                "Diebeskunst W8"
+            ],
+            "beschreibung": "Weitreichende Fingerfertigkeit: kann Diebeskunst mit –2 auf Entfernung von 5'' verwenden; Spontaner Angriff: Einmal pro Begegnung kann der Schwindler Hinterhältiger Angriff ohne Überraschungsangriff oder Verwundbar verwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkaner Betrüger II": {
+            "name": "Arkaner Betrüger II",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Arkaner Betrüger"
+            ],
+            "beschreibung": "Unsichtbarer Dieb: einmal pro Tag automatisch Unsichtbarkeit für 1 Machtpunkt mit automatischer Steigerung (kein Wurf)",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkaner Betrüger III": {
+            "name": "Arkaner Betrüger III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Arkaner Betrüger II"
+            ],
+            "beschreibung": "Überraschungszauber: Die Zauber des Helden profitieren von Hinterhältiger Angriff.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Assassine": {
+            "name": "Assassine",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [],
+            "beschreibung": "Todesangriff: Wenn Assassine mit Überraschungsangriff angreift und mindestens eine Wunde erzielt, muss Opfer Konstitutionsprobe schaffen oder sterben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Assassine II": {
+            "name": "Assassine II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Assassine"
+            ],
+            "beschreibung": "Meisterliches Verstecken: –4 um Assassinen zu sehen, wenn er sich nicht bewegt. Widerstand gegen Gift: +4 Widerstand gegen Gift",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Assassine III": {
+            "name": "Assassine III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Assassine II"
+            ],
+            "beschreibung": "Todesengel: Der Assassine lässt ein getötetes Opfer zu Staub zerfallen und verhindert eine Wiederauferstehung. Schneller Tod: Einmal pro Tag erhält der Assassine einen Überraschungsangriff gegen ein Opfer seiner Wahl.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Drachenjünger": {
+            "name": "Drachenjünger",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH oder MM",
+                "Okkultismus W6"
+            ],
+            "beschreibung": "Odemangriff: 3W6 Schaden plus Ausprägung, Kegelschablone, einmal pro Begegnung",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Drachenjünger II": {
+            "name": "Drachenjünger II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Drachenjünger"
+            ],
+            "beschreibung": "Schwingen: Charakter erhält Flügel für Flug, Bewegungsweite 8.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Drachenjünger III": {
+            "name": "Drachenjünger III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Drachenjünger II"
+            ],
+            "beschreibung": "Drachengestalt: Zweimal pro Tag kann der Drachenjünger als beschränkte Aktion die Gestalt eines Drachens seiner Blutlinie annehmen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Duellant": {
+            "name": "Duellant",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Geschicklichkeit W8",
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Chirurgischer Schlag: +2 Schaden mit bestimmten Waffen. Parieren: Duellant kann sich Verteidigen, wenn er noch nicht gehandelt hat, mit Paradebonus +6.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Duellant II": {
+            "name": "Duellant II",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Duellant"
+            ],
+            "beschreibung": "Schwächender Schlag: Verringere Bewegungsweite des Gegners um 2 bis geheilt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Duellant III": {
+            "name": "Duellant III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Duellant II"
+            ],
+            "beschreibung": "Geschosse abwehren: –2, um mit physischen Fernkampfangriffen getroffen zu werden",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kundschafter-Chronist": {
+            "name": "Kundschafter-Chronist",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Überleben W6",
+                "Allgemeinwissen oder Okkultismus W8"
+            ],
+            "beschreibung": "Finden des Weges: Erhöht Reisegeschwindigkeit um 10 %, kann feindliche Begegnung umgehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kundschafter-Chronist II": {
+            "name": "Kundschafter-Chronist II",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kundschafter-Chronist"
+            ],
+            "beschreibung": "Epische Geschichten: Erzähle bei der Rast eine Geschichte, um Gruppe einen Benny zu gewähren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kundschafter-Chronist III": {
+            "name": "Kundschafter-Chronist III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Kundschafter-Chronist II"
+            ],
+            "beschreibung": "Rufen der Legenden: Beschwöre 5 Schatten für eine Stunde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Ritter": {
+            "name": "Mystischer Ritter",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH",
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Mystische Aufladung: Erhalte Machtpunkt bei Steigerung mit Angriff oder arkaner Fertigkeit.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Ritter II": {
+            "name": "Mystischer Ritter II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Mystischer Ritter"
+            ],
+            "beschreibung": "Mystischer Schlag: Gib 2 Machtpunkte nach Angriff aus, und addiere +2 auf Angriff.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Ritter III": {
+            "name": "Mystischer Ritter III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Mystischer Ritter II"
+            ],
+            "beschreibung": "Verb. Mystischer Schlag: Gib zwei Machtpunkte aus, nachdem du einen erfolgreichen Angriffswurf abgelegt hat, um den Schaden des Angriffs um +2 zu erhöhen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Theurg": {
+            "name": "Mystischer Theurg",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Magiefusion: Wirke zwei Zauber auf einmal und würfle eine arkane Fertigkeit für jede sowie den Wildcard-Würfel.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Theurg II": {
+            "name": "Mystischer Theurg II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Mystischer Theurg"
+            ],
+            "beschreibung": "Zaubersynergie: Verringere die Kosten beider Zauber wenn du Magiefusion verwendest.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Theurg III": {
+            "name": "Mystischer Theurg III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Mystischer Theurg II"
+            ],
+            "beschreibung": "Zaubersynthese: Klassentalente sind für alle Mächte verfügbar.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schattentänzer": {
+            "name": "Schattentänzer",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Darbietung W6",
+                "Heimlichkeit W8",
+                "Diebeskunst W6"
+            ],
+            "beschreibung": "Mächtige Dunkelsicht: Sehen in absoluter oder magischer Dunkelheit",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schattentänzer II": {
+            "name": "Schattentänzer II",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Schattentänzer"
+            ],
+            "beschreibung": "Schattenmantel: freies Schaden wegstecken mit –2 in Düsterer oder Dunkler Beleuchtung",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schattentänzer III": {
+            "name": "Schattentänzer III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schattentänzer II"
+            ],
+            "beschreibung": "Mystische Mächte (Schattenkraft): 10 gewidmete Machtpunkte zum Wirken von Flächenschlag, Illusion, Teleportation oder Verbündeten beschwören (nur Schatten) (nur selbst)",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wissenshüter": {
+            "name": "Wissenshüter",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Ver W8"
+            ],
+            "beschreibung": "Legendenkunde: freie Wiederholung bei Allgemeinwissen, Geisteswissenschaften, Okkultismus oder Naturwissenschaften",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wissenshüter II": {
+            "name": "Wissenshüter II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Wissenshüter"
+            ],
+            "beschreibung": "Geheimnis: Erhalte eine Fähigkeit eines Kern-Klassentalents.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wissenshüter III": {
+            "name": "Wissenshüter III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Wissenshüter II"
+            ],
+            "beschreibung": "Höhere Legendenkunde: Erhalte 2 neue Mächte, die in der Kampagne verfügbar sind.",
+            "neue_maechte": 2,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Chi": {
+            "name": "Chi",
+            "kategorie": "Übersinnlich",
+            "rang": "V",
+            "voraussetzungen": [
+                "Kampfkunstmeister"
+            ],
+            "beschreibung": "Einmal pro Kampf kannst du eine misslungene Kämpfenprobe wiederholen, einen Gegner einen erfolgreichen Angriff wiederholen lassen oder +W6 Schaden auf einen waffenlosen Angriff addieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mut in Flaschen": {
+            "name": "Mut in Flaschen",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "KON W8"
+            ],
+            "beschreibung": "Alkohol erhöht Konstitution um einen Würfeltyp und du ignorierst eine Stufe Wundabzüge; –1 Geschicklichkeit, Verstand und verknüpfte Fertigkeiten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Eiserner Wille": {
+            "name": "Eiserner Wille",
+            "kategorie": "Sozial",
+            "rang": "F",
+            "voraussetzungen": [
+                "Mutig",
+                "Starker Wille"
+            ],
+            "beschreibung": "Der Bonus gilt jetzt zum Widerstehen und Erholen von Mächten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnell": {
+            "name": "Schnell",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Held kann Aktionskarten von 5 oder weniger abwerfen und neu ziehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Riesentöter": {
+            "name": "Riesentöter",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "+1W6 Schaden gegen Kreaturen, deren Größe die eigene um 3 oder mehr übersteigt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ermittler": {
+            "name": "Ermittler",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W8",
+                "Geisteswissenschaften W8"
+            ],
+            "beschreibung": "+2 Geisteswissenschaften und auf bestimmte Wahrnehmungsproben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gelehrter": {
+            "name": "Gelehrter",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W8"
+            ],
+            "beschreibung": "+2 auf eine Wissensfertigkeit",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Reparaturgenie": {
+            "name": "Reparaturgenie",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Reparieren W8"
+            ],
+            "beschreibung": "+2 auf Reparieren, halbe Zeit bei Steigerung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Alchemist)": {
+            "name": "AH (Alchemist)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Arkane Fertigkeit: Alchemie (Verstand)",
+            "neue_maechte": 3,
+            "machtpunkte": 15,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Chemiker": {
+            "name": "Chemiker",
+            "kategorie": "Alchemist",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Alchemist)",
+                "Alchemie W8"
+            ],
+            "beschreibung": "Die Gebräue des Alchemisten halten eine Woche statt 48 Stunden, wenn sie an andere weitergegeben werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterlicher Alchemist": {
+            "name": "Meisterlicher Alchemist",
+            "kategorie": "Alchemist",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Alchemist)",
+                "Alchemie W10"
+            ],
+            "beschreibung": "Erlaubt die Herstellung permanenter Tränke zu halb so hohen Kosten mit improvisierten Vorräten oder einer Alchemistentasche.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Grabgesang": {
+            "name": "Grabgesang",
+            "kategorie": "Barde",
+            "rang": "H",
+            "voraussetzungen": [
+                "AH (Barde)"
+            ],
+            "beschreibung": "Löst Furcht aus und reduziert Proben von Feinden um -2, wenn sie Bennys verwenden. Der Barde muss singen oder ein Instrument spielen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heldentum inspirieren": {
+            "name": "Heldentum inspirieren",
+            "kategorie": "Barde",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Barde)",
+                "Darbietung W8"
+            ],
+            "beschreibung": "Erlaubt es, fünf Inspirations-Marker zu generieren, die Kameraden Boni auf Proben oder Schadenswürfe geben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Instrument": {
+            "name": "Instrument",
+            "kategorie": "Barde",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Barde)"
+            ],
+            "beschreibung": "Bietet +1 auf Darbietungsproben, wenn ein Instrument beim Zaubern verwendet wird.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Diabolist)": {
+            "name": "AH (Diabolist)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+            "neue_maechte": 5,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Elementarist)": {
+            "name": "AH (Elementarist)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+            "neue_maechte": 5,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Illusionist)": {
+            "name": "AH (Illusionist)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+            "neue_maechte": 5,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Nekromant)": {
+            "name": "AH (Nekromant)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
+            "neue_maechte": 5,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Schamane)": {
+            "name": "AH (Schamane)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6"
+            ],
+            "beschreibung": "Arkane Fertigkeit: Glaube (Willenskraft)",
+            "neue_maechte": 5,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "AH (Tüftler)": {
+            "name": "AH (Tüftler)",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Arkane Fertigkeit: Reparieren (Verstand)",
+            "neue_maechte": 2,
+            "machtpunkte": 15,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Stärkung": {
+            "name": "Arkane Stärkung",
+            "kategorie": "Beschwörer",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Beschwörer)"
+            ],
+            "beschreibung": "Beschworene Tiere erhalten einen magischen Harnisch, der ihre Robustheit um +2 erhöht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ungezügelte Beschwörung": {
+            "name": "Ungezügelte Beschwörung",
+            "kategorie": "Beschwörer",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Beschwörer)"
+            ],
+            "beschreibung": "Erlaubt dem Beschwörer, beschworenen Monstern ein Kampftalent seines Rangs oder niedriger zu gewähren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Höhere Beschwörung": {
+            "name": "Höhere Beschwörung",
+            "kategorie": "Beschwörer",
+            "rang": "H",
+            "voraussetzungen": [
+                "AH (Beschwörer)"
+            ],
+            "beschreibung": "Erlaubt das Beschwören mächtiger Kreaturen wie Barghest, Mammut, Frostmammut, Tyrannosaurus Rex oder jungen Drachen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zorn der Hölle": {
+            "name": "Zorn der Hölle",
+            "kategorie": "Diabolist",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Diabolist)"
+            ],
+            "beschreibung": "Mächte wie Flächenschlag, Geschoss und Strahl verursachen +2 Schaden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Infernale Rüstung": {
+            "name": "Infernale Rüstung",
+            "kategorie": "Diabolist",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Diabolist)"
+            ],
+            "beschreibung": "Verleiht +2 Rüstung durch eine höllische Aura, macht Heimlichkeit jedoch nahezu unmöglich.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Herzholzstab": {
+            "name": "Herzholzstab",
+            "kategorie": "Druide",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Druide)"
+            ],
+            "beschreibung": "Ein Kampfstab, der zusätzlichen Schaden verursacht und bei Verlust durch ein Ritual ersetzt werden kann.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wahre Form": {
+            "name": "Wahre Form",
+            "kategorie": "Druide",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Druide)"
+            ],
+            "beschreibung": "Ermöglicht Druiden, in Tierform zu sprechen und Mächte zu wirken, mit Risiken bei längerem Verweilen in Tiergestalt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Elementare Absorption": {
+            "name": "Elementare Absorption",
+            "kategorie": "Elementarmagier",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Elementarmagier)"
+            ],
+            "beschreibung": "Erhöht Robustheit um +2 während der Nutzung von Elementarsynergie.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Elementarer Meister": {
+            "name": "Elementarer Meister",
+            "kategorie": "Elementarmagier",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Elementarist)"
+            ],
+            "beschreibung": "Erlaubt die Beherrschung eines zusätzlichen Elements, Mächte können zwischen Elementen gewechselt werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Böser Blick": {
+            "name": "Böser Blick",
+            "kategorie": "Hexer/Hexe",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Hexer/Hexe)"
+            ],
+            "beschreibung": "Zwingt Feinde zu Willenskraftproben mit -2 bei der Nutzung von Bennys, die fehlschlagen können.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Hexenzeit": {
+            "name": "Hexenzeit",
+            "kategorie": "Hexer/Hexe",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Hexer/Hexe)"
+            ],
+            "beschreibung": "Verleiht Boni während einer besonderen Stunde, z. B. keine Kritischen Fehlschläge und kostenloses Wegstecken von Schaden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tödliche Illusion": {
+            "name": "Tödliche Illusion",
+            "kategorie": "Illusionist",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Illusionist)",
+                "Zaubern W10"
+            ],
+            "beschreibung": "Erlaubt den Einsatz des Machtmodifikators Tödliche Illusion ohne zusätzliche Machtpunkte.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterlicher Illusionist": {
+            "name": "Meisterlicher Illusionist",
+            "kategorie": "Illusionist",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Illusionist)",
+                "Zaubern W8"
+            ],
+            "beschreibung": "Illusionen erhalten die Machtmodifikatoren Beweglich und Geräusch ohne zusätzliche Machtpunkte.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Untote zerstören": {
+            "name": "Untote zerstören",
+            "kategorie": "Kleriker",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Kleriker)"
+            ],
+            "beschreibung": "Kanalisierung positiver Energie, um Untote mit 2W6 (oder 3W6 für 2 Machtpunkte) Schaden zu treffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gnade": {
+            "name": "Gnade",
+            "kategorie": "Kleriker",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Kleriker)",
+                "Glaube W8"
+            ],
+            "beschreibung": "Hebt Abgelenkt, Angeschlagen oder Verwundbar durch Einsatz von 1 Machtpunkt auf.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unheimliche Inspiration": {
+            "name": "Unheimliche Inspiration",
+            "kategorie": "Magier",
+            "rang": "H",
+            "voraussetzungen": [
+                "AH (Magier)"
+            ],
+            "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht mit einem Benny, solange Zugang zu Zauberbüchern besteht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zauberbücher": {
+            "name": "Zauberbücher",
+            "kategorie": "Magier",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Magie)"
+            ],
+            "beschreibung": "Erhält drei neue Mächte bei Wahl des Talents Neue Mächte und sofort eine Macht des eigenen Ranges.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Seelengefäß": {
+            "name": "Seelengefäß",
+            "kategorie": "Nekromant",
+            "rang": "L",
+            "voraussetzungen": [
+                "AH (Nekromant)",
+                "Okkultismus W10"
+            ],
+            "beschreibung": "Versteckt die Seele in einem Behälter, um nach dem Tod in einen vorbereiteten Leichnam zurückzukehren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Untoter Vertrauter": {
+            "name": "Untoter Vertrauter",
+            "kategorie": "Nekromant",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Nekromant)"
+            ],
+            "beschreibung": "Erhält einen untoten Tiergefährten mit speziellen Boni, ähnlich wie das Talent Vertrauter.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Urtümliche Magie": {
+            "name": "Urtümliche Magie",
+            "kategorie": "Schamane",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Schamane)"
+            ],
+            "beschreibung": "Erhöht Schaden von Mächten um +2, verursacht jedoch bei Kritischen Fehlschlägen Betäubung im Umkreis.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Geweihter Fetisch": {
+            "name": "Geweihter Fetisch",
+            "kategorie": "Schamane",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Schamane)",
+                "Glaube W8"
+            ],
+            "beschreibung": "Verleiht eine Freie Wurfwiederholung bei Glaubensproben, wenn ein geweihter Fetisch genutzt wird.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Konstrukt-Vertrauter": {
+            "name": "Konstrukt-Vertrauter",
+            "kategorie": "Tüftler",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Tüftler)"
+            ],
+            "beschreibung": "Erhält einen mechanischen Tiergefährten mit speziellen Vorteilen, ähnlich wie das Talent Vertrauter.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tüftlerrüstung": {
+            "name": "Tüftlerrüstung",
+            "kategorie": "Tüftler",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Tüftler)"
+            ],
+            "beschreibung": "Ermöglicht modifizierte Rüstung mit Boni auf Arme, Rumpf oder Beine, unterliegt jedoch Ausfällen bei Wunden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Große Macht": {
+            "name": "Große Macht",
+            "kategorie": "Zauberer",
+            "rang": "V",
+            "voraussetzungen": [
+                "AH (Zauberer)"
+            ],
+            "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht bis 20 Machtpunkte mit einem Abzug von -2 auf die Zaubernprobe.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Phänomenale Macht": {
+            "name": "Phänomenale Macht",
+            "kategorie": "Zauberer",
+            "rang": "H",
+            "voraussetzungen": [
+                "AH (Zauberer)",
+                "Große Macht"
+            ],
+            "beschreibung": "Erlaubt das Wirken jeder Macht mit Entschlossenheit und fügt den Entschlossenheitsbonus dem Zauberwurf hinzu.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Auserkoren": {
+            "name": "Auserkoren",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Entschlossenheit hält bis zum Ende der Begegnung an, ohne dass sie mit Bennys aufrechterhalten werden muss. Der Charakter hat ein unverkennbares Mal und wird von mächtigen Feinden verfolgt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bevorzugtes Gelände": {
+            "name": "Bevorzugtes Gelände",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Überleben W6"
+            ],
+            "beschreibung": "Wähle ein Geländetyp. In diesem Gelände erhält der Charakter eine freie Wiederholung bei Überlebens- und Wahrnehmungsproben sowie eine zusätzliche Aktionskarte zur Initiative.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Erbstück": {
+            "name": "Erbstück",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Gewährt einen magischen Gegenstand im Wert von bis zu 10.000 Goldmünzen. Der Gegenstand muss bei Verlust durch ein Abenteuer wiedergefunden werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Erzfeind": {
+            "name": "Erzfeind",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Athletik W6",
+                "Kämpfen oder Schießen W6"
+            ],
+            "beschreibung": "Wähle eine Art von Feind. Der Charakter erhält eine freie Wiederholung bei Überlebensproben, um diese zu verfolgen, und bei Angriffen auf diese Feinde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Feenblütig": {
+            "name": "Feenblütig",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Gewährt eine freie Wiederholung, um feindlichen Mächten und zauberähnlichen Effekten zu widerstehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Betäubungsschlag": {
+            "name": "Betäubungsschlag",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "STÄ W8"
+            ],
+            "beschreibung": "Schläge mit stumpfen Waffen zwingen Gegner zu Konstitutionsproben. Bei einem Misserfolg wird der Gegner Betäubt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Böe": {
+            "name": "Böe",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [],
+            "beschreibung": "Mächtige Flügelschläge können Gegner in einem Kegel Angeschlagen machen oder Betäuben, wenn ein Joker gezogen wird.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Doppelschuss": {
+            "name": "Doppelschuss",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Athletik W8 für Wurfwaffen oder Schießen W8 für Bögen"
+            ],
+            "beschreibung": "Erlaubt das Schießen oder Werfen von zwei Geschossen in einem Angriff mit separaten Angriffswürfen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Vierfachschuss": {
+            "name": "Vierfachschuss",
+            "kategorie": "Kampf",
+            "rang": "H",
+            "voraussetzungen": [
+                "Doppelschuss",
+                "Athletik W10 für Wurfwaffen oder Schießen W10 für Bögen"
+            ],
+            "beschreibung": "Erlaubt das zweimalige Nutzen des Talents Doppelschuss pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unglaubliche Reflexe": {
+            "name": "Unglaubliche Reflexe",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Geschicklichkeit W8",
+                "Athletik W8"
+            ],
+            "beschreibung": "Der Charakter ignoriert den üblichen -2 Geschicklichkeits-Abzug beim Wegspringen und kann bei Flächeneffekten oder Angriffen wie Strahl oder Verwirrung Wegspringen anwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Versengen": {
+            "name": "Versengen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "KON W8"
+            ],
+            "beschreibung": "Erhöht den Schaden einer Odemwaffe um einen Würfeltyp und erlaubt die Wahl zwischen Kegel- und Strahlschablone.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verteidiger": {
+            "name": "Verteidiger",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Erlaubt das Teilen des Parade- und Deckungsbonus eines Schildes mit einem Verbündeten in der Nähe als freie Aktion.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wildling": {
+            "name": "Wildling",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Ein Rücksichtsloser Angriff verursacht +4 Schaden statt +2.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zerschmettern": {
+            "name": "Zerschmettern",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W8"
+            ],
+            "beschreibung": "Fügt bei Angriffen auf Objekte +W6 Schaden hinzu, wobei die Schadenswürfel nicht explodieren können.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Artefakterschaffer": {
+            "name": "Artefakterschaffer",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Erlaubt die Herstellung von temporären Arkane Apparaturen und permanenter magischer Gegenstände.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterlicher Artefakterschaffer": {
+            "name": "Meisterlicher Artefakterschaffer",
+            "kategorie": "Macht",
+            "rang": "H",
+            "voraussetzungen": [
+                "Artefakterschaffer",
+                "Okkultismus W10"
+            ],
+            "beschreibung": "Erhöht die Belohnung für Okkultismusproben bei der Herstellung magischer Gegenstände auf 1000 G pro Erfolg oder Steigerung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bevorzugte Macht": {
+            "name": "Bevorzugte Macht",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (beliebig)",
+                "Glaube oder Zaubern W8"
+            ],
+            "beschreibung": "Erlaubt das Ignorieren von bis zu zwei Punkten Abzügen bei der Aktivierung einer ausgewählten Macht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Blutmagie": {
+            "name": "Blutmagie",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Gewährt W6 Machtpunkte zurück, wenn der Charakter einem bewussten Wesen eine Wunde zufügt, die nicht weggesteckt wird.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Epische Meisterschaft": {
+            "name": "Epische Meisterschaft",
+            "kategorie": "Macht",
+            "rang": "V",
+            "voraussetzungen": [
+                "AH (beliebig)",
+                "Glaube oder Zaubern W6"
+            ],
+            "beschreibung": "Gewährt Zugang zu epischen Machtmodifikatoren für alle Mächte des Helden. Gilt für alle arkanen Hintergründe, die der Charakter besitzt, wenn er die Voraussetzungen erfüllt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystische Kräfte": {
+            "name": "Mystische Kräfte",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "Fortgeschritten"
+            ],
+            "beschreibung": "Erlaubt das Erlernen von 10 dedizierten Machtpunkten mit ausgewählten Mächten, die automatisch aktiviert werden können. Die Mächte und Einschränkungen sind abhängig vom gewählten Paket (z. B. Barbar, Kämpfer, Mönch, etc.).",
+            "neue_maechte": 0,
+            "machtpunkte": 10,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schlachtenmagie": {
+            "name": "Schlachtenmagie",
+            "kategorie": "Macht",
+            "rang": "V",
+            "voraussetzungen": [
+                "AH (beliebig)",
+                "Glaube oder Zaubern W10"
+            ],
+            "beschreibung": "Erlaubt das Wirken von Zaubern auf große Einheiten von Statisten. Siehe Regeln für Schlachtenmagie.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Stillzauberer": {
+            "name": "Stillzauberer",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (jeder außer Barde)",
+                "Okkultismus W8"
+            ],
+            "beschreibung": "Erlaubt das Wirken von Zaubern ohne zu sprechen. Funktioniert auch unter Wasser, in einem Vakuum, oder innerhalb der Macht Stille.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Übertragung": {
+            "name": "Übertragung",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Erlaubt das Übertragen von bis zu fünf Machtpunkten auf eine andere Person in Sichtweite als begrenzte freie Aktion.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Vertrauter": {
+            "name": "Vertrauter",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Diabolist, Druide, Elementarmagier, Schamane, Hexer, Nekromant, Hexer, Zauberer, Hexenmeister)"
+            ],
+            "beschreibung": "Gewährt einen loyalen magischen Begleiter, der 5 eigene Machtpunkte hat und als Wildcard fungiert. Der Vertraute kann keine Zauber wirken, aber der Meister kann auf seine Machtpunkte zugreifen.",
+            "neue_maechte": 0,
+            "machtpunkte": 5,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Entdecker": {
+            "name": "Entdecker",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "KON W6",
+                "Überleben W8"
+            ],
+            "beschreibung": "Ermöglicht eine zusätzliche Aktionskarte bei Reisen und verkürzt die Reisezeit der Gruppe um 10%.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Fallengespür": {
+            "name": "Fallengespür",
+            "kategorie": "Experte",
+            "rang": "F",
+            "voraussetzungen": [
+                "Reparieren W6"
+            ],
+            "beschreibung": "Ermöglicht eine Wahrnehmungsprobe zum Erkennen von Fallen in 10 Metern Entfernung und ignoriert 2 Punkte Abzüge beim Entschärfen von Fallen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Giftmischer": {
+            "name": "Giftmischer",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Alchemie, Heilen oder Überleben W6"
+            ],
+            "beschreibung": "Erstellt Gifte in der Hälfte der Zeit, die Kontaktgifte halten 12 statt 4 Stunden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Im Sattel geboren": {
+            "name": "Im Sattel geboren",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Geschicklichkeit W8",
+                "Reiten W6"
+            ],
+            "beschreibung": "Verleiht eine freie Wiederholung bei Reitenproben, erhöht die Bewegungsweite des Reittiers um 2 und den Sprintwürfel um einen Würfeltyp.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kundschafter": {
+            "name": "Kundschafter",
+            "kategorie": "Experte",
+            "rang": "F",
+            "voraussetzungen": [
+                "Überleben W6"
+            ],
+            "beschreibung": "Ermöglicht Wahrnehmungsproben zum frühzeitigen Erkennen von Gefahren, verbessert Wachsamkeit und gibt Boni auf Allgemeinwissen über bereiste Orte.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Reittier": {
+            "name": "Reittier",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Reiten W6"
+            ],
+            "beschreibung": "Gewährt ein treues, aufsteigbares Reittier mit besonderen Fähigkeiten. Ermöglicht die Wahl eines mächtigen Reittiers auf höheren Rängen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ritter": {
+            "name": "Ritter",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "STÄ W8",
+                "KON W8",
+                "Kämpfen W8",
+                "Reiten W6"
+            ],
+            "beschreibung": "Repräsentiert einen Lehnsherrn, gewährt +1 auf Einschüchtern- oder Überredenproben gegenüber Autorität-respektierenden Personen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schatzjäger": {
+            "name": "Schatzjäger",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Wahrnehmung W8",
+                "Okkultismus W8"
+            ],
+            "beschreibung": "Erlaubt Verstandsproben zur Einschätzung von Schätzen und magischen Gegenständen. Ermöglicht das Neuwürfeln von magischen Gegenstandseffekten mit einem Benny.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Steingespür": {
+            "name": "Steingespür",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Reparieren W6"
+            ],
+            "beschreibung": "Erhöht Wahrnehmungsproben um +2, um Fallen oder versteckte Türen in Stein zu entdecken.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Troubadour": {
+            "name": "Troubadour",
+            "kategorie": "Experte",
+            "rang": "F",
+            "voraussetzungen": [
+                "Allgemeinwissen W6",
+                "Darbietung W8"
+            ],
+            "beschreibung": "Gewährt +2 auf Allgemeinwissenproben und erlaubt die Nutzung von Darbietung statt Kriegskunst für Anführertalente.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Täuscher": {
+            "name": "Täuscher",
+            "kategorie": "Sozial",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W8"
+            ],
+            "beschreibung": "Erlaubt das Ziel, bei Herausforderungen entweder mit Verstand oder Willenskraft zu widerstehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Aura der Tapferkeit": {
+            "name": "Aura der Tapferkeit",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Verbündete im Umkreis von 20 Metern erhalten +1 auf Furchtproben und -1 auf der Furchttabelle.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bestienflüsterer": {
+            "name": "Bestienflüsterer",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Erlaubt es, mit einer Tiergattung zu kommunizieren und Informationen von ihnen zu erhalten, abhängig von ihrer Intelligenz.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelle Verwandlung": {
+            "name": "Schnelle Verwandlung",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Erlaubt eine Formveränderung als begrenzte Aktion statt der üblichen 10 Minuten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Aristokrat": {
+            "name": "Aristokrat",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "+2 auf Allgemeinwissen und Informationsbeschaffung in der Oberschicht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Resistenz": {
+            "name": "Arkane Resistenz",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –2 verringert.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Starke Arkane Resistenz": {
+            "name": "Starke Arkane Resistenz",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Arkane Resistenz"
+            ],
+            "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –4 verringert.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Attraktiv": {
+            "name": "Attraktiv",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "KON W6"
+            ],
+            "beschreibung": "+1 auf Darbietung und Überreden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Sehr Attraktiv": {
+            "name": "Sehr Attraktiv",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Attraktiv"
+            ],
+            "beschreibung": "+2 auf Darbietung und Überreden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Aufmerksamkeit": {
+            "name": "Aufmerksamkeit",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "+2 auf Wahrnehmungsproben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Beidhändig": {
+            "name": "Beidhändig",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Ignoriere den Abzug von –2 für Aktionen mit der falschen Hand.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bekannt": {
+            "name": "Bekannt",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "+1 auf Überredenproben, wenn erkannt (Allgemeinwissen), doppelte normale Summe für Darbietung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Berühmt": {
+            "name": "Berühmt",
+            "kategorie": "Hintergrund",
+            "rang": "F",
+            "voraussetzungen": [
+                "Bekannt"
+            ],
+            "beschreibung": "+2 auf Überredenproben, wenn erkannt (Allgemeinwissen), fünffache normale Summe oder mehr für Darbietung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Charismatisch": {
+            "name": "Charismatisch",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Freie Wiederholung bei der Verwendung von Überreden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Elan": {
+            "name": "Elan",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "+2 beim Ausgeben eines Bennys für die Wiederholung einer Eigenschaftsprobe.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Flink": {
+            "name": "Flink",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W6"
+            ],
+            "beschreibung": "Bewegungsweite +2, erhöhe Sprintwürfel um einen Schritt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Glück": {
+            "name": "Glück",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "+1 Benny zu Beginn jeder Sitzung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Großes Glück": {
+            "name": "Großes Glück",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Glück"
+            ],
+            "beschreibung": "+2 Bennys zu Beginn jeder Sitzung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kräftig": {
+            "name": "Kräftig",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W6",
+                "KON W6"
+            ],
+            "beschreibung": "Größe (und somit Robustheit) +1. Behandle Stärke als einen Würfeltyp höher für Belastung und Mindeststärke bei Waffen, Rüstung und Ausrüstung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Linguist": {
+            "name": "Linguist",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Charakter hat einen W6 in Sprachen gleich halbem Verstandswürfel.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mutig": {
+            "name": "Mutig",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6"
+            ],
+            "beschreibung": "+2 auf Furchtproben und –2 bei Würfen auf der Furchttabelle.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Reich": {
+            "name": "Reich",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Charakter beginnt mit dreifachem Startkapital und einem Jahreseinkommen von $150.000.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Stinkreich": {
+            "name": "Stinkreich",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Reich"
+            ],
+            "beschreibung": "Fünffaches Startkapital und $500.000 Jahreseinkommen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Rohling": {
+            "name": "Rohling",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W6",
+                "KON W6"
+            ],
+            "beschreibung": "Verknüpfe Athletik mit Stärke anstelle von Geschicklichkeit (auch für Herausfordern). Kurze Entfernung von geworfenen Gegenständen +1. Verdopple den Bonus für die angepasste mittlere Entfernung und nochmal für die weite Entfernung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelle Heilung": {
+            "name": "Schnelle Heilung",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "KON W8"
+            ],
+            "beschreibung": "+2 Konstitution für natürliche Heilung, Wurf alle 3 Tage.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Engelsschwingen": {
+            "name": "Engelsschwingen",
+            "kategorie": "Hintergrund",
+            "rang": "F",
+            "voraussetzungen": [
+                "Volk: Aasimars"
+            ],
+            "beschreibung": "Der Charakter wächst Flügel aus göttlichem Licht. Er erhält eine Flug-Bewegungsweite von 6\" und muss sich pro Runde mindestens 1\" fortbewegen oder landen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Rüstung des Abgrunds": {
+            "name": "Rüstung des Abgrunds",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Tieflinge"
+            ],
+            "beschreibung": "+2 natürlicher Rüstungsschutz sowie Umgebungsresistenz gegen Kälte, Elektrizität oder Feuer (Wahl bei Erwerb des Talents).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Naturverbundenheit": {
+            "name": "Naturverbundenheit",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Elf"
+            ],
+            "beschreibung": "Im bevorzugten Gelände (aus dem Talent Bevorzugtes Gelände) kann der Charakter jede 24 Stunden einen natürlichen Heilungswurf mit +2 Bonus ablegen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bluttrinker": {
+            "name": "Bluttrinker",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Dhampire"
+            ],
+            "beschreibung": "Der Charakter kann einen natürlichen Heilungswurf durchführen, wenn er Blut trinkt (erfordert eine Aktion und einen willigen oder wehrlosen Spender).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Brenn! Brenn! Brenn!": {
+            "name": "Brenn! Brenn! Brenn!",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Goblin",
+                "Diebeskunst W6"
+            ],
+            "beschreibung": "Der Charakter verursacht mit natürlichem Feuer erhöhten Schaden: Brennende Gegenstände, Fackeln und ähnliche Lichtquellen fügen in seiner Hand +1 Würfeltyp Schaden zu.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Lässiger Illusionist": {
+            "name": "Lässiger Illusionist",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Gnom"
+            ],
+            "beschreibung": "Durch Ausgabe von Machtpunkten erhält der Charakter einen Bonus auf Täuschen- oder Heimlichkeitsproben: 1 MP für +1, 2 MP für +2, bis zu +4.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Himmlischer Diener": {
+            "name": "Himmlischer Diener",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Aasimars",
+                "Tiermeister"
+            ],
+            "beschreibung": "Der Begleiter des Aasimars erhält einen himmlischen Segen: +2 auf alle Eigenschaftswürfe und der Begleiter gilt als übernatürliches Wesen mit entsprechenden Widerstandsboni.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Krallensturz": {
+            "name": "Krallensturz",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Katzenfolk",
+                "GES W6",
+                "STÄ W6"
+            ],
+            "beschreibung": "Erfordert die Alternativfähigkeit Katzenkrallen. Bei einem Rücksichtslosen Angriff mit Klauen erhält der Charakter +2 Schaden zusätzlich zum normalen Bonus des Rücksichtslosen Angriffs.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tiefblick": {
+            "name": "Tiefblick",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                {
+                    "oder": [
+                        "Volk-Eigenschaft: dunkelsicht",
+                        "Volk-Eigenschaft: nachtsicht"
+                    ]
+                }
+            ],
+            "beschreibung": "Der Charakter verbessert seine Sehfähigkeit im Dunkeln: Er ignoriert alle Beleuchtungsabzüge vollständig (entspricht Nachtsicht auf höchster Stufe).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Glücklicher Halbling": {
+            "name": "Glücklicher Halbling",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Halbling",
+                "Selbstlos"
+            ],
+            "beschreibung": "Der Charakter kann einen Benny ausgeben, um einem Verbündeten in Sichtweite eine Wiederholung für eine Eigenschaftsprobe mit +2 Bonus zu ermöglichen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Flinker Angreifer": {
+            "name": "Flinker Angreifer",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk-Eigenschaft: sprinter",
+                "GES W8"
+            ],
+            "beschreibung": "Der Charakter erleidet keinen Abzug, wenn er in derselben Runde rennt und eine einzelne Aktion ausführt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Klingenzahn": {
+            "name": "Klingenzahn",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Halbork"
+            ],
+            "beschreibung": "Der Charakter erhält durch seine verlängerten Stoßzähne einen Biss als natürliche Waffe (Stärke+W4 Schaden, gilt als natürliche Waffe nach Pathfinder-Regeln).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zauberbrecher": {
+            "name": "Zauberbrecher",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Volk: Zwerg"
+            ],
+            "beschreibung": "Der Charakter kann als begrenzte freie Aktion (einmal pro Zug) versuchen, eine aktive Macht in Nahkampfreichweite aufzuheben (wie der Zauber Aufheben, mit STÄ als arkaner Fertigkeit).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Rüstungsausbildung": {
+            "name": "Rüstungsausbildung",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Handicap: Rüstungsbeschränkung"
+            ],
+            "beschreibung": "Der Charakter ist im Umgang mit Rüstungen geübt: Die Abzüge durch Rüstungsbeschränkung werden um 2 reduziert (Rüstungsbeschränkung (leicht) → kein GES-Abzug; Rüstungsbeschränkung (mittelschwer) → Abzüge wie bei leichter Beschränkung).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Deckende Verteidigung": {
+            "name": "Deckende Verteidigung",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Wenn der Charakter den Verteidigungsmanöver einsetzt (beide Aktionen, +4 Parade), erhalten alle Verbündeten in Reichweite von 2'' ebenfalls +2 auf ihre Parade.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Lähmender Angriff": {
+            "name": "Lähmender Angriff",
+            "kategorie": "Kampf",
+            "rang": "H",
+            "voraussetzungen": [
+                "Lieblingswaffe"
+            ],
+            "beschreibung": "Mit einer Erhöhung bei einem Angriff mit der Lieblingswaffe wird die Bewegungsweite des Ziels um 2 reduziert (Minimum 1). Dieser Malus gilt bis zur Heilung oder bis zum Ende der Begegnung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Armbrustmeisterschaft": {
+            "name": "Armbrustmeisterschaft",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schnelles Nachladen",
+                "Schießen W8"
+            ],
+            "beschreibung": "Der Charakter schießt mit einer Armbrust so schnell wie mit einem Bogen (kein Nachteil durch Nachladezeit; Armbrust gilt als Nachladen 0). Zudem kann er eine Armbrust im Nahkampf als schwere Keule einsetzen (STÄ+W6 Schaden, kein Abzug).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystische Klauen": {
+            "name": "Mystische Klauen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Erfordert natürliche Klauenangriffe (z.B. Katzenkrallen). Die Klauen lösen Umgebungsschwächen von Kreaturen aus (z.B. Silber bei Werwölfen, Feuer bei Untoten) und gelten als magische Waffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wilde Klauen": {
+            "name": "Wilde Klauen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "STÄ W6"
+            ],
+            "beschreibung": "Erfordert natürliche Klauenangriffe (z.B. Katzenkrallen). Die Klauen verursachen erhöhten Schaden (STÄ+W6 statt STÄ+W4) und gelten als Panzerbrecher (AP 2).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Reißende Klauen": {
+            "name": "Reißende Klauen",
+            "kategorie": "Kampf",
+            "rang": "H",
+            "voraussetzungen": [
+                "Wilde Klauen",
+                "STÄ W8"
+            ],
+            "beschreibung": "Die Klauen des Charakters verursachen Reißende Angriffe: Bei einem Treffer mit einer Erhöhung muss das Ziel eine Konstitutionsprobe ablegen oder erleidet eine zusätzliche Wunde durch Blutung/Reißen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heldenhafter Widerstand": {
+            "name": "Heldenhafter Widerstand",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "KON W8"
+            ],
+            "beschreibung": "Einmal pro Szene kann der Charakter als begrenzte freie Aktion automatisch einen der folgenden negativen Zustände aufheben: Erschüttert, Abgelenkt oder Erschöpft.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Geschossabwehr": {
+            "name": "Geschossabwehr",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [],
+            "beschreibung": "Der Charakter erhält +2 Robustheit gegen alle Fernkampfangriffe (Schießen, Athletik-Würfe für Wurfwaffen und ähnliche Distanzangriffe).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Berittener Schild": {
+            "name": "Berittener Schild",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Der Charakter kann seinen Schildbonus (Parade und Robustheit) auf sein Reittier übertragen, solange er berittenen Kampf führt und das Schild hält.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Nahschussmeister": {
+            "name": "Nahschussmeister",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schießen W10"
+            ],
+            "beschreibung": "Der Charakter erleidet keinen Abzug auf Schießen-Proben, wenn er sich im Nahkampf befindet oder angebunden ist. Zudem kann er im Nahkampf schießen, ohne einen automatischen Kritischen Fehlschlag zu riskieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schattenangriff": {
+            "name": "Schattenangriff",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Hinterhältiger Angriff",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Der Charakter kann den Hinterhältigen Angriff in Gebieten mit schlechter Beleuchtung (Düster oder Dunkel) einsetzen, auch ohne volle Deckung oder direkten Überraschungsangriff.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Berührung der Stille": {
+            "name": "Berührung der Stille",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "WIL W8",
+                "Waffenloser Schlag",
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Ki-Aktion (1 Machtpunkt): Bei einem erfolgreichen unbewaffneten Treffer muss das Ziel eine Willenskraftprobe ablegen oder kann bis zum Ende seines nächsten Zuges keine Aktionen ausführen (gilt als Erschöpft).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Stolperschlag": {
+            "name": "Stolperschlag",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Mit einer Erhöhung bei einem Nahkampfangriff kann der Charakter das Ziel zu Boden werfen: Das Ziel fällt hin (Hingeworfen, –2 auf alle Proben; Angreifer erhalten +2 auf Angriffe gegen das Ziel).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unter dem Riesen": {
+            "name": "Unter dem Riesen",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Handicap: Klein",
+                "Athletik W8"
+            ],
+            "beschreibung": "Wenn ein Gegner der Größe 1 oder größer diesen Charakter angreift, kann der Charakter als freie Aktion eine Athletik-Probe ablegen. Bei Erfolg fällt der Gegner hin (Hingeworfen). Einmal pro Zug einsetzbar.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ausweichen": {
+            "name": "Ausweichen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "–2 bei Angriffen durch Fernkampfwaffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelles Ausweichen": {
+            "name": "Schnelles Ausweichen",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Ausweichen"
+            ],
+            "beschreibung": "+2 auf Wegspringen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Beidhändiger Fernkampf": {
+            "name": "Beidhändiger Fernkampf",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Führe einen zusätzlichen Angriff mit Athletik (Werfen) oder Schießen mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Beidhändiger Kampf": {
+            "name": "Beidhändiger Kampf",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Führe einen zusätzlichen Kämpfen-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Berechnend": {
+            "name": "Berechnend",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W8"
+            ],
+            "beschreibung": "Ignoriere 2 Punkte Abzüge bei einer Aktion mit einer Aktionskarte von 5 oder weniger.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Block": {
+            "name": "Block",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "+1 Parade, ignoriere 1 Punkt Überzahlbonus.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Harter Block": {
+            "name": "Harter Block",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Block"
+            ],
+            "beschreibung": "+2 Parade, ignoriere 2 Punkt Überzahlbonus.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Eisenkiefer": {
+            "name": "Eisenkiefer",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "KON W8"
+            ],
+            "beschreibung": "+2 auf Schaden wegstecken und Konstitutionsproben, um K.O.-Schlägen zu widerstehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Erstschlag": {
+            "name": "Erstschlag",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Freier Kämpfen-Angriff einmal pro Runde, wenn sich ein Feind in Reichweite bewegt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schneller Erstschlag": {
+            "name": "Schneller Erstschlag",
+            "kategorie": "Kampf",
+            "rang": "H",
+            "voraussetzungen": [
+                "Erstschlag"
+            ],
+            "beschreibung": "Freie Kämpfen-Angriffe gegen bis zu drei Gegner, wenn sie sich in Reichweite bewegen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Finte": {
+            "name": "Finte",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Du kannst einen Feind bei einer Kämpfen-Herausforderung mit Verstand statt mit Geschicklichkeit widerstehen lassen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Improvisationsgabe": {
+            "name": "Improvisationsgabe",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "Ignoriere den Abzug von –2, wenn du mit improvisierten Waffen angreifst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kampfkünstler": {
+            "name": "Kampfkünstler",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Unbewaffnetes Kämpfen +1, Fäuste und Füße zählen als Natürliche Waffen, addiere W4 auf den Schaden unbewaffneter Angriffe (oder erhöhe den Schaden um einen Würfeltyp, wenn du bereits einen Würfel hast).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kampfkunstmeister": {
+            "name": "Kampfkunstmeister",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kampfkünstler"
+            ],
+            "beschreibung": "Unbewaffnetes Kämpfen +2, erhöhe Schadenswürfel um einen Würfeltyp.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kampfreflexe": {
+            "name": "Kampfreflexe",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [],
+            "beschreibung": "+2 Erholungsproben gegen Angeschlagen oder Betäubt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Keine Gnade": {
+            "name": "Keine Gnade",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [],
+            "beschreibung": "+2 Schaden, wenn du einen Benny ausgibst, um den Schadenswurf zu wiederholen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Killerinstinkt": {
+            "name": "Killerinstinkt",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [],
+            "beschreibung": "Freie Wiederholung für vergleichende Proben, wenn er Herausfordern einleitet.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kühler Kopf": {
+            "name": "Kühler Kopf",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W8"
+            ],
+            "beschreibung": "Ziehe jede Runde eine zusätzliche Aktionskarte und wähle, welche du verwenden willst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Sehr Kühler Kopf": {
+            "name": "Sehr Kühler Kopf",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kühler Kopf"
+            ],
+            "beschreibung": "Ziehe jede Runde zwei zusätzliche Aktionskarten und wähle, welche du verwenden willst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Lieblingswaffe": {
+            "name": "Lieblingswaffe",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfen oder Schießen W8"
+            ],
+            "beschreibung": "+1 auf Athletik (Werfen), Kämpfen oder Schießen mit einer bestimmten Waffe; +1 Parade, wenn die Waffe bereit ist.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Absolute Lieblingswaffe": {
+            "name": "Absolute Lieblingswaffe",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Lieblingswaffe"
+            ],
+            "beschreibung": "Der Bonus auf Angriff und Parade steigt auf +2.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mächtiger Hieb": {
+            "name": "Mächtiger Hieb",
+            "kategorie": "Kampf",
+            "rang": "WC",
+            "voraussetzungen": [
+                "A",
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden des ersten erfolgreichen Kämpfen-Angriffs in dieser Runde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterschütze": {
+            "name": "Meisterschütze",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Athletik oder Schießen W8"
+            ],
+            "beschreibung": "Bei erster Aktion +1 Bonus oder ignoriere bis zu 2 Punkte Abzüge auf Athletik (Werfen) oder Schießen, wenn du dich nicht bewegst und nicht mehr als FR 1 verwendest.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Parkour": {
+            "name": "Parkour",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Ignoriere Schwieriges Gelände und addiere +2 auf Athletikproben in Verfolgungsjagden zu Fuß.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Raufbold": {
+            "name": "Raufbold",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W8",
+                "KON W8"
+            ],
+            "beschreibung": "Robustheit +1, addiere W4 zum Schaden von Fäusten oder erhöhe Würfeltyp bei Kombination mit Kampfkünstler, Klauen oder ähnlichen Fähigkeiten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schläger": {
+            "name": "Schläger",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Raufbold"
+            ],
+            "beschreibung": "Erhöhe unbewaffneten Schaden um einen Würfeltyp und Robustheit noch einmal um +1.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Riposte": {
+            "name": "Riposte",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Freier Angriff gegen einen Feind, der eine Kämpfenprobe nicht geschafft hat.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Geschickte Riposte": {
+            "name": "Geschickte Riposte",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Riposte"
+            ],
+            "beschreibung": "Wie Riposte, jedoch bei bis zu drei Angriffen pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Rückzug": {
+            "name": "Rückzug",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Ein angrenzender Gegner erhält keinen freien Angriff, wenn du dich aus dem Nahkampf zurückziehst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wendiger Rückzug": {
+            "name": "Wendiger Rückzug",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Rückzug"
+            ],
+            "beschreibung": "Drei angrenzende Gegner erhalten keine freien Angriffe, wenn du dich aus dem Nahkampf zurückziehst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ruhige Hände": {
+            "name": "Ruhige Hände",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Ignoriere den Abzug für Unsicheren Grund; verringere Abzüge für Sprinten auf –1.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Rundumschlag": {
+            "name": "Rundumschlag",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "STÄ W8",
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Kämpfen-Wurf mit –2 gegen alle Ziele in der Reichweite der Waffe, nicht öfter als einmal pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kontrollierter Rundumschlag": {
+            "name": "Kontrollierter Rundumschlag",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Rundumschlag"
+            ],
+            "beschreibung": "Wie oben, aber ohne den Abzug von –2.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schmerzresistenz": {
+            "name": "Schmerzresistenz",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "KON W8"
+            ],
+            "beschreibung": "Ignoriere eine Stufe Wundabzüge.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Stärkere Schmerzresistenz": {
+            "name": "Stärkere Schmerzresistenz",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "Schmerzresistenz"
+            ],
+            "beschreibung": "Ignoriere bis zu zwei Stufen Wundabzüge.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schneller Angriff": {
+            "name": "Schneller Angriff",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei einem Nahkampfangriff pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Blitzschneller Angriff": {
+            "name": "Blitzschneller Angriff",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schneller Angriff"
+            ],
+            "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei bis zu zwei Nahkampfangriffen pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnellfeuer": {
+            "name": "Schnellfeuer",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Schießen W6"
+            ],
+            "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verbessertes Schnellfeuer": {
+            "name": "Verbessertes Schnellfeuer",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schnellfeuer"
+            ],
+            "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schwer zu töten": {
+            "name": "Schwer zu töten",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Ignoriere Wundabzüge, wenn du Konstitutionsproben machst, um Verbluten zu verhindern.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wirklich schwer zu töten": {
+            "name": "Wirklich schwer zu töten",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schwer zu töten"
+            ],
+            "beschreibung": "Wirf einen Würfel, wenn der Charakter umkommt. Auch wenn er Ausgeschaltet ist, überlebt er irgendwie.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Volles Rohr!": {
+            "name": "Volles Rohr!",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Schießen W8"
+            ],
+            "beschreibung": "Sofern du dich in deinem Zug nicht bewegst, ignoriere den Rückstoß-Malus, wenn du Waffen mit einer FR von 2 oder mehr verwendest.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Volltreffer": {
+            "name": "Volltreffer",
+            "kategorie": "Kampf",
+            "rang": "WC",
+            "voraussetzungen": [
+                "A",
+                "Athletik oder Schießen W8"
+            ],
+            "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden deines ersten erfolgreichen Angriffs mit Athletik (Werfen) oder Schießen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Anführer": {
+            "name": "Anführer",
+            "kategorie": "Anführer",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "+1 auf Erholungsproben gegen Angeschlagen und Betäubt von Statisten im Befehlsradius.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Großer Anführer": {
+            "name": "Großer Anführer",
+            "kategorie": "Anführer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Anführer"
+            ],
+            "beschreibung": "Erhöhe Befehlsradius auf 10“ (20 m).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Anheizen": {
+            "name": "Anheizen",
+            "kategorie": "Anführer",
+            "rang": "V",
+            "voraussetzungen": [
+                "WIL W8",
+                "Anführer"
+            ],
+            "beschreibung": "+1 auf Kämpfen-Schadenswürfe von Statisten im Befehlsradius.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Geborener Anführer": {
+            "name": "Geborener Anführer",
+            "kategorie": "Anführer",
+            "rang": "F",
+            "voraussetzungen": [
+                "WIL W8",
+                "Anführer"
+            ],
+            "beschreibung": "Anführertalente gelten nun auch für Wildcards.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Haltet die Stellung!": {
+            "name": "Haltet die Stellung!",
+            "kategorie": "Anführer",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W8",
+                "Anführer"
+            ],
+            "beschreibung": "+1 auf Robustheit der Statisten im Befehlsradius.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Inspirieren": {
+            "name": "Inspirieren",
+            "kategorie": "Anführer",
+            "rang": "F",
+            "voraussetzungen": [
+                "Anführer"
+            ],
+            "beschreibung": "Einmal pro Zug kann der Held auf Kriegskunst würfeln, um alle Statisten im Befehlsradius bei einer Art von Eigenschaftsprobe zu unterstützen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Taktiker": {
+            "name": "Taktiker",
+            "kategorie": "Anführer",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W8",
+                "Anführer",
+                "Kriegskunst W6"
+            ],
+            "beschreibung": "Ziehe eine zusätzliche Aktionskarte pro Zug und weise sie einem verbündeten Statisten im Befehlsradius zu.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meistertaktiker": {
+            "name": "Meistertaktiker",
+            "kategorie": "Anführer",
+            "rang": "V",
+            "voraussetzungen": [
+                "Taktiker"
+            ],
+            "beschreibung": "Ziehe und verteile zwei zusätzliche Aktionskarten anstelle von einer.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Energieschub": {
+            "name": "Energieschub",
+            "kategorie": "Macht",
+            "rang": "WC",
+            "voraussetzungen": [
+                "A",
+                "Glaube oder Zaubern W8",
+                "AH"
+            ],
+            "beschreibung": "Erhalte 10 Machtpunkte zurück, wenn du im Kampf einen Joker ziehst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heiliger/Unheiliger Krieger": {
+            "name": "Heiliger/Unheiliger Krieger",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Wunder)",
+                "Glaube W6"
+            ],
+            "beschreibung": "Addiere +1 bis +4 auf Schaden wegstecken für jeden Machtpunkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kanalisieren": {
+            "name": "Kanalisieren",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH"
+            ],
+            "beschreibung": "Verringere Machtpunktekosten um –1 nach einer Steigerung beim Aktivierungswurf.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Konzentration": {
+            "name": "Konzentration",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH"
+            ],
+            "beschreibung": "Wirkungsdauer von Mächten wird verdoppelt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Machtpunkte": {
+            "name": "Machtpunkte",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH"
+            ],
+            "beschreibung": "Erhalte 5 zusätzliche Machtpunkte, nur einmal pro Rang.",
+            "neue_maechte": 0,
+            "machtpunkte": 5,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Neue Mächte": {
+            "name": "Neue Mächte",
+            "kategorie": "Macht",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH"
+            ],
+            "beschreibung": "Dein Charakter kennt zwei neue Mächte.",
+            "neue_maechte": 2,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelle Machtregeneration": {
+            "name": "Schnelle Machtregeneration",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "WIL W6",
+                "AH"
+            ],
+            "beschreibung": "Regeneriere 10 Machtpunkte pro Stunde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnellere Machtregeneration": {
+            "name": "Schnellere Machtregeneration",
+            "kategorie": "Macht",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schnelle Machtregeneration"
+            ],
+            "beschreibung": "Regeneriere 20 Machtpunkte pro Stunde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Seelenentzug": {
+            "name": "Seelenentzug",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH",
+                "Glaube oder Zaubern W10"
+            ],
+            "beschreibung": "Erhalte 5 Machtpunkte für eine Stufe Erschöpfung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zusätzliche Anstrengung": {
+            "name": "Zusätzliche Anstrengung",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Begabt)",
+                "Fokus W6"
+            ],
+            "beschreibung": "Erhöhe Fokus um +1 für 1 Machtpunkt oder +2 für 3 Machtpunkte.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Akrobat": {
+            "name": "Akrobat",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8",
+                "Athletik W8"
+            ],
+            "beschreibung": "Wurfwiederholung bei akrobatischen Athletik-Aktionen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kampfakrobat": {
+            "name": "Kampfakrobat",
+            "kategorie": "Experte",
+            "rang": "F",
+            "voraussetzungen": [
+                "Akrobat"
+            ],
+            "beschreibung": "–1 für Gegner zum Treffen mit Fernkampf- und Nahkampfangriffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Alleskönner": {
+            "name": "Alleskönner",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W10"
+            ],
+            "beschreibung": "Du erhältst W4 in einer Fertigkeit (oder W6 bei einer Steigerung), bis du sie ersetzt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ass am Steuer": {
+            "name": "Ass am Steuer",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Charakter kann Bennys ausgeben, um für sein Fahrzeug Schaden wegstecken anzuwenden und ignoriert bis zu 2 Punkte Abzüge.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Dieb": {
+            "name": "Dieb",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8",
+                "Heimlichkeit W6",
+                "Diebeskunst W6"
+            ],
+            "beschreibung": "+1 Diebeskunst, Athletik zum Klettern, Heimlichkeit in urbanen Umgebungen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "McGyver": {
+            "name": "McGyver",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6",
+                "Reparieren W8",
+                "Wahrnehmung W8"
+            ],
+            "beschreibung": "Du kannst schnell improvisierte Gerätschaften aus Schrott erfinden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Naturbursche": {
+            "name": "Naturbursche",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "Überleben W8"
+            ],
+            "beschreibung": "+2 Überleben und Heimlichkeit in der Wildnis.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Soldat": {
+            "name": "Soldat",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W6",
+                "KON W6"
+            ],
+            "beschreibung": "Stärke ist einen Würfeltyp höher für Belastung und Mindeststärke. Wiederhole Konstitutionsproben beim Widerstand gegen Umweltgefahren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Aufwiegler": {
+            "name": "Aufwiegler",
+            "kategorie": "Sozial",
+            "rang": "F",
+            "voraussetzungen": [
+                "Heimlichkeit W8"
+            ],
+            "beschreibung": "Einmal pro Zug kannst du alle Feinde in einer mittleren Flächenschablone mit einer Einschüchtern- oder Provozieren-Herausforderung beeinflussen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bedrohlich": {
+            "name": "Bedrohlich",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "+2 auf Einschüchtern.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Beziehungen": {
+            "name": "Beziehungen",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Kontakte bieten einmal pro Sitzung Unterstützung oder andere Gefallen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ermutigen": {
+            "name": "Ermutigen",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Kann den Zustand Abgelenkt oder Verwundbar nach Herausfordern aufheben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Erniedrigen": {
+            "name": "Erniedrigen",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "Provozieren W8"
+            ],
+            "beschreibung": "Freie Wiederholung bei Provozieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Erzürnen": {
+            "name": "Erzürnen",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "Provozieren W6"
+            ],
+            "beschreibung": "Kann Feinde mit einer Steigerung bei einer Provozierenprobe „erzürnen“.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gassenwissen": {
+            "name": "Gassenwissen",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6"
+            ],
+            "beschreibung": "+2 auf Proben mit Allgemeinwissen und Informationsbeschaffung in kriminellen Kreisen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Konter": {
+            "name": "Konter",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "Provozieren W6"
+            ],
+            "beschreibung": "Eine Steigerung beim Widerstand gegen Provozieren oder Einschüchtern verursacht beim Feind Abgelenkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Rampensau": {
+            "name": "Rampensau",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Einmal pro Zug wirf einen zweiten Würfel, wenn du mit Darbietung oder Überreden unterstützt und wende das Ergebnis auf einen Verbündeten an.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Echte Rampensau": {
+            "name": "Echte Rampensau",
+            "kategorie": "Sozial",
+            "rang": "F",
+            "voraussetzungen": [
+                "Rampensau"
+            ],
+            "beschreibung": "Wie oben, aber bis zu zweimal pro Zug.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Selbstlos": {
+            "name": "Selbstlos",
+            "kategorie": "Sozial",
+            "rang": "WC",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Der Held kann anderen seine Bennys geben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Starker Wille": {
+            "name": "Starker Wille",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "+2 um Herausfordern mit Verstand oder Willenskraft zu widerstehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verlässlich": {
+            "name": "Verlässlich",
+            "kategorie": "Sozial",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Freie Wiederholung bei Unterstützung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Auserwählter": {
+            "name": "Auserwählter",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "+2 Schaden gegen übernatürlich böse (oder gute) Kreaturen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heiler": {
+            "name": "Heiler",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "+2 auf Heilungsproben, magisch oder anderweitig.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Sammler": {
+            "name": "Sammler",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "Glück"
+            ],
+            "beschreibung": "Kann einmal pro Begegnung einen benötigten Gegenstand finden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Sechster Sinn": {
+            "name": "Sechster Sinn",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Wahrnehmungsprobe mit +2 zum Spüren von Hinterhalten oder ähnlichen Ereignissen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tierempathie": {
+            "name": "Tierempathie",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Der Held kann Bennys für Tiere unter seiner Kontrolle ausgeben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tiermeister": {
+            "name": "Tiermeister",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "WIL W8"
+            ],
+            "beschreibung": "Tiere mögen deinen Helden und er hat eine Art von Haustier.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gefolgsleute": {
+            "name": "Gefolgsleute",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "WC"
+            ],
+            "beschreibung": "Der Held hat fünf Gefolgsleute.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Handlanger": {
+            "name": "Handlanger",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "WC"
+            ],
+            "beschreibung": "Der Charakter erhält einen Wildcard-Handlanger.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Profi": {
+            "name": "Profi",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [],
+            "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Experte": {
+            "name": "Experte",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Profi"
+            ],
+            "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen weiteren Schritt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meister": {
+            "name": "Meister",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Experte"
+            ],
+            "beschreibung": "Der Wildcard-Würfel des Charakters für die Eigenschaft ist ein W10.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Waffenmeister": {
+            "name": "Waffenmeister",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Kämpfen W12"
+            ],
+            "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W8.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meister aller Waffen": {
+            "name": "Meister aller Waffen",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Waffenmeister"
+            ],
+            "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W10.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zäh wie Leder": {
+            "name": "Zäh wie Leder",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Konstitution W8"
+            ],
+            "beschreibung": "Der Held kann vier Wunden einstecken, ehe er Ausgeschaltet ist.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zäher als Leder": {
+            "name": "Zäher als Leder",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Zäh wie Leder",
+                "KON W12"
+            ],
+            "beschreibung": "Der Held kann fünf Wunden einstecken, ehe er Ausgeschaltet ist.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Behände": {
+            "name": "Behände",
+            "kategorie": "Barbar",
+            "rang": "A",
+            "voraussetzungen": [
+                "Barbar"
+            ],
+            "beschreibung": "Bewegungsweite +2.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kampfrausch": {
+            "name": "Kampfrausch",
+            "kategorie": "Barbar",
+            "rang": "A",
+            "voraussetzungen": [
+                "Barbar"
+            ],
+            "beschreibung": "Der Barbar kann freiwillig in einen Kampfrausch verfallen. Nach Angeschlagen oder Wunde: Rücksichtslose Angriffe erzwungen, +1 Würfeltyp Stärke, +2 Robustheit, ignoriere eine Stufe Wundabzüge. Endet nach 5 Runden mit Erschöpfung oder Verstandsprobe mit -2.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Scharfzüngig": {
+            "name": "Scharfzüngig",
+            "kategorie": "Barde",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Barde)"
+            ],
+            "beschreibung": "Der Barde kann Darbietung statt Provozieren verwenden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bindung mit der Natur": {
+            "name": "Bindung mit der Natur",
+            "kategorie": "Druide",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Druide)"
+            ],
+            "beschreibung": "Der Druide kann ein Tier beschwören, das als sein Begleiter dient.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Naturgespür": {
+            "name": "Naturgespür",
+            "kategorie": "Druide",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Druide)"
+            ],
+            "beschreibung": "-2 auf Überreden und Einschüchtern in der Stadt, +2 in der Wildnis.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kriegerische Anpassungsfähigkeit": {
+            "name": "Kriegerische Anpassungsfähigkeit",
+            "kategorie": "Kämpfer",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfer"
+            ],
+            "beschreibung": "Einmal pro Begegnung kann der Kämpfer als begrenzte freie Aktion die Vorteile eines Kampftalents erhalten. Er muss alle Voraussetzungen erfüllen, und die Vorteile enden nach fünf Runden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Energie fokussieren": {
+            "name": "Energie fokussieren",
+            "kategorie": "Kleriker",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Kleriker)"
+            ],
+            "beschreibung": "Der Kleriker kann die Macht Heilung auf eine Entfernung gleich seiner Willenskraft wirken. Er erhält außerdem den Machtmodifikator Zusätzlicher Empfänger, sodass er für jeweils 1 Machtpunkt nahe Verbündete heilen kann.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Arkane Verbindung": {
+            "name": "Arkane Verbindung",
+            "kategorie": "Magier",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Magier)"
+            ],
+            "beschreibung": "Der Magier wählt eine Arkane Verbindung: einen Gegenstand (+1 auf Zaubern) oder einen Vertrauten (siehe Regeln).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schule": {
+            "name": "Schule",
+            "kategorie": "Magier",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Magier)"
+            ],
+            "beschreibung": "Der Magier wählt eine Schule, die bestimmt, auf welche Arten von Mächten er sich spezialisiert.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Betäubende Fäuste": {
+            "name": "Betäubende Fäuste",
+            "kategorie": "Mönch",
+            "rang": "A",
+            "voraussetzungen": [
+                "Mönch"
+            ],
+            "beschreibung": "Bei einer Steigerung beim Kämpfen-Wurf kann der Mönch einen Feind betäuben oder einen Verursacher machen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Beweglichkeit": {
+            "name": "Beweglichkeit",
+            "kategorie": "Mönch",
+            "rang": "A",
+            "voraussetzungen": [
+                "Mönch"
+            ],
+            "beschreibung": "Der Mönch ist schnell und wendig und erhält +1 auf Sprint und Ausweichen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kämpferische Disziplin": {
+            "name": "Kämpferische Disziplin",
+            "kategorie": "Mönch",
+            "rang": "A",
+            "voraussetzungen": [
+                "Mönch"
+            ],
+            "beschreibung": "Der Mönch erhält +1 Robustheit, wenn er keine Rüstung trägt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Waffenloser Schlag": {
+            "name": "Waffenloser Schlag",
+            "kategorie": "Mönch",
+            "rang": "A",
+            "voraussetzungen": [
+                "Mönch"
+            ],
+            "beschreibung": "Der Mönch erhält +1 auf Kampfwürfe und verursacht STÄ+W4 Schaden bei waffenlosen Angriffen. Dieser Schadenswürfel steigt mit dem Rang.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Böses Entdecken": {
+            "name": "Böses Entdecken",
+            "kategorie": "Paladin",
+            "rang": "A",
+            "voraussetzungen": [
+                "Paladin"
+            ],
+            "beschreibung": "Als freie Aktion kann der Paladin eine Wahrnehmungsprobe ablegen, um böse übernatürliche Kreaturen oder Charaktere in einer Entfernung von 5'' (10 Metern) zu entdecken.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Böses Niederstrecken": {
+            "name": "Böses Niederstrecken",
+            "kategorie": "Paladin",
+            "rang": "A",
+            "voraussetzungen": [
+                "Paladin"
+            ],
+            "beschreibung": "Einmal pro Begegnung erhält der Paladin eine freie Wiederholung bei allen Angriffswürfen gegen einen gewählten bösen Gegner.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Hinterhältiger Angriff": {
+            "name": "Hinterhältiger Angriff",
+            "kategorie": "Schurke",
+            "rang": "A",
+            "voraussetzungen": [
+                "Schurke"
+            ],
+            "beschreibung": "Der Schurke addiert +W6 auf den Schaden, wenn er einen Überraschungsangriff gegen ein Ziel durchführen kann und das Opfer verwundbar ist. Dies gilt für Angriffe mit Athletik (Werfen), Kämpfen oder Schießen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wildnis durchqueren": {
+            "name": "Wildnis durchqueren",
+            "kategorie": "Waldläufer",
+            "rang": "A",
+            "voraussetzungen": [
+                "Waldläufer"
+            ],
+            "beschreibung": "Der Waldläufer ignoriert Abzüge für Schwieriges Gelände in der Wildnis.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Blutlinie": {
+            "name": "Blutlinie",
+            "kategorie": "Zauberer",
+            "rang": "A",
+            "voraussetzungen": [
+                "AH (Zauberer)"
+            ],
+            "beschreibung": "Der Zauberer muss eine Blutlinie wählen (siehe Seite 69). Bei der Beschreibung jeder Blutlinie findest du auch die zusätzliche Spezialfähigkeit, die du erhältst, wenn du das Talent Mächtige Blutlinie wählst.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gemeinsamer Angriff": {
+            "name": "Gemeinsamer Angriff",
+            "kategorie": "Anführer",
+            "rang": "V",
+            "voraussetzungen": [
+                "VER W8",
+                "Anführer"
+            ],
+            "beschreibung": "Erlaubt Verbündeten, begrenzte Aktionen und begrenzte freie Aktionen einmal zusätzlich pro Runde zu nutzen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Abprallende Zauber": {
+            "name": "Abprallende Zauber",
+            "kategorie": "Macht",
+            "rang": "V",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Leite den Zauber des Helden auf einen Gegner um, falls das ursprüngliche Ziel dem Zauber widersteht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Störende Zauber": {
+            "name": "Störende Zauber",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Die Zauber dieses Charakters erschweren es Gegnern, Mystische Kräfte und Angeborene Kräfte zu aktivieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schlachtherold": {
+            "name": "Schlachtherold",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kavalier oder Paladin",
+                "Anführer",
+                "Einschüchtern W4",
+                "Überreden W6"
+            ],
+            "beschreibung": "Inspirierender Befehl: Verleiht den Verbündeten des Helden erhöhte Kampffähigkeiten im Kampf.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schlachtherold II": {
+            "name": "Schlachtherold II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Schlachtherold"
+            ],
+            "beschreibung": "Stimme der Autorität: Verleiht Verbündeten eines der Kampftalente dieses Charakters.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schlachtherold III": {
+            "name": "Schlachtherold III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Schlachtherold II"
+            ],
+            "beschreibung": "Letztes Gefecht: Bringe Verbündete vom Rande des Todes zurück.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heiliger Verteidiger": {
+            "name": "Heiliger Verteidiger",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kanalisieren",
+                "Okkultismus W6"
+            ],
+            "beschreibung": "Stigmata: Der Charakter erhält einen Bonus auf Heilungsproben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heiliger Verteidiger II": {
+            "name": "Heiliger Verteidiger II",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Heiliger Verteidiger"
+            ],
+            "beschreibung": "Blutfeuer: Der Schaden der Waffe dieses Charakters wird erhöht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heiliger Verteidiger III": {
+            "name": "Heiliger Verteidiger III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Heiliger Verteidiger II"
+            ],
+            "beschreibung": "Blutregen: Die Stigmata des Helden verursachen Schaden bei Gegnern.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Horizontwanderer": {
+            "name": "Horizontwanderer",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Überleben W6"
+            ],
+            "beschreibung": "Geländemeisterschaft: Unterstützt Verbündete in einem bestimmten Geländetyp. Erhält bevorzugtes Gelände.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Horizontwanderer II": {
+            "name": "Horizontwanderer II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Horizontwanderer"
+            ],
+            "beschreibung": "Geländedominanz: Erhält besondere Fähigkeiten basierend auf bevorzugten Geländetypen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisteralchemist": {
+            "name": "Meisteralchemist",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Mutagene"
+            ],
+            "beschreibung": "Mutagene Form: Verwandele dich in ein Alter Ego mit verbesserten Fähigkeiten. Gewährt Mutieren-Fähigkeit.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisteralchemist II": {
+            "name": "Meisteralchemist II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Meisteralchemist"
+            ],
+            "beschreibung": "Brutalität: Verursache +2 Schaden mit Nahkampfangriffen und natürlichen Angriffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisteralchemist III": {
+            "name": "Meisteralchemist III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Meisteralchemist II"
+            ],
+            "beschreibung": "Fortgeschrittene Mutagene: Erhalte eine einzigartige Fähigkeit in mutagener Form.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterspion": {
+            "name": "Meisterspion",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Aufmerksamkeit W6",
+                "Auftreten W6",
+                "Überreden W8"
+            ],
+            "beschreibung": "Meister der Verkleidung: Reduziert den Malus für das Verkleiden als Völker mit anderer Größe, anderem Alter oder Geschlecht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterspion II": {
+            "name": "Meisterspion II",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Meisterspion"
+            ],
+            "beschreibung": "Oberflächliches Wissen: Ignoriert Mali für verstandbasierte Fertigkeitsproben, die die Tarnidentität betreffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterspion III": {
+            "name": "Meisterspion III",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Meisterspion II"
+            ],
+            "beschreibung": "Annahme: Werde unsichtbar für Wahrsagungszauber und Gedankenlesen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Naturwächter": {
+            "name": "Naturwächter",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Tiermeister",
+                "Glaube W6 oder MP",
+                "Überleben W4"
+            ],
+            "beschreibung": "Überlebenskünstler: Parade +1, erhält eine kostenlose Wiederholung auf Überleben- und Aufmerksamkeit-Proben im gewählten Gelände und ignoriert Schwieriges Gelände sowie Gefahren durch natürliche Elemente.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Naturwächter II": {
+            "name": "Naturwächter II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Naturwächter"
+            ],
+            "beschreibung": "Eisenpranke: Teile Zaubereffekte mit Begleitern.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Naturwächter III": {
+            "name": "Naturwächter III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Naturwächter II"
+            ],
+            "beschreibung": "Begleiterseele: Erhalte übernatürliche Fähigkeiten mit dem Begleiter dieses Charakters.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zornprophet": {
+            "name": "Zornprophet",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (Wunder oder Orakel)",
+                "Kampfrausch",
+                "Okkultismus W4"
+            ],
+            "beschreibung": "Zornzauberer: Zauber, die im Kampfrausch gewirkt werden, sind schwerer zu widerstehen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zornprophet II": {
+            "name": "Zornprophet II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Zornprophet"
+            ],
+            "beschreibung": "Zornzauberstärke: Zauber, die auf den Zaubernden zielen, sind begrenzte freie Aktionen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zornprophet III": {
+            "name": "Zornprophet III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Zornprophet II"
+            ],
+            "beschreibung": "Geisterkrieger: Der Zornprophet ist besser darin, Feenwesen, Externare und Untote zu töten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unbeugsamer Verteidiger": {
+            "name": "Unbeugsamer Verteidiger",
+            "kategorie": "Prestige",
+            "rang": "F",
+            "voraussetzungen": [
+                "Nerven aus Stahl",
+                "Keine Rüstungsbeschränkung oder Behindernde Rüstung"
+            ],
+            "beschreibung": "Verteidigungshaltung: Der Charakter wird zu einem Bollwerk der Verteidigung und erhöht seine Attribute auf Kosten der Bewegungsfreiheit.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unbeugsamer Verteidiger II": {
+            "name": "Unbeugsamer Verteidiger II",
+            "kategorie": "Prestige",
+            "rang": "V",
+            "voraussetzungen": [
+                "Unbeugsamer Verteidiger"
+            ],
+            "beschreibung": "Letztes Wort: Führe einen Angriff aus, bevor du kampfunfähig wirst. Behandle den Angriff, als hättest du einen Joker erhalten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unbeugsamer Verteidiger III": {
+            "name": "Unbeugsamer Verteidiger III",
+            "kategorie": "Prestige",
+            "rang": "H",
+            "voraussetzungen": [
+                "Unbeugsamer Verteidiger II"
+            ],
+            "beschreibung": "Bollwerk: Erhöhungen verursachen nur zusätzlichen Schaden gegen den Verteidiger, lösen aber keine anderen Effekte wie Betäubender Schlag aus.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schnelle Unterstützung": {
+            "name": "Schnelle Unterstützung",
+            "kategorie": "Sozial",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W8"
+            ],
+            "beschreibung": "Unterstütze Verbündete als begrenzte freie Aktion, wenn deine Aktionskarte eine Bildkarte oder ein Joker ist.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ducken und Deckung": {
+            "name": "Ducken und Deckung",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [],
+            "beschreibung": "Der Charakter und ein Verbündeter können die Würfe des jeweils anderen beim Ausweichen nutzen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zertrümmern": {
+            "name": "Zertrümmern",
+            "kategorie": "Übersinnlich",
+            "rang": "A",
+            "voraussetzungen": [
+                "Halb-Ork",
+                "STÄ W10"
+            ],
+            "beschreibung": "Der Charakter kann Schadenswürfe explodieren lassen, wenn er versucht, Objekte zu zerstören.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tödliche Darbietung": {
+            "name": "Tödliche Darbietung",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Barde-Talente"
+            ],
+            "beschreibung": "Nutze Auftreten, um Zuhörer zu Betäuben oder Kampfunfähig zu machen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heiliger Champion": {
+            "name": "Heiliger Champion",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Paladin-Talente"
+            ],
+            "beschreibung": "+2 Robustheit und verbanne Externare bei Böses-Niederstrecken-Angriffen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Heimvorteil": {
+            "name": "Heimvorteil",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "WIL W8",
+                "Mindestens zwei Druiden-Talente"
+            ],
+            "beschreibung": "Gib einen Benny aus, um alle Machtpunkte wiederherzustellen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meisterangriff": {
+            "name": "Meisterangriff",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Schurken-Talente"
+            ],
+            "beschreibung": "Hinterhältige Angriffe dieses Charakters können lähmen, töten oder Gegner in Schlaf versetzen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Mystischer Jäger": {
+            "name": "Mystischer Jäger",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [],
+            "beschreibung": "Ignoriere Unaufhaltsam bei einer Bildkarte und hindere Gegner daran, die Angriffe dieses Charakters zu absorbieren, wenn du einen Joker hast.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Perfekter Körper": {
+            "name": "Perfekter Körper",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Mönch-Talente"
+            ],
+            "beschreibung": "Erhalte +4 Robustheit und werde zu einem Externar.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Schon gesehen": {
+            "name": "Schon gesehen",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Waldläufer-Talente"
+            ],
+            "beschreibung": "Der Waldläufer wird gegenüber Fähigkeiten seiner bevorzugten Feinde nahezu unempfindlich.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Einzigartige Blutlinie": {
+            "name": "Einzigartige Blutlinie",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Zauberer-Talente"
+            ],
+            "beschreibung": "Erhalte eine zusätzliche fortgeschrittene Blutlinie.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unaufhaltsame Wut": {
+            "name": "Unaufhaltsame Wut",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Barbar-Talente"
+            ],
+            "beschreibung": "Erhalte Unaufhaltsam während des Kampfrausches.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Veteran des ewigen Krieges": {
+            "name": "Veteran des ewigen Krieges",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Kämpfer-Talente"
+            ],
+            "beschreibung": "Gegner erhalten keinen Bonus für Rücksichtslose Angriffe gegen diesen Helden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gut vorbereitet": {
+            "name": "Gut vorbereitet",
+            "kategorie": "Legendär",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Magier-Talente"
+            ],
+            "beschreibung": "Wirke einen Zauber als begrenzte freie Aktion für +1 Machtpunkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wasserabstammung": {
+            "name": "Wasserabstammung",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Undinen"
+            ],
+            "beschreibung": "Gewährt die Fähigkeit Wasseratmung und schnellere Bewegung im Wasser.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kletterranke": {
+            "name": "Kletterranke",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Weinranken-Leshy",
+                "STÄ W6"
+            ],
+            "beschreibung": "Gewährt die Kletterer-Fähigkeit (Wandkletterer).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Elementare Reise": {
+            "name": "Elementare Reise",
+            "kategorie": "Hintergrund",
+            "rang": "F",
+            "voraussetzungen": [
+                "Ifrits oder Oreads oder Sylphen oder Undinen"
+            ],
+            "beschreibung": "Gewährt die Fähigkeit, zur Ebene zu reisen, die eng mit deiner Blutlinie verbunden ist. Du bist immun gegen die negativen Effekte dieser Ebene.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Innerer Atem": {
+            "name": "Innerer Atem",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Sylphen"
+            ],
+            "beschreibung": "Dein Held muss nicht mehr atmen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kudzu-Ringer": {
+            "name": "Kudzu-Ringer",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Weinranken-Leshy",
+                "GES W6",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Behindert die Sicht eines Gegners beim Ringen und erschwert diesem das Ausführen von Aktionen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Oread-Gräber": {
+            "name": "Oread-Gräber",
+            "kategorie": "Hintergrund",
+            "rang": "A",
+            "voraussetzungen": [
+                "Oreads"
+            ],
+            "beschreibung": "Gewährt die Fähigkeit, unter der Erde zu graben.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Versengende Waffe": {
+            "name": "Versengende Waffe",
+            "kategorie": "Hintergrund",
+            "rang": "F",
+            "voraussetzungen": [
+                "Ifrits"
+            ],
+            "beschreibung": "Waffenlose Angriffe verursachen Feuerschaden. Kann auf Metallwaffen übertragen werden.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Flügel der Luft": {
+            "name": "Flügel der Luft",
+            "kategorie": "Hintergrund",
+            "rang": "F",
+            "voraussetzungen": [
+                "Sylphen"
+            ],
+            "beschreibung": "Gewährt die Fähigkeit zu fliegen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Revolverheld": {
+            "name": "Revolverheld",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W6",
+                "Schießen W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (leicht), Taten, Schneid.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_leicht"
+            ]
+        },
+        "Zielen (Revolverheld)": {
+            "name": "Zielen (Revolverheld)",
+            "kategorie": "Revolverheld",
+            "rang": "F",
+            "voraussetzungen": [
+                "Revolverheld"
+            ],
+            "beschreibung": "Gib einen Benny aus, um einen Bonus auf gezielte Angriffe zu erhalten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Todesschuss (Revolverheld)": {
+            "name": "Todesschuss (Revolverheld)",
+            "kategorie": "Revolverheld",
+            "rang": "V",
+            "voraussetzungen": [
+                "Revolverheld"
+            ],
+            "beschreibung": "Gib einen Benny aus, um den Schusswaffenschaden zu verdoppeln.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Betrug des Todes": {
+            "name": "Betrug des Todes",
+            "kategorie": "Revolverheld",
+            "rang": "H",
+            "voraussetzungen": [
+                "Revolverheld"
+            ],
+            "beschreibung": "Gib einen Benny aus, um das Wundemaximum zu reduzieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Todesschütze": {
+            "name": "Todesschütze",
+            "kategorie": "Revolverheld",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Revolverheld-Talente"
+            ],
+            "beschreibung": "Gib einen Benny aus, um ein angeschlagenes oder verwundetes Ziel zu einer Konstitutionsprobe zu zwingen oder kampfunfähig zu machen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Magus": {
+            "name": "Magus",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "VER W6",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Arkaner Hintergrund (Magus), Rüstungsbehinderung (leicht), Magus-Arkana, Zauberbücher, Zauberhieb.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Behindernde Rüstung_leicht"
+            ]
+        },
+        "Zauberstab-Meisterschaft": {
+            "name": "Zauberstab-Meisterschaft",
+            "kategorie": "Magus",
+            "rang": "F",
+            "voraussetzungen": [
+                "Magus"
+            ],
+            "beschreibung": "Der Magus kann einen Zauberstab für Zauberhiebe nutzen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zaubererinnerung": {
+            "name": "Zaubererinnerung",
+            "kategorie": "Magus",
+            "rang": "V",
+            "voraussetzungen": [
+                "Magus"
+            ],
+            "beschreibung": "Stelle alle verlorenen Machtpunkte wieder her.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gegenschlag (Magus)": {
+            "name": "Gegenschlag (Magus)",
+            "kategorie": "Magus",
+            "rang": "H",
+            "voraussetzungen": [
+                "Magus"
+            ],
+            "beschreibung": "Erhalte einen freien Angriff gegen einen Gegner, der einen Zauber wirkt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wahrer Magus": {
+            "name": "Wahrer Magus",
+            "kategorie": "Magus",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Magus-Talente"
+            ],
+            "beschreibung": "Ignoriere Arkane Resistenz und Verbesserte Arkane Resistenz.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ninja": {
+            "name": "Ninja",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "Athletik W6",
+                "Heimlichkeit W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (leicht), Mystische Kräfte (Ninja).",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_leicht"
+            ]
+        },
+        "Keine Spur": {
+            "name": "Keine Spur",
+            "kategorie": "Ninja",
+            "rang": "F",
+            "voraussetzungen": [
+                "Ninja"
+            ],
+            "beschreibung": "Es ist schwerer, den Ninja zu verfolgen und zu identifizieren.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Meister-Ninja-Trick": {
+            "name": "Meister-Ninja-Trick",
+            "kategorie": "Ninja",
+            "rang": "V",
+            "voraussetzungen": [
+                "Ninja"
+            ],
+            "beschreibung": "Gewährt zusätzliche Mystische Kräfte.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Ki-Ladung": {
+            "name": "Ki-Ladung",
+            "kategorie": "Ninja",
+            "rang": "H",
+            "voraussetzungen": [
+                "Ninja"
+            ],
+            "beschreibung": "Lade eine Waffe mit mystischer Energie auf, um mehr Schaden zu verursachen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Unsichtbare Klinge": {
+            "name": "Unsichtbare Klinge",
+            "kategorie": "Ninja",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Ninja-Talente"
+            ],
+            "beschreibung": "Gewährt leichter das Überraschungsmoment gegen einen Gegner.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wandler": {
+            "name": "Wandler",
+            "kategorie": "Klasse",
+            "rang": "A",
+            "voraussetzungen": [
+                "Kämpfen W6",
+                "Überleben W6"
+            ],
+            "beschreibung": "Rüstungsbeschränkung (mittelschwer), Defensive Instinkte, Geheimsprache, Wandler-Aspekt, Wandlerklauen, Wildnisschritt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "auto_handicaps": [
+                "Rüstungsbeschränkung_mittelschwer"
+            ]
+        },
+        "Chimären-Aspekt": {
+            "name": "Chimären-Aspekt",
+            "kategorie": "Wandler",
+            "rang": "F",
+            "voraussetzungen": [
+                "Wandler"
+            ],
+            "beschreibung": "Gewährt einen zusätzlichen Aspekt.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Wandler-Tiergestalt": {
+            "name": "Wandler-Tiergestalt",
+            "kategorie": "Wandler",
+            "rang": "V",
+            "voraussetzungen": [
+                "Wandler"
+            ],
+            "beschreibung": "Verwandele dich in die Hauptform des Aspekts.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verbesserte Form (Wandler)": {
+            "name": "Verbesserte Form (Wandler)",
+            "kategorie": "Wandler",
+            "rang": "H",
+            "voraussetzungen": [
+                "Wandler"
+            ],
+            "beschreibung": "Werde eine mächtigere Version des Wandler-Aspekts.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verbesserte Defensive Instinkte": {
+            "name": "Verbesserte Defensive Instinkte",
+            "kategorie": "Wandler",
+            "rang": "L",
+            "voraussetzungen": [
+                "Mindestens zwei Wandler-Talente"
+            ],
+            "beschreibung": "Nutze Willenskraft und Konstitution zur Berechnung der Robustheit.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Gebrandmarkt für Vergeltung": {
+            "name": "Gebrandmarkt für Vergeltung",
+            "kategorie": "Inquisitor",
+            "rang": "V",
+            "voraussetzungen": [
+                "Inquisitor",
+                "Bann"
+            ],
+            "beschreibung": "Teile die Vorteile von Bann mit Verbündeten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Kranich-Stil": {
+            "name": "Kranich-Stil",
+            "kategorie": "Mönch",
+            "rang": "V",
+            "voraussetzungen": [
+                "Mönch"
+            ],
+            "beschreibung": "Greife einen Gegner an, der den Charakter beim Verteidigen treffen würde.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Erweiterter Aspekt": {
+            "name": "Erweiterter Aspekt",
+            "kategorie": "Wandler",
+            "rang": "A",
+            "voraussetzungen": [
+                "Wandler"
+            ],
+            "beschreibung": "Gewährt zusätzliche 15 Minuten in der Nebenform des Wandlers.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Extra Schneid": {
+            "name": "Extra Schneid",
+            "kategorie": "Revolverheld",
+            "rang": "F",
+            "voraussetzungen": [
+                "Revolverheld"
+            ],
+            "beschreibung": "Gewährt mehr als einen Benny zurück pro Kampf durch Schneid.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Hinterhalt-Gespür": {
+            "name": "Hinterhalt-Gespür",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Aufmerksamkeit W8"
+            ],
+            "beschreibung": "Würfle auf Aufmerksamkeit, um zu verhindern, dass jemand deinen Helden überrascht.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Bestienmeister-Stil": {
+            "name": "Bestienmeister-Stil",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "WIL W6",
+                "Tiermeister oder ähnliche Fähigkeit"
+            ],
+            "beschreibung": "Der Bestienmeister kann mit seinem tierischen Begleiter zusammenarbeiten, um zu verhindern, dass dieser Schaden erleidet.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Körperschild": {
+            "name": "Körperschild",
+            "kategorie": "Kampf",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8",
+                "Kämpfen W6"
+            ],
+            "beschreibung": "Benutze einen gepackten Gegner als Deckung.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Würgegriff": {
+            "name": "Würgegriff",
+            "kategorie": "Kampf",
+            "rang": "V",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Schalte einen Gegner bewusstlos, anstatt ihn weiter zu schädigen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verstärkte Rüstungsausbildung": {
+            "name": "Verstärkte Rüstungsausbildung",
+            "kategorie": "Kampf",
+            "rang": "F",
+            "voraussetzungen": [
+                "Kämpfen W8"
+            ],
+            "beschreibung": "Zerstöre die Rüstung oder den Schild des Trägers, um eine Erhöhung gegen ihn zu verhindern.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Fluchtweg": {
+            "name": "Fluchtweg",
+            "kategorie": "Anführer",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W6",
+                "Anführer"
+            ],
+            "beschreibung": "Verhindere freie Angriffe, wenn Verbündete sich aus dem Nahkampf mit jemandem zurückziehen, der mit dem Helden kämpft.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verseuchende Zauber": {
+            "name": "Verseuchende Zauber",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Fügt dem Ziel einen Zauberfluch zu.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Zerstörerische Bannung": {
+            "name": "Zerstörerische Bannung",
+            "kategorie": "Macht",
+            "rang": "V",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Beim Bannen einer Macht wird der Gegner abgelenkt, bei einer Erhöhung zusätzlich verletzlich.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Göttliche Einmischung": {
+            "name": "Göttliche Einmischung",
+            "kategorie": "Macht",
+            "rang": "H",
+            "voraussetzungen": [
+                "AH (Kleriker, Orakel, Wunder)"
+            ],
+            "beschreibung": "Gib Machtpunkte aus, um einen Gegner zu zwingen, einen Angriffswurf mit einem Malus zu wiederholen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Entwickelter Vertrauter": {
+            "name": "Entwickelter Vertrauter",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "VER W6",
+                "WIL W6",
+                "AH (beliebig)",
+                "Vertrauter"
+            ],
+            "beschreibung": "Der Vertraute deines Charakters erhält eine Entwicklung aus der Eidolon-Entwicklungsliste.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Verbesserter Vertrauter": {
+            "name": "Verbesserter Vertrauter",
+            "kategorie": "Macht",
+            "rang": "F",
+            "voraussetzungen": [
+                "AH (beliebig)",
+                "Vertrauter"
+            ],
+            "beschreibung": "Gewährt einen mächtigeren Vertrauten.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Durchdringender Zauber": {
+            "name": "Durchdringender Zauber",
+            "kategorie": "Macht",
+            "rang": "V",
+            "voraussetzungen": [
+                "AH (beliebig)"
+            ],
+            "beschreibung": "Reduziert den Malus durch Arkane Resistenz.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Feldreparatur": {
+            "name": "Feldreparatur",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "Reparieren W8"
+            ],
+            "beschreibung": "Repariere Objekte im Feld schnell zum halben Preis.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Fallensteller": {
+            "name": "Fallensteller",
+            "kategorie": "Experte",
+            "rang": "A",
+            "voraussetzungen": [
+                "GES W8"
+            ],
+            "beschreibung": "Gewährt die Fähigkeit, tödliche Fallen zu bauen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
+        },
+        "Tödlicher Fallensteller": {
+            "name": "Tödlicher Fallensteller",
+            "kategorie": "Experte",
+            "rang": "F",
+            "voraussetzungen": [
+                "Fallensteller"
+            ],
+            "beschreibung": "Gewährt einen freien Bonus beim Bau von Fallen.",
+            "neue_maechte": 0,
+            "machtpunkte": 0,
+            "ausgewaehlt": false,
+            "aktiv": true
         }
-      }
     },
-    "Zwerg": {
-      "name": "Zwerg",
-      "handicaps": [
-        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Eiserne Konstitution (+1 beim Widerstand gegen Gift, +1 zum Widerstand oder zur Erholung von Mächten)",
-        "Steingespür (+2 auf Wahrnehmungsproben bei ungewöhnlich bearbeitetem Stein innerhalb von 3m)",
-        "Widerstandsfähig (Konstitution W6 statt W4, Maximum W12+1, Stärke um einen Würfel höher für Belastung und Mindeststärke)"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Zwergisch"
-      ],
-      "altersspanne": "Erwachsen mit 45, Alt mit 188, maximales Alter 250–450",
-      "groesse_maennlich": "1,20-1,35m, 74-93kg (Durchschnitt 1,30m, 84kg)",
-      "groesse_weiblich": "1,15-1,30m, 61-80kg (Durchschnitt 1,20m, 75kg)",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Konstitution": 2
+    "handicaps": {
+        "Ahnen-Schwäche_leicht": {
+            "name": "Ahnen-Schwäche",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Einige Familien können ihre Abstammungslinie weit genug zurückverfolgen, um einen Vorfahren von einer anderen Ebene zu entdecken. Wähle eines: Feuer, Kälte oder Elektrizität. Der Charakter erleidet +2 Schaden durch Angriffe dieses Typs.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": -1,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Langsam_leicht",
-          "Verringerte Bewegungsweite (Schritt)"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "eiserne_konstitution": true,
-          "steingespür": true,
-          "staerke_bonus_traglast": true
+        "Ahnen-Schwäche_schwer": {
+            "name": "Ahnen-Schwäche",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Einige Familien können ihre Abstammungslinie weit genug zurückverfolgen, um einen Vorfahren von einer anderen Ebene zu entdecken. Wähle eines: Feuer, Kälte oder Elektrizität. Der Charakter erleidet +4 Schaden durch Angriffe dieses Typs.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Ifrits": {
-      "name": "Ifrits",
-      "handicaps": [],
-      "talente": [],
-      "besonderheiten": [
-        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Elementarzauberei (Ifrit-Zauberer mit dem Talent Elementarblut [Feuer] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
-        "Angeborene Macht: Ausbruch / Brennende Hände (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
-        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-        "Alternativfähigkeit – Wüstenspiegelung: +1 auf Proben gegen Hunger und Durst; ersetzt Elementarzauberei",
-        "Alternativfähigkeit – Efrit-Magie: Angeborene Macht wird Wachsen/Schrumpfen (selbst, zwei Größenstufen) statt Ausbruch; modifiziert Angeborene Macht",
-        "Alternativfähigkeit – Feuer im Blut: Schnelle Regeneration für 2 Runden wenn durch Feuer Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Beweglich"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Ignanisch"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); oft spitze Ohren, rote oder gefleckte Hörner, flammenartiges Haar",
-      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit messingfarbener Haut oder anthrazitfarbenen Schuppen",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2
+        "Akribisch": {
+            "name": "Akribisch",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dein Held plant und bereitet alles bis ins Detail vor und improvisiert schlecht, wenn die Dinge nicht nach Plan laufen. Dieser Charakter erleidet –4 auf ungelernte Fertigkeitsproben anstelle der üblichen –2.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "elementarzauberei_feuer": true,
-          "angeborene_macht_feuer": true,
-          "heimischer_aussenseiter": true
+        "Alt": {
+            "name": "Alt",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–1 auf Bewegungsweite, Sprint-Würfel, Geschicklichkeit, Stärke und Konstitution. Held erhält 5 zusätzliche Fertigkeitspunkte.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Oreads": {
-      "name": "Oreads",
-      "handicaps": [
-        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Stark (Stärke W6 statt W4, Maximum W12+1)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Granitene Haut (Felsige Wucherungen gewähren +2 Rüstung)",
-        "Elementarzauberei (Oread-Zauberer mit dem Talent Elementarblut [Erde] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
-        "Angeborene Macht: Blitz / Magischer Stein (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
-        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-        "Alternativfähigkeit – Eisenwuchs: 1×/Tag kann ein berührtes nicht-magisches Eisen- oder Stahlstück zu einem Gegenstand bis 4,5 kg wachsen (10 Minuten); ersetzt Angeborene Macht",
-        "Alternativfähigkeit – Stein im Blut (Schnell): Schnelle Regeneration für 2 Runden wenn durch Säure Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Stark; schließt Stein im Blut (Langsam) aus",
-        "Alternativfähigkeit – Stein im Blut (Langsam): Langsame Regeneration wenn durch Säure Erschüttert oder Verwundet; ersetzt Elementarzauberei; schließt Stein im Blut (Schnell) aus",
-        "Alternativfähigkeit – Tückische Erde: 1×/Tag kann der Oread eine große Schablone (Reichweite Verstand) in schweres Gelände verwandeln (Erde, Stein oder Sand); Dauer in Minuten je nach Rang: Anfänger 1, Erfahren 2, Veteran 3, Held 4, Legendär 5; ersetzt Granitene Haut"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Terranisch"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut und Haar in steinigen Tönen (Schwarz, Braun, Grau, Weiß)",
-      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche mit glänzender Obsidian-Haut, Gesteinsvorsprüngen oder kristallinen Haarspitzen",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Stärke": 2
+        "Analphabet": {
+            "name": "Analphabet",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter kann nicht lesen oder schreiben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": -1,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Langsam_leicht",
-          "Verringerte Bewegungsweite (Schritt)"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "granit_haut": true,
-          "elementarzauberei_erde": true,
-          "angeborene_macht_erde": true,
-          "heimischer_aussenseiter": true
+        "Angetrieben_leicht": {
+            "name": "Angetrieben",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Sylphen": {
-      "name": "Sylphen",
-      "handicaps": [
-        "Zerbrechlich (-1 Robustheit)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Intelligent (Verstand W6 statt W4, Maximum W12+1)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Elementarzauberei (Sylph-Zauberer mit dem Talent Elementarblut [Luft] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
-        "Federfall (1×/Tag kann der Sylph jeden Schaden durch einen Fall verhindern)",
-        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-        "Alternativfähigkeit – Wie der Wind: Bewegungsweite +2; ersetzt Beweglich",
-        "Alternativfähigkeit – Himmelssprecher: Angeborene Macht Tierfreund mit Geistesreiter (Vögel und andere fliegende Tiere, 1×/Tag); ersetzt Elementarzauberei",
-        "Alternativfähigkeit – Sturm im Blut: Schnelle Regeneration für 2 Runden wenn durch Elektrizität Erschüttert oder Verwundet (max. 2 Wunden/Tag); ersetzt Intelligent"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Auranisch"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); blass und schlank, blaue spiralförmige Markierungen auf der Haut",
-      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); eine leichte Brise begleitet sie stets als Zeichen ihrer elementaren Abstammung",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2,
-          "Verstand": 2
+        "Angetrieben_schwer": {
+            "name": "Angetrieben",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Zerbrechlich"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "federfall": true,
-          "elementarzauberei_luft": true,
-          "heimischer_aussenseiter": true
+        "Angewohnheit_leicht": {
+            "name": "Angewohnheit",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Undinen": {
-      "name": "Undinen",
-      "handicaps": [
-        "Verringerte Stärke (-1 auf alle Stärkeproben)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Lebhaft (Willenskraft W6 statt W4, Maximum W12+1)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Elementarzauberei (Undinen-Zauberer mit dem Talent Elementarblut [Wasser] reduzieren die Ranganforderung für Fortgeschrittenes Elementarblut auf Veteran)",
-        "Anmutige Schwimmer (Können sich im Wasser stets mit ihrer vollen Bewegungsweite bewegen)",
-        "Angeborene Macht: Verheerung / Hydraulischer Stoß (Willenskraft zum Wirken, 1×/Tag; keine Machtmodifikatoren erlaubt)",
-        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-        "Alternativfähigkeit – Säureatem: Angeborene Macht wird Ausbruch (Säureatem) statt Verheerung; modifiziert Angeborene Macht",
-        "Alternativfähigkeit – Hydrierte Vitalität (Schnell): Schnelle Regeneration für 2 Runden wenn mind. 10 Min vollständig in Wasser untergetaucht (max. 2 Wunden/Tag); ersetzt Beweglich; schließt Hydrierte Vitalität (Langsam) aus",
-        "Alternativfähigkeit – Hydrierte Vitalität (Langsam): Langsame Regeneration wenn mind. 10 Min vollständig in Wasser untergetaucht; ersetzt Elementarzauberei; schließt Hydrierte Vitalität (Schnell) aus",
-        "Alternativfähigkeit – Wasserwahrnehmung: Blindwahrnehmung 10\"/20 Meter im Wasser durch Vibrationssinn; ersetzt Dunkelsicht"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Aquanisch"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); Haut in Türkis- bis Meeresgrüntönen, flossartige Ohren, Schwimmhäute an Händen und Füßen",
-      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); Augen immer hellblau, Haar etwas dunkler als die Hautfarbe",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2,
-          "Willenskraft": 2,
-          "Stärke": -1
+        "Angewohnheit_schwer": {
+            "name": "Angewohnheit",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Verringerte Stärke"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "anmutige_schwimmer": true,
-          "elementarzauberei_wasser": true,
-          "angeborene_macht_wasser": true,
-          "heimischer_aussenseiter": true
+        "Arm": {
+            "name": "Arm",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Halbiere das Startkapital, und der Charakter ist immer pleite.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Weinranken-Leshy": {
-      "name": "Weinranken-Leshy",
-      "handicaps": [
-        "Größe -1 (Reduzierte Größe und Robustheit um 1)",
-        "Verringerte Bewegungsweite (-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert)",
-        "Verringerte Fertigkeiten (Beginnen nicht mit W4 in Allgemeinwissen und Wahrnehmung – diese starten auf W4-2)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Lebhaft (Willenskraft W6 statt W4, Maximum W12+1)",
-        "Zäh (Konstitution W6 statt W4, Maximum W12+1)",
-        "Heimlich (Heimlichkeit W6 statt W4, Maximum W12+1)",
-        "Nachtsicht (Ignoriert alle Beleuchtungsabzüge)",
-        "Gestalt wandeln (Als eingeschränkte freie Aktion [Willenskraftprobe]: verwandelt sich in eine gesunde kleine Weinrebe oder zurück in die wahre Form)",
-        "Leshypflanze (Typus ist Pflanze statt Humanoid; keine normalen Pflanzenimmunitäten; kann mit Weinreben sprechen)",
-        "Üppiger Ausbruch (Beim Tod: Explosion mit großer Schablone; Pflanzenwesen in der Schablone heilen 1 Wunde; Gebiet wird für 24h zu schwerem Gelände, wenn die Umgebung Weinreben unterstützt)",
-        "Alternativfähigkeit – Weinrebe: 1×/Tag Macht Heilung wirken (Willenskraftprobe); ersetzt Heimlich",
-        "Alternativfähigkeit – Giftig: Als eingeschränkte freie Aktion können die Ranken mit mildem Gift belegt werden; der nächste unbewaffnete Treffer wirkt mildes Gift auf das Ziel; ersetzt Heimlich",
-        "Alternativfähigkeit – Sumpf-Leshy: Gewinnt Aquatisch; Nachtsicht wird durch Dunkelsicht (10\"/20 Meter) ersetzt; ändert Nachtsicht"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Sylvanisch"
-      ],
-      "altersspanne": "Unbekannt; als Pflanzenwesen kehrt der Geist beim Tod in die Natur zurück und kann einen neuen Körper bewohnen",
-      "groesse_maennlich": "Kleinwüchsig (~60-90cm, 10-20kg); Körper aus verflochtenen Ranken und Blättern, manchmal mit Blüten und Früchten",
-      "groesse_weiblich": "Kleinwüchsig (~60-90cm, 10-20kg); Gesicht aus Blättern mit runden Augen, kleinem Mund, ohne sichtbare Nase",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Willenskraft": 2,
-          "Konstitution": 2
+        "Arrogant": {
+            "name": "Arrogant",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Dominiert gerne seine Gegner, fordert den mächtigsten Feind im Kampf heraus.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": -1,
-        "fertigkeits_startboni": {
-          "Heimlichkeit": 2
+        "Außenseiter_leicht": {
+            "name": "Außenseiter",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "fertigkeits_startmalus": {
-          "Allgemeinwissen": -2,
-          "Wahrnehmung": -2
+        "Außenseiter_schwer": {
+            "name": "Außenseiter",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab. Bei einem schweren Handicap hat er keine Rechte oder leidet unter anderen schweren Konsequenzen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Klein",
-          "Langsam_leicht",
-          "Größe -1 (Reduzierte Größe und Robustheit)",
-          "Verringerte Bewegungsweite (Schritt)",
-          "Verringerte Fertigkeiten"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "gestalt_wandeln": true,
-          "leshy_pflanze": true,
-          "uppiger_ausbruch": true
+        "Befleckter Geist": {
+            "name": "Befleckter Geist",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Als Kind schloss ein Elternteil oder eine Autoritätsperson einen Pakt mit einem Teufelswesen und stahl dabei einen Teil der Lebenskraft des Charakters als Pfand. Unmittelbar nachdem ein Kampf endet, muss dieser Charakter einen Konstitutionswurf ablegen oder erleidet eine Erschöpfungsstufe. Diese Erschöpfung dauert an, bis der Charakter 24 Stunden ohne Kampf verbracht hat.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Aasimars": {
-      "name": "Aasimars",
-      "handicaps": [],
-      "talente": [],
-      "besonderheiten": [
-        "Lebhaft (Willenskraft W6 statt W4, Maximum W12+1)",
-        "Diplomatisch (Überreden W6 statt W4, Maximum W12+1)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Tageslicht (1×/Tag als eingeschränkte freie Aktion: geringes Licht als Angeborene Macht wirken)",
-        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-        "Alternativfähigkeit – Himmlischer Kreuzritter: Gewinnt Bevorzugter Feind (Außenseiter) wie das Waldläufer-Klassentalent; ersetzt Diplomatisch",
-        "Alternativfähigkeit – Erhöhter Widerstand: Gewinnt das Talent Arkaner Widerstand auch ohne Voraussetzungen; ersetzt Lebhaft",
-        "Alternativfähigkeit – Heiligenschein: Tageslicht erzeugt einen heiligenscheinförmigen Lichtkreis um den Kopf; bei aktivem Heiligenschein freie Wiederholung bei Testen gegen böse Kreaturen; ersetzt Dunkelsicht"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Himmlisch"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); häufig metallisch glänzendes Haar, juwelenförmige Augen oder schimmernder Teint",
-      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); manche besitzen einen leuchtenden goldenen Heiligenschein als sichtbares Zeichen ihrer himmlischen Abstammung",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Willenskraft": 2
+        "Behindernde Rüstung_jede": {
+            "name": "Behindernde Rüstung (jede)",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er jede Art von Rüstung trägt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {
-          "Überreden": 2
+        "Behindernde Rüstung_leicht": {
+            "name": "Behindernde Rüstung (leicht)",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er leichte oder schwerere Rüstung trägt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "auto_talente": [],
-        "auto_handicaps": [],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "tageslicht": true,
-          "heimischer_aussenseiter": true
+        "Behindernde Rüstung_mittelschwer": {
+            "name": "Behindernde Rüstung (mittelschwer)",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er mittelschwere oder schwerere Rüstung trägt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Katzenfolk": {
-      "name": "Katzenfolk",
-      "handicaps": [],
-      "talente": [],
-      "besonderheiten": [
-        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Nachtsicht (Ignoriert Abzüge für Düstere und Dunkle Beleuchtung)",
-        "Katzenglück (Freie Wiederholung bei fehlgeschlagenen Ausweichproben)",
-        "Sprinter (Sprintwürfel um einen Typ erhöht)",
-        "Alternativfähigkeit – Katzenkrallen: Natürliche Waffe, Stärke+W4 Schaden (Natürliche Waffen laut Pathfinder für Savage Worlds); ersetzt Beweglich",
-        "Alternativfähigkeit – Sicherer Fall: Landet stets auf den Füßen; reduziert Fallschaden um 1W6+1; ersetzt Sprinter",
-        "Alternativfähigkeit – Geruchssinn: Ignoriert bis zu 4 Punkte Abzüge bei Angriffen gegen durch magische Dunkelheit, Unsichtbarkeit o.ä. verborgene Gegner; ersetzt Nachtsicht"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Katzenfolk"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–100)",
-      "groesse_maennlich": "Zwischen Zwerg und Mensch (~1,30-1,65m, 45-65kg); schlanker Körper mit feinem Fell, Schlitzpupillen, Katzenohren und schlankem Schwanz",
-      "groesse_weiblich": "Zwischen Zwerg und Mensch (~1,25-1,60m, 40-58kg); einziehbare Krallen; Fell-, Haar- und Augenfarbe stark variierend",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2
+        "Beschämt_leicht": {
+            "name": "Beschämt",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [],
-        "spezielle_effekte": {
-          "nachtsicht": true,
-          "katzenglueck": true,
-          "sprinter": true
+        "Beschämt_schwer": {
+            "name": "Beschämt",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Dhampire": {
-      "name": "Dhampire",
-      "handicaps": [
-        "Lichtempfindlich (-1 auf Eigenschaftswürfe bei Sichterfordernissen im hellen Licht)",
-        "Verringerte Vitalität (-1 Robustheit)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Nachtsicht (Ignoriert alle Beleuchtungsabzüge)",
-        "Untote spüren (Als eingeschränkte Aktion: Untote innerhalb von 20\"/40 Meter erspüren; als eingeschränkte freie Aktion: Anzahl und ungefähre Stärke der Untoten ermitteln)",
-        "Untotenresistenz (Freie Wiederholung beim Widerstand gegen Krankheiten; immun gegen Energieentzug)",
-        "Alternativfähigkeit – Tageskind: Nicht durch Tageslicht beeinträchtigt; verliert Lichtempfindlichkeit; Nachtsicht wird durch Nachtsicht (nur Düster/Dunkel) ersetzt",
-        "Alternativfähigkeit – Fangzähne: Natürliche Waffe Biss, Stärke+W4 Schaden (Natürliche Waffen laut Pathfinder für Savage Worlds); ersetzt Untotenresistenz",
-        "Alternativfähigkeit – Vampirische Empathie: Kann mit Fledermäusen, Ratten und Wölfen kommunizieren; freie Wiederholung bei fehlgeschlagenen Überreden-Proben mit diesen Tieren; ersetzt Untote spüren"
-      ],
-      "sprachen": [
-        "Gemeinsprache"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110), jedoch mit übernatürlicher Langlebigkeit ähnlich wie Elfen",
-      "groesse_maennlich": "Hochgewachsen und schlank (1,70-2,00m, 60-85kg); unheimlich schöne Züge, verlängerte Eckzähne, oft gespenstische Blässe im Tageslicht",
-      "groesse_weiblich": "Hochgewachsen und schlank (1,65-1,90m, 55-75kg); übernatürlich flüssige Bewegungen; dunkle Haut wirkt manchmal wie ein Bluterguss",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2
+        "Bevorzugte Klasse_leicht": {
+            "name": "Bevorzugte Klasse",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Wenn sich dein Held auf etwas einlässt, zieht er es bis zum Ende durch, auch auf Kosten anderer Studien. Wähle eine Kern-Klassen-Eigenschaft. Alle Merkmalsanforderungen für andere Klassen-Eigenschaften und Prestige-Eigenschaften werden um einen Würfeltyp erhöht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Lichtempfindlich",
-          "Verringerte Vitalität"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "lichtempfindlich": true,
-          "untote_spueren": true,
-          "untotenresistenz": true
+        "Bevorzugte Klasse_schwer": {
+            "name": "Bevorzugte Klasse",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Wenn sich dein Held auf etwas einlässt, zieht er es bis zum Ende durch, auch auf Kosten anderer Studien. Der Charakter kann nur eine Kern-Klassen-Eigenschaft haben und kann keine Prestige-Eigenschaften erwerben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Tieflinge": {
-      "name": "Tieflinge",
-      "handicaps": [
-        "Außenseiter (leicht, -2 auf Überredenproben, werden oft abgelehnt oder verspottet)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Beweglich (Geschicklichkeit W6 statt W4, Maximum W12+1)",
-        "Intelligent (Verstand W6 statt W4, Maximum W12+1)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Dunkelheit (1×/Tag als eingeschränkte freie Aktion: geringes Dunkel als Angeborene Macht wirken)",
-        "Teuflische Zauberei (Tieflinge-Zauberer mit Abgrundsblut oder Infernalblut reduzieren die Ranganforderung für Fortgeschrittenes Blut auf Veteran)",
-        "Heimischer Außenseiter (Typus ist Außenseiter statt Humanoid)",
-        "Alternativfähigkeit – Teuflischer Sprinter: Gewinnt das Talent Schnell (Fleet-Footed); ersetzt Intelligent",
-        "Alternativfähigkeit – Greifbarer Schwanz: Kann mit dem Schwanz verstaute Gegenstände als freie Aktion hervorholen; ersetzt Teuflische Zauberei",
-        "Alternativfähigkeit – Verkümmerte Flügel: Fliegen mit Bewegungsweite 6; am Ende jeder Flug-Runde Konstitutionsprobe oder Erschöpfung; ersetzt Teuflische Zauberei"
-      ],
-      "sprachen": [
-        "Abyssalisch",
-        "Gemeinsprache",
-        "Infernalisch"
-      ],
-      "altersspanne": "Wie Mensch (Erwachsen mit 17, Alt mit 53, maximales Alter 70–110)",
-      "groesse_maennlich": "Wie Mensch (1,50-1,95m, 54-100kg); individuelle teuflische Merkmale wie Hörner, gezackter Schwanz, unnatürlich gefärbte Augen, Klauen oder kleine Flügel",
-      "groesse_weiblich": "Wie Mensch (1,50-1,85m, 43-84kg); kein Tieflinge gleicht dem anderen – von seltsam schön bis erschreckend fremdländisch",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 2,
-          "Verstand": 2
+        "Blind": {
+            "name": "Blind",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–6 auf alle Aufgaben, die Sicht erfordern (aber ein freies Talent zum Ausgleich).",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": 0,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {},
-        "fertigkeits_modifier_boni": {
-          "Überreden": -2
+        "Blutrünstig": {
+            "name": "Blutrünstig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Nimmt niemals Gefangene.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Außenseiter_leicht"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true,
-          "dunkelheit_macht": true,
-          "teuflische_zauberei": true,
-          "heimischer_aussenseiter": true
+        "Dünnhäutig_leicht": {
+            "name": "Dünnhäutig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –2, wenn er Provozieren-Angriffen widerstehen will.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    },
-    "Goblin": {
-      "name": "Goblin",
-      "handicaps": [
-        "Größe -1 (Reduzierte Größe und Robustheit um 1)",
-        "Außenseiter (Schwer) (-2 auf alle Überreden-Proben; werden von anderen oft gemobbt)"
-      ],
-      "talente": [],
-      "besonderheiten": [
-        "Flink (Geschicklichkeit W8 statt W4, Maximum W12+2)",
-        "Dunkelsicht (Ignoriert Beleuchtungsabzüge auf bis zu 10\" / 20 Meter)",
-        "Fähiger Reiter (Beginnt mit W4 in Reiten)",
-        "Heimlich (Heimlichkeit W6 statt W4, Maximum W12+1)",
-        "Alternativfähigkeit – Alles essen: Freie Wiederholung bei Überleben-Proben zur Nahrungssuche; +2 bei Konstitutionsproben gegen toxische Substanzen; ersetzt Fähiger Reiter",
-        "Alternativfähigkeit – Harter Schädel, große Zähne: Natürliche Waffe Biss, Stärke+W4 Schaden; ersetzt Heimlich",
-        "Alternativfähigkeit – Übergroße Ohren: Wahrnehmung W6 statt W4, Maximum W12+1; ersetzt Fähiger Reiter"
-      ],
-      "sprachen": [
-        "Gemeinsprache",
-        "Goblinisch"
-      ],
-      "altersspanne": "Jugend mit 3, Erwachsen mit 7–8, maximales Alter 50+ (selten über 20 ohne Beschützer)",
-      "groesse_maennlich": "Klein (~85-100cm, 17-22kg); knochige Gestalt, übergroßer kahler Schädel, riesige Ohren, kleine rote oder gelbe Augen",
-      "groesse_weiblich": "Klein (~80-95cm, 15-20kg); Hautfarbe variiert: Grün, Grau, Blau, Schwarz oder Blassgrau; riesiges Maul mit zackigen Zähnen",
-      "aktiv": true,
-      "custom": false,
-      "effects": {
-        "attribute_bonuses": {
-          "Geschicklichkeit": 4
+        "Dünnhäutig_schwer": {
+            "name": "Dünnhäutig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –4, wenn er Provozieren-Angriffen widerstehen will.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "robustheit_bonus": -1,
-        "bewegungsweite_bonus": 0,
-        "fertigkeits_startboni": {
-          "Heimlichkeit": 2,
-          "Reiten": 2
+        "Ehrenkodex": {
+            "name": "Ehrenkodex",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter hält sein Wort und benimmt sich wie ein Gentleman.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "fertigkeits_modifier_boni": {
-          "Überreden": -2
+        "Eifersüchtig_leicht": {
+            "name": "Eifersüchtig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter will das, was andere haben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "auto_talente": [],
-        "auto_handicaps": [
-          "Klein",
-          "Größe -1 (Reduzierte Größe und Robustheit)"
-        ],
-        "spezielle_effekte": {
-          "dunkelsicht": true
+        "Eifersüchtig_schwer": {
+            "name": "Eifersüchtig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter will das, was andere haben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         },
-        "wahlmoeglichkeiten": {}
-      }
-    }
-  },
-  "voelker_selected": {
-    "Elf": false,
-    "Gnom": false,
-    "Halbelf": false,
-    "Halbling": false,
-    "Halbork": false,
-    "Ifrits": false,
-    "Mensch": true,
-    "Oreads": false,
-    "Zwerg": false
-  },
-  "attribute": {
-    "Geschicklichkeit": {
-      "attribut_name": "Geschicklichkeit",
-      "wert": 4,
-      "modifier": 0
-    },
-    "Verstand": {
-      "attribut_name": "Verstand",
-      "wert": 4,
-      "modifier": 0
-    },
-    "Stärke": {
-      "attribut_name": "Stärke",
-      "wert": 4,
-      "modifier": 0
-    },
-    "Konstitution": {
-      "attribut_name": "Konstitution",
-      "wert": 4,
-      "modifier": 0
-    },
-    "Willenskraft": {
-      "attribut_name": "Willenskraft",
-      "wert": 4,
-      "modifier": 0
-    }
-  },
-  "fertigkeiten_daten": {
-    "Allgemeinwissen": [
-      "Verstand"
-    ],
-    "Athletik": [
-      "Geschicklichkeit"
-    ],
-    "Heimlichkeit": [
-      "Geschicklichkeit"
-    ],
-    "Überreden": [
-      "Willenskraft"
-    ],
-    "Wahrnehmung": [
-      "Verstand"
-    ],
-    "Kämpfen": [
-      "Geschicklichkeit"
-    ],
-    "Schießen": [
-      "Geschicklichkeit"
-    ],
-    "Diebeskunst": [
-      "Geschicklichkeit"
-    ],
-    "Überleben": [
-      "Verstand"
-    ],
-    "Reiten": [
-      "Geschicklichkeit"
-    ],
-    "Fahren": [
-      "Geschicklichkeit"
-    ],
-    "Seefahrt": [
-      "Geschicklichkeit"
-    ],
-    "Pilot": [
-      "Geschicklichkeit"
-    ],
-    "Darbietung": [
-      "Willenskraft"
-    ],
-    "Einschüchtern": [
-      "Willenskraft"
-    ],
-    "Glaube": [
-      "Willenskraft"
-    ],
-    "Heilen": [
-      "Verstand"
-    ],
-    "Provozieren": [
-      "Verstand"
-    ],
-    "Reparieren": [
-      "Verstand"
-    ],
-    "Glücksspiel": [
-      "Verstand"
-    ],
-    "Kriegskunst": [
-      "Verstand"
-    ],
-    "Okkultismus": [
-      "Verstand"
-    ],
-    "Geisteswissenschaften": [
-      "Verstand"
-    ],
-    "Naturwissenschaften": [
-      "Verstand"
-    ],
-    "Zaubern": [
-      "Verstand"
-    ],
-    "Zaubern (Zauberer)": [
-      "Willenskraft"
-    ],
-    "Verrückte Wissenschaft": [
-      "Verstand"
-    ],
-    "Alchemie": [
-      "Verstand"
-    ],
-    "Fokus": [
-      "Willenskraft"
-    ]
-  },
-  "talente": {
-    "Berserker": {
-      "name": "Berserker",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Erhöhe Stärke um einen Würfeltyp. Du musst einen Rücksichtslosen Angriff ausführen, wenn möglich.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Barbar": {
-      "name": "Barbar",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W6",
-        "KON W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Behände (Bewegungsweite +2), Kampfrausch (siehe Text)",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Berserker",
-        "Behände",
-        "Kampfrausch"
-      ],
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_mittelschwer"
-      ]
-    },
-    "Kraftvoller Schlag": {
-      "name": "Kraftvoller Schlag",
-      "kategorie": "Barbar",
-      "rang": "F",
-      "voraussetzungen": [
-        "Barbar"
-      ],
-      "beschreibung": "Rücksichtslose Angriffe verursachen +4 Schaden anstatt +2.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Einschüchterndes Niederstarren": {
-      "name": "Einschüchterndes Niederstarren",
-      "kategorie": "Barbar",
-      "rang": "V",
-      "voraussetzungen": [
-        "Barbar"
-      ],
-      "beschreibung": "Der Barbar kann eine Einschüchternprobe als freie Aktion ausführen, wenn ihm im Kampf ein Bube oder besser ausgeteilt wird.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kraftrausch": {
-      "name": "Kraftrausch",
-      "kategorie": "Barbar",
-      "rang": "H",
-      "voraussetzungen": [
-        "Barbar"
-      ],
-      "beschreibung": "Die Stärke des Helden wird um zwei Würfeltypen erhöht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Barde)": {
-      "name": "AH (Barde)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "Allgemeinwissen W6"
-      ],
-      "beschreibung": "AH (Barde), Behindernde Rüstung (leicht), Scharfzüngig (kann Darbietung zum Provozieren verwenden)",
-      "neue_maechte": 3,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Scharfzüngig"
-      ],
-      "auto_handicaps": [
-        "Behindernde Rüstung_leicht"
-      ]
-    },
-    "Bannlied": {
-      "name": "Bannlied",
-      "kategorie": "Barde",
-      "rang": "V",
-      "voraussetzungen": [
-        "Barde"
-      ],
-      "beschreibung": "Verbündete innerhalb von 5'' erhalten eine Wurfwiederholung, wenn sie feindlichen Zaubereffekten widerstehen oder sich von ihnen erholen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Klagelied": {
-      "name": "Klagelied",
-      "kategorie": "Barde",
-      "rang": "H",
-      "voraussetzungen": [
-        "Barde"
-      ],
-      "beschreibung": "Feindliche Wildcards innerhalb von 10'' ziehen –2 vom Gesamtwert ab, wenn sie einen Benny ausgeben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Druide)": {
-      "name": "AH (Druide)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "Überleben W6"
-      ],
-      "beschreibung": "AH (Druide), Behindernde Rüstung (leicht), Bindung mit der Natur, Naturgespür",
-      "neue_maechte": 3,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Bindung mit der Natur",
-        "Naturgespür"
-      ],
-      "auto_handicaps": [
-        "Schwur_schwer",
-        "Behindernde Rüstung_leicht"
-      ]
-    },
-    "Tiergestalt": {
-      "name": "Tiergestalt",
-      "kategorie": "Druide",
-      "rang": "F",
-      "voraussetzungen": [
-        "Druide"
-      ],
-      "beschreibung": "Der Druide erhält Gestaltwandeln. Wirkungsdauer ist eine Stunde, und er wirkt den Zauber mit einem Rang höher als normal.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bevorzugte Mächte (Druide)": {
-      "name": "Bevorzugte Mächte (Druide)",
-      "kategorie": "Druide",
-      "rang": "V",
-      "voraussetzungen": [
-        "Druide"
-      ],
-      "beschreibung": "Als begrenzte freie Aktion kann der Druide bis zu zwei Punkte Abzüge ignorieren, wenn er Schutz, Verstricken oder Waffe verbessern wirkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Göttliche Meisterschaft (Druide)": {
-      "name": "Göttliche Meisterschaft (Druide)",
-      "kategorie": "Druide",
-      "rang": "H",
-      "voraussetzungen": [
-        "Druide"
-      ],
-      "beschreibung": "Der Druide kann Epische Machtmodifikatoren verwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kämpfer": {
-      "name": "Kämpfer",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W6",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Kriegerische Anpassungsfähigkeit (kann einmal pro Begegnung ein Kampftalent erhalten)",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Kriegerische Anpassungsfähigkeit"
-      ],
-      "auto_handicaps": []
-    },
-    "Tödlicher Hieb": {
-      "name": "Tödlicher Hieb",
-      "kategorie": "Kämpfer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfer"
-      ],
-      "beschreibung": "Der Kämpfer addiert +1 auf alle Angriffe, die Schaden verursachen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verbesserte kriegerische Anpassungsfähigkeit": {
-      "name": "Verbesserte kriegerische Anpassungsfähigkeit",
-      "kategorie": "Kämpfer",
-      "rang": "V",
-      "voraussetzungen": [
-        "Kämpfer"
-      ],
-      "beschreibung": "Der Kämpfer kann jetzt zwei Kampftalente pro Begegnung wählen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kämpferisches Können": {
-      "name": "Kämpferisches Können",
-      "kategorie": "Kämpfer",
-      "rang": "H",
-      "voraussetzungen": [
-        "Kämpfer"
-      ],
-      "beschreibung": "Der Kämpfer erhält eine freie Wiederholung bei jeder misslungenen Kämpfenprobe.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Kleriker)": {
-      "name": "AH (Kleriker)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "Okkultismus W6"
-      ],
-      "beschreibung": "AH (Kleriker), Energie fokussieren (kann mit Reichweite von Willenskraft heilen)",
-      "neue_maechte": 3,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Gnade",
-        "Energie fokussieren"
-      ],
-      "auto_handicaps": [
-        "Schwur_schwer"
-      ]
-    },
-    "Bevorzugte Mächte (Kleriker)": {
-      "name": "Bevorzugte Mächte (Kleriker)",
-      "kategorie": "Kleriker",
-      "rang": "V",
-      "voraussetzungen": [
-        "Kleriker"
-      ],
-      "beschreibung": "Als begrenzte freie Aktion kann der Kleriker bis zu zwei Punkte Abzüge ignorieren, wenn er Heiligtum, Heilung oder Waffe verbessern wirkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Göttliche Meisterschaft (Kleriker)": {
-      "name": "Göttliche Meisterschaft (Kleriker)",
-      "kategorie": "Kleriker",
-      "rang": "H",
-      "voraussetzungen": [
-        "Kleriker"
-      ],
-      "beschreibung": "Der Kleriker kann Epische Machtmodifikatoren verwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Magier)": {
-      "name": "AH (Magier)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6",
-        "Okkultismus W6"
-      ],
-      "beschreibung": "AH (Magier) Arkane Verbindung (Verbindung mit einem Gegenstand für +1 Zaubern oder ein Vertrauter), Behindernde Rüstung (jede), Schule, Zauberbücher",
-      "neue_maechte": 3,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Zauberbücher",
-        "Arkane Verbindung",
-        "Schule"
-      ],
-      "auto_handicaps": [
-        "Behindernde Rüstung_jede"
-      ]
-    },
-    "Bevorzugte Mächte (Magier)": {
-      "name": "Bevorzugte Mächte (Magier)",
-      "kategorie": "Magier",
-      "rang": "F",
-      "voraussetzungen": [
-        "Magier"
-      ],
-      "beschreibung": "Als begrenzte freie Aktion kann der Magier bis zu zwei Punkte Abzüge ignorieren, wenn er Abwehren, Arkanen Schutz oder Aufheben wirkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Meisterschaft (Magier)": {
-      "name": "Arkane Meisterschaft (Magier)",
-      "kategorie": "Magier",
-      "rang": "V",
-      "voraussetzungen": [
-        "Magier"
-      ],
-      "beschreibung": "Der Magier kann Epische Machtmodifikatoren verwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mönch": {
-      "name": "Mönch",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W6",
-        "WIL W6",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (jede), Betäubende Fäuste, Beweglichkeit, Kämpferische Disziplin, Waffenloser Schlag",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Betäubende Fäuste",
-        "Beweglichkeit",
-        "Kämpferische Disziplin",
-        "Waffenloser Schlag"
-      ],
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_jede"
-      ]
-    },
-    "Mystische Mächte (Mönch)": {
-      "name": "Mystische Mächte (Mönch)",
-      "kategorie": "Mönch",
-      "rang": "F",
-      "voraussetzungen": [
-        "Mönch"
-      ],
-      "beschreibung": "Der Mönch hat 10 gewidmete Machtpunkte, die er verwenden kann, um Abwehren, Beschleunigung, Eigenschaft erhöhen (Geschicklichkeit, Athletik, Kämpfen oder Heimlichkeit) oder Waffe verbessern zu wirken. Alle wirken nur auf den Mönch selbst.",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mächtiges Ki": {
-      "name": "Mächtiges Ki",
-      "kategorie": "Mönch",
-      "rang": "V",
-      "voraussetzungen": [
-        "Mönch",
-        "Mystische Mächte (Mönch)"
-      ],
-      "beschreibung": "Zu den mystischen Mächten des Mönchs gehören jetzt Eigenschaft erhöhen (Stärke), Kriegersegen, Schutz, Wandkrabbler.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unversehrtheit des Körpers": {
-      "name": "Unversehrtheit des Körpers",
-      "kategorie": "Mönch",
-      "rang": "H",
-      "voraussetzungen": [
-        "Mönch",
-        "Mystische Mächte (Mönch)"
-      ],
-      "beschreibung": "Der Mönch kann 2 Machtpunkte ausgeben, um auf Schaden wegstecken zu würfeln. Dies wird nicht behandelt, als hätte er einen Benny ausgegeben",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Paladin": {
-      "name": "Paladin",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "STÄ W6"
-      ],
-      "beschreibung": "Aura der Tapferkeit (+1 auf Furchtproben innerhalb von 10''), Ehrenkodex, Böses entdecken, Böses niederstrecken (freie Wiederholung bei Angriffswürfen gegen einen gewählten bösen Gegner pro Begegnung)",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Aura der Tapferkeit",
-        "Böses Entdecken",
-        "Böses Niederstrecken"
-      ],
-      "auto_handicaps": [
-        "Ehrenkodex"
-      ]
-    },
-    "Mystische Mächte (Paladin)": {
-      "name": "Mystische Mächte (Paladin)",
-      "kategorie": "Paladin",
-      "rang": "F",
-      "voraussetzungen": [
-        "Paladin"
-      ],
-      "beschreibung": "Der Paladin hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Kämpfen, Stärke, Konstitution), Heilung, Linderung, Waffe verbessern nutzen kann. Alle außer Heilung und Linderung wirken nur auf den Paladin selbst.",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gnade (Paladin)": {
-      "name": "Gnade (Paladin)",
-      "kategorie": "Paladin",
-      "rang": "V",
-      "voraussetzungen": [
-        "Paladin"
-      ],
-      "beschreibung": "Der Paladin kann Abgelenkt, Verwundbar, Angeschlagen bei einem Verbündeten in Willenskraft-Reichweite aufheben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Reittier (Paladin)": {
-      "name": "Reittier (Paladin)",
-      "kategorie": "Paladin",
-      "rang": "H",
-      "voraussetzungen": [
-        "Paladin"
-      ],
-      "beschreibung": "Der Held erhält ein loyales leichtes oder schweres Pferd als Wildcard.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schurke": {
-      "name": "Schurke",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W6",
-        "Wahrnehmung W6",
-        "Heimlichkeit W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (leicht), Hinterhältiger Angriff",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Hinterhältiger Angriff"
-      ],
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_leicht"
-      ]
-    },
-    "Reflexbewegung": {
-      "name": "Reflexbewegung",
-      "kategorie": "Schurke",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schurke"
-      ],
-      "beschreibung": "Der Schurke ignoriert den üblichen Abzug von –2 beim Wegspringen und kann versuchen, bei jedem Flächenangriff wegzuspringen, der dies normalerweise nicht erlaubt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Opportunist": {
-      "name": "Opportunist",
-      "kategorie": "Schurke",
-      "rang": "H",
-      "voraussetzungen": [
-        "Schurke"
-      ],
-      "beschreibung": "Der Schurke erhält einen freien Angriff gegen einen Feind, der sich aus dem Nahkampf zurückzieht, auch wenn dieser Rückzug besitzt. Wenn er nicht über Rückzug verfügt, zählt der Gegner als Verwundbar.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Waldläufer": {
-      "name": "Waldläufer",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "Athletik W6, Kämpfen oder Schießen W6",
-        "Überleben W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Erzfeind, Bevorzugtes Gelände, Wildnis durchqueren",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Erzfeind",
-        "Bevorzugtes Gelände",
-        "Wildnis durchqueren"
-      ],
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_mittelschwer"
-      ]
-    },
-    "Beute": {
-      "name": "Beute",
-      "kategorie": "Waldläufer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Waldläufer"
-      ],
-      "beschreibung": "Der Waldläufer wählt einen zusätzlichen Gegner- und Geländetyp für Erzfeind und Bevorzugtes Gelände.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystische Mächte (Waldläufer)": {
-      "name": "Mystische Mächte (Waldläufer)",
-      "kategorie": "Waldläufer",
-      "rang": "V",
-      "voraussetzungen": [
-        "Waldläufer"
-      ],
-      "beschreibung": "Der Waldläufer hat 10 gewidmete Machtpunkte, die er für Eigenschaft stärken (Athletik, Kämpfen, Schießen), Kriegersegen, Tierfreund, Verstricken nutzen kann. Alle bis auf Verstricken wirken nur auf den Waldläufer selbst.",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterjäger": {
-      "name": "Meisterjäger",
-      "kategorie": "Waldläufer",
-      "rang": "H",
-      "voraussetzungen": [
-        "Waldläufer"
-      ],
-      "beschreibung": "Der Jäger addiert zusätzliche W6 Schaden, wenn er einen erfolgreichen Angriff mit Athletik (Werfen), Kämpfen oder Schießen gegen einen Erzfeind ausführt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Zauberer)": {
-      "name": "AH (Zauberer)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6",
-        "WIL W6"
-      ],
-      "beschreibung": "AH (Zauberer), Behindernde Rüstung (jede), Blutlinie",
-      "neue_maechte": 2,
-      "machtpunkte": 15,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Blutlinie"
-      ],
-      "auto_handicaps": [
-        "Behindernde Rüstung_jede"
-      ]
-    },
-    "AH (Hexenmeister)": {
-      "name": "AH (Hexenmeister)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6",
-        "Okkultismus W4"
-      ],
-      "beschreibung": "AH (Hexenmeister), Behindernde Rüstung (jede), Vertrauter, Hexerei (1 freie Hexerei aus der Liste). Arkane Fertigkeit: Zaubern. Startet mit 2 Mächten aus der Hexenmeister-Liste. Der Vertraute speichert die Zauber des Patrons; tägliche Kommunikation mit dem Vertrauten erforderlich.",
-      "neue_maechte": 2,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "Vertrauter"
-      ],
-      "auto_handicaps": [
-        "Behindernde Rüstung_jede"
-      ]
-    },
-    "Weitere Hexerei": {
-      "name": "Weitere Hexerei",
-      "kategorie": "Hexenmeister",
-      "rang": "F",
-      "voraussetzungen": [
-        "Hexenmeister"
-      ],
-      "beschreibung": "Der:ie Hexenmeister:in kann eine neue Hexerei auswählen. Kann einmal pro Rang genommen werden. Hexereien (Auswahl): Agonie, Verstärkung, Verfluchen, Kichern, Verzaubern, Böser Blick, Heilung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Starke Hexerei": {
-      "name": "Starke Hexerei",
-      "kategorie": "Hexenmeister",
-      "rang": "V",
-      "voraussetzungen": [
-        "Hexenmeister"
-      ],
-      "beschreibung": "Der:ie Hexenmeister:in kann eine Starke Hexerei auswählen. Kann einmal pro Rang genommen werden. Starke Hexereien (Auswahl): Vettelnauge, Albträume, Vision, Wachsabbild, Wetterkontrolle.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Meisterschaft (Hexenmeister)": {
-      "name": "Arkane Meisterschaft (Hexenmeister)",
-      "kategorie": "Hexenmeister",
-      "rang": "H",
-      "voraussetzungen": [
-        "Hexenmeister"
-      ],
-      "beschreibung": "Durch ihren finsteren Patron erschließt die Hexe die Geheimnisse ihrer mystischen Kräfte. Erhält Zugriff auf alle Epischen Machtmodifikatoren ihrer Mächte.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mächtige Hexerei": {
-      "name": "Mächtige Hexerei",
-      "kategorie": "Hexenmeister",
-      "rang": "L",
-      "voraussetzungen": [
-        "Hexenmeister",
-        "Mindestens zwei Hexenmeister-Vorteile"
-      ],
-      "beschreibung": "Wild Card. Der:ie Hexenmeister:in kann eine Mächtige Hexerei auswählen. Kann einmal pro Rang genommen werden. Mächtige Hexereien (Auswahl): Todesfluch, Ewiger Schlaf, Erzwungene Wiedergeburt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Alchemist": {
-      "name": "Alchemist",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Alchemische Identifikation (+2 auf Proben zur Identifikation alchemischer Gegenstände), AH (Alchemist) [Arkane Fertigkeit: Alchemie], Behindernde Rüstung (leicht), Bomben (Aktion: wirf eine Bombe, 1W6 Schaden in Bereich), Extrakte (Tränke für Kraftvolle Heilung oder Eigenschaftsverbesserung), Mutagene (Konstitution für Stärke, Intelligenz für Ausdauer oder Geschicklichkeit für Abwehr tauschen).",
-      "neue_maechte": 3,
-      "machtpunkte": 15,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_talente": [
-        "AH (Alchemist)"
-      ],
-      "auto_handicaps": [
-        "Behindernde Rüstung_leicht"
-      ]
-    },
-    "Entdeckung": {
-      "name": "Entdeckung",
-      "kategorie": "Alchemist",
-      "rang": "F",
-      "voraussetzungen": [
-        "Alchemist"
-      ],
-      "beschreibung": "Der Alchemist wählt eine Entdeckung aus (z.B. verbesserte Bombe, verbessertes Mutagen, neue Extrakt-Formeln, Giftkunst, Schnellbomben). Kann einmal pro Rang genommen werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Fortgeschrittene Entdeckung": {
-      "name": "Fortgeschrittene Entdeckung",
-      "kategorie": "Alchemist",
-      "rang": "V",
-      "voraussetzungen": [
-        "Alchemist"
-      ],
-      "beschreibung": "Der Alchemist wählt eine Fortgeschrittene Entdeckung aus (mächtigere Varianten: Bombenregeneration, Großes Mutagen, Flüssiges Feuer, Verdauungssäure).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Große Entdeckung": {
-      "name": "Große Entdeckung",
-      "kategorie": "Alchemist",
-      "rang": "H",
-      "voraussetzungen": [
-        "Alchemist"
-      ],
-      "beschreibung": "Der Alchemist wählt eine Große Entdeckung aus (Höhepunkt der Alchemie: Wahres Elixier der Langlebigkeit, Stein der Weisen, Wahre Verwandlung, Unsterblichkeitselixier).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kavalier": {
-      "name": "Kavalier",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W6",
-        "Kämpfen W6",
-        "Reiten W6"
-      ],
-      "beschreibung": "Herausforderung (einmal pro Begegnung: wähle einen Gegner – beide erhalten Wundabzüge des anderen nicht; der Kavalier erhält +2 Schaden gegen das Ziel), Mächtiger Ansturm (bei Ansturm mit Lanze +4 Schaden statt +2), Orden (tritt einem Ritterorden bei und erhält dessen Kenntnisse), Kavalier-Reittier (verbesserte Variante des Tiermeister-Begleiters).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Panier": {
-      "name": "Panier",
-      "kategorie": "Kavalier",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kavalier"
-      ],
-      "beschreibung": "Verbündete innerhalb von 12'' erhalten +1 auf Furcht-Proben. Bei einem Ansturm erhalten sie zusätzlich +2 auf Angriffswürfe, solange das Panier sichtbar ist.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ordensfähigkeit": {
-      "name": "Ordensfähigkeit",
-      "kategorie": "Kavalier",
-      "rang": "V",
-      "voraussetzungen": [
-        "Kavalier"
-      ],
-      "beschreibung": "Der Kavalier erhält eine besondere Fähigkeit seines Ordens (z.B. Orden des Stabs: +2 auf Wissenswürfe; Orden des Schwertes: +1 auf Kämpfen; Orden des Sterns: einmal täglich Gnadenbitte für sich selbst).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Fordernde Herausforderung": {
-      "name": "Fordernde Herausforderung",
-      "kategorie": "Kavalier",
-      "rang": "H",
-      "voraussetzungen": [
-        "Kavalier"
-      ],
-      "beschreibung": "Gegner, die durch die Herausforderung des Kavaliers gebunden sind, können keine Bennies ausgeben, um gegen den Kavalier gerichtete Würfe zu wiederholen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Überlegener Ansturm": {
-      "name": "Überlegener Ansturm",
-      "kategorie": "Kavalier",
-      "rang": "WC",
-      "voraussetzungen": [
-        "L",
-        "Kavalier",
-        "Mindestens zwei Kavalier-Talente"
-      ],
-      "beschreibung": "Wild Card. Der Kavalier verdoppelt den Schaden bei einem Ansturm mit einer Lanze (anstatt des normalen +4-Bonus). Erfordert Legendär-Rang und mindestens zwei weitere Kavalier-Talente.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Inquisitor": {
-      "name": "Inquisitor",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "Athletik W6 oder Kämpfen W6 oder Schießen W6",
-        "Okkultismus W4"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Urteil (einmal pro Begegnung: +1 auf Angriffs- oder Schadenswürfe, oder +2 auf Eigenschaftswürfe – Wahl bei Einsatz), Monsterkunde (+2 auf Allgemeinwissen-Proben über Monster, Dämonen und Untote).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_mittelschwer"
-      ]
-    },
-    "Bann": {
-      "name": "Bann",
-      "kategorie": "Inquisitor",
-      "rang": "F",
-      "voraussetzungen": [
-        "Inquisitor"
-      ],
-      "beschreibung": "Der Inquisitor verzaubert seine Waffe mit Bann: Angriffe ignorieren den Übernatürlichen Schutz des Ziels und verursachen +2 Schaden gegen die gewählte Kreaturenart (festgelegt bei Aktivierung der Macht).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Brandmal": {
-      "name": "Brandmal",
-      "kategorie": "Inquisitor",
-      "rang": "F",
-      "voraussetzungen": [
-        "Inquisitor"
-      ],
-      "beschreibung": "Der Inquisitor brandmarkt einen Feind (Aktion, Berührungsangriff): Das Ziel gilt als Abgelenkt (-2 auf alle Proben) bis es eine Willenskraft-Probe schafft (einmal pro Runde am Ende des Zuges).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystische Mächte (Inquisitor)": {
-      "name": "Mystische Mächte (Inquisitor)",
-      "kategorie": "Inquisitor",
-      "rang": "V",
-      "voraussetzungen": [
-        "Inquisitor"
-      ],
-      "beschreibung": "Der Inquisitor erhält 10 gewidmete Machtpunkte für folgende Mächte: Eigenschaft erhöhen (Einschüchtern, Wahrnehmung oder Überleben), Dunkelsicht, Magie entdecken/verbergen und Aufheben. Alle Mächte wirken nur auf den Inquisitor selbst.",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schwäche ausnutzen": {
-      "name": "Schwäche ausnutzen",
-      "kategorie": "Inquisitor",
-      "rang": "H",
-      "voraussetzungen": [
-        "Inquisitor"
-      ],
-      "beschreibung": "Der Inquisitor kann die Umgebungsschwächen von Kreaturen gezielt auslösen (z.B. Feuer bei Untoten, Silber bei Werwölfen): Der Inquisitor verursacht mit einem Angriff automatisch die Schwachstellen-Effekte der Kreatur.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wahres Urteil": {
-      "name": "Wahres Urteil",
-      "kategorie": "Inquisitor",
-      "rang": "WC",
-      "voraussetzungen": [
-        "L",
-        "Inquisitor",
-        "Mindestens zwei Inquisitor-Talente"
-      ],
-      "beschreibung": "Wild Card. Der Inquisitor trifft sein Urteilsziel mit vernichtendem Schaden (automatischer Erfolg und eine Erhöhung auf den Angriff) und kann sofort einen neuen Feind als Urteilsziel wählen. Erfordert Legendär-Rang und mindestens zwei weitere Inquisitor-Talente.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Orakel)": {
-      "name": "AH (Orakel)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6"
-      ],
-      "beschreibung": "AH (Orakel) [Arkane Fertigkeit: Glaube], Behindernde Rüstung (mittelschwer), Fluch (unvermeidliche Beeinträchtigung, die mit den Stufen stärker wird, z.B. Blindheit, Taubheit, Schwäche), Mysterium (wählt eine göttliche Verbindung, z.B. Tod, Flammen, Natur, Wasser).",
-      "neue_maechte": 3,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Behindernde Rüstung_mittelschwer"
-      ]
-    },
-    "Offenbarung": {
-      "name": "Offenbarung",
-      "kategorie": "Orakel",
-      "rang": "F",
-      "voraussetzungen": [
-        "Orakel"
-      ],
-      "beschreibung": "Das Orakel kann eine Macht aus seinem Mysterium als begrenzte freie Aktion wirken (einmal pro Zug, ohne Machtpunkte-Abzug für die begrenzte freie Aktion). Kann mehrfach genommen werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Göttliche Meisterschaft": {
-      "name": "Göttliche Meisterschaft",
-      "kategorie": "Orakel",
-      "rang": "V",
-      "voraussetzungen": [
-        "Orakel"
-      ],
-      "beschreibung": "Das Orakel darf jetzt Epische Macht-Modifikatoren auf seine göttlichen Mächte anwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Große Offenbarung": {
-      "name": "Große Offenbarung",
-      "kategorie": "Orakel",
-      "rang": "H",
-      "voraussetzungen": [
-        "Orakel"
-      ],
-      "beschreibung": "Das Orakel schaltet seine finale Offenbarung frei – die mächtigste Fähigkeit seines Mysteriums (z.B. ewiges Feuer, Totenbeschwörung, Windkörper).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Beschwörer)": {
-      "name": "AH (Beschwörer)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-      "neue_maechte": 5,
-      "machtpunkte": 15,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zusätzliche Evolution": {
-      "name": "Zusätzliche Evolution",
-      "kategorie": "Beschwörer",
-      "rang": "A",
-      "voraussetzungen": [
-        "Beschwörer"
-      ],
-      "beschreibung": "Das Eidolon des Beschwörers erhält 3 zusätzliche Evolutionspunkte für Verbesserungen (z.B. zusätzliche Gliedmaßen, natürlicher Rüstungsschutz, Flug). Kann einmal genommen werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ruf des Schöpfers": {
-      "name": "Ruf des Schöpfers",
-      "kategorie": "Beschwörer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Beschwörer"
-      ],
-      "beschreibung": "Der Beschwörer kann sein Eidolon per Aktion sofort zu sich teleportieren oder mit ihm den Platz tauschen (einmal pro Begegnung, keine Sichtlinie erforderlich).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ruf des Beschwörers": {
-      "name": "Ruf des Beschwörers",
-      "kategorie": "Beschwörer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Beschwörer"
-      ],
-      "beschreibung": "Das Eidolon erhält +1 Würfeltyp auf Geschicklichkeit, Stärke und Konstitution (permanent).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Lebensband": {
-      "name": "Lebensband",
-      "kategorie": "Beschwörer",
-      "rang": "V",
-      "voraussetzungen": [
-        "Beschwörer"
-      ],
-      "beschreibung": "Solange das Eidolon in der Nähe ist (12''), kann der Beschwörer empfangenen Schaden (Wunden) auf das Eidolon übertragen. Das Eidolon kann nicht unter diesen Schaden fallen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Aspekt": {
-      "name": "Aspekt",
-      "kategorie": "Beschwörer",
-      "rang": "H",
-      "voraussetzungen": [
-        "Beschwörer"
-      ],
-      "beschreibung": "Der Beschwörer kann Evolutionspunkte des Eidolons nutzen, um sich selbst zu transformieren und körperliche Eigenschaften des Eidolons zu übernehmen (z.B. Klauen, Panzerung, Flug).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zwillingseidolon": {
-      "name": "Zwillingseidolon",
-      "kategorie": "Beschwörer",
-      "rang": "WC",
-      "voraussetzungen": [
-        "L",
-        "Beschwörer",
-        "Mindestens zwei Beschwörer-Talente"
-      ],
-      "beschreibung": "Wild Card. Der Beschwörer kann sich vollständig in sein Eidolon verwandeln – alle Eigenschaftspunkte und Fähigkeiten des Eidolons werden für den Beschwörer übernommen. Erfordert Legendär-Rang und mindestens zwei weitere Beschwörer-Talente.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Hexe)": {
-      "name": "AH (Hexe)",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6",
-        "Okkultismus W4"
-      ],
-      "beschreibung": "AH (Hexe) [Arkane Fertigkeit: Zaubern], Behindernde Rüstung (jede), Vertrauter (magisch verbundenes Tier, das Patron-Zauber speichert; tägliche Kommunikation erforderlich), Hex (wählt einen Hex aus der Hexen-Liste, z.B. Böser Blick, Schlaf, Heilung, Verfluchung).",
-      "neue_maechte": 3,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Behindernde Rüstung_jede"
-      ]
-    },
-    "Zusätzlicher Hex": {
-      "name": "Zusätzlicher Hex",
-      "kategorie": "Hexe",
-      "rang": "F",
-      "voraussetzungen": [
-        "Hexe"
-      ],
-      "beschreibung": "Die Hexe schaltet einen zusätzlichen Hex frei. Kann einmal pro Rang genommen werden. Hexen (Auswahl): Agonie, Verhexung, Schlaf, Kichern, Heilung, Böser Blick, Verfluchung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Großer Hex": {
-      "name": "Großer Hex",
-      "kategorie": "Hexe",
-      "rang": "V",
-      "voraussetzungen": [
-        "Hexe"
-      ],
-      "beschreibung": "Die Hexe erhält Zugang zu einem Großen Hex (mächtigere Variante der normalen Hexen-Fähigkeiten). Auswahl: Vettelnauge, Albträume, Langlebigkeit, Wachsabbild, Wetterkontrolle.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Meisterschaft (Hexe)": {
-      "name": "Arkane Meisterschaft (Hexe)",
-      "kategorie": "Hexe",
-      "rang": "H",
-      "voraussetzungen": [
-        "Hexe"
-      ],
-      "beschreibung": "Die Hexe darf jetzt Epische Macht-Modifikatoren auf ihre Zaubern-Mächte anwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Grandioser Hex": {
-      "name": "Grandioser Hex",
-      "kategorie": "Hexe",
-      "rang": "WC",
-      "voraussetzungen": [
-        "L",
-        "Hexe",
-        "Mindestens zwei Hexen-Talente"
-      ],
-      "beschreibung": "Wild Card. Die Hexe schaltet einen Grandiosen Hex frei – die mächtigste Form ihrer Hexerei (z.B. ewiger Schlaf, Todesfluch, Seelenstehlen). Erfordert Legendär-Rang und mindestens zwei weitere Hexen-Talente.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Aura der Gerechtigkeit": {
-      "name": "Aura der Gerechtigkeit",
-      "kategorie": "Paladin",
-      "rang": "F",
-      "voraussetzungen": [
-        "Paladin"
-      ],
-      "beschreibung": "Der Paladin teilt seine Fähigkeit Böses Niederstrecken mit Verbündeten in Sichtweite (12''). Betroffene Verbündete erhalten dieselben Angriffsboni wie der Paladin gegen das gewählte Ziel für eine Runde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Versteinerungsschlag": {
-      "name": "Versteinerungsschlag",
-      "kategorie": "Mönch",
-      "rang": "F",
-      "voraussetzungen": [
-        "WIL W8",
-        "Mönch",
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Ki-Aktion (1 Machtpunkt): Bei einem Treffer mit einer Erhöhung muss das Ziel eine Konstitutionsprobe ablegen oder gilt als Erschöpft und beginnt zu versteinen. Misslingt die Probe mit einer Erhöhung, ist das Ziel sofort Kampfunfähig (Versteinerung).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kreuzblütig": {
-      "name": "Kreuzblütig",
-      "kategorie": "Zauberer",
-      "rang": "H",
-      "voraussetzungen": [
-        "AH (Zauberer)"
-      ],
-      "beschreibung": "Der Zauberer erhält Zugang zu einer zweiten Blutlinie und kann deren Blutlinienfähigkeiten nutzen. Er erleidet jedoch –1 auf alle Zaubern-Proben (Konzentrationsschwierigkeiten durch zwei konkurrierende Blutlinien).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Störende Wut": {
-      "name": "Störende Wut",
-      "kategorie": "Barbar",
-      "rang": "V",
-      "voraussetzungen": [
-        "WIL W8",
-        "Barbar",
-        "Okkultismus W6"
-      ],
-      "beschreibung": "Befindet sich der Barbar im Kampfrausch und wirkt ein Ziel in Nahkampfreichweite (2'') eine Macht, kann der Barbar als freie Aktion sofort einen einzelnen Nahkampfangriff gegen dieses Ziel ausführen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zusätzliche Domäne": {
-      "name": "Zusätzliche Domäne",
-      "kategorie": "Kleriker",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Kleriker)"
-      ],
-      "beschreibung": "Der Kleriker wählt eine zusätzliche Götterdomäne und erhält die damit verbundene Domänenmacht als neue arkane Macht (+1 neue Macht, +5 Machtpunkte).",
-      "neue_maechte": 1,
-      "machtpunkte": 5,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bevorzugte Mächte": {
-      "name": "Bevorzugte Mächte",
-      "kategorie": "Hintergrund",
-      "rang": "F",
-      "voraussetzungen": [
-        {
-          "oder": [
-            "AH (Zauberer)",
-            "AH (Magier)"
-          ]
+        "Einarmig": {
+            "name": "Einarmig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–4 auf Aufgaben (wie Athletik), die beide Hände erfordern.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Eingeengt": {
+            "name": "Eingeengt",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Manche Menschen können die einengende Natur von Rüstungen nicht ertragen. Die enge Umhüllung aus Leder und erstickende Helme versetzen sie in Panik. Dieser Charakter erhält Rüstungsbeschränkung (mittelschwer) für eine seiner Klassen-Eigenschaften. Besitzt er bereits eine Rüstungsbeschränkung, wird diese um eine Stufe erhöht (mittelschwer zu leicht, leicht zu jede).",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Einzelgänger": {
+            "name": "Einzelgänger",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Aufgewachsen unter Piraten, Banditen oder anderen Unruhestiftern, die nicht bereit waren, für ihn den Kopf hinzuhalten, ist dieser Charakter es gewohnt, auf eigene Faust zu agieren. Die Anwesenheit von Verbündeten kann leicht zur Ablenkung werden. Dieser Charakter profitiert nicht von Überzahl-Boni.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Einäugig": {
+            "name": "Einäugig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–2 auf Aktionen auf 5ʺ (10 Meter) oder mehr Entfernung.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Feengeraubt": {
+            "name": "Feengeraubt",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Als Kind wurde dein Held von schelmischen Feenwesen für eine Zeit entführt. Als er zurückkehrte, galt er für immer als eigenartig und distanziert. Er sehnt sich zurück und findet die sterbliche Welt stumpf und manchmal abstoßend, isst schlecht und vertraut seltsamen Visionen. Der Charakter erleidet –2 auf Proben gegen Krankheiten und Gift sowie auf Proben gegen Zauber, Fähigkeiten und Konfrontationen von Feenwesen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Feige": {
+            "name": "Feige",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–2 auf Furchtproben und beim Widerstand gegen Einschüchtern.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Feind_leicht": {
+            "name": "Feind",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Feind_schwer": {
+            "name": "Feind",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Fettleibig": {
+            "name": "Fettleibig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Größe +1, Bewegungsweite –1, Sprintwürfel W4. Behandle Stärke als einen Würfeltyp niedriger, wenn es um Mindeststärke geht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Fies": {
+            "name": "Fies",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–1 auf Überredenproben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Geheimnis_leicht": {
+            "name": "Geheimnis",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Held hat ein dunkles Geheimnis.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Geheimnis_schwer": {
+            "name": "Geheimnis",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Held hat ein dunkles Geheimnis.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gesucht_leicht": {
+            "name": "Gesucht",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gesucht_schwer": {
+            "name": "Gesucht",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gewöhnliche Sicht": {
+            "name": "Gewöhnliche Sicht",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Etwas – oft ein Fluch, eine Krankheit oder ein ähnlicher Effekt – hat dazu geführt, dass dein Held die übernatürliche Sicht seiner Abstammung verloren hat. Der Charakter verliert seine Dämmerungssicht oder Nachtsicht. Voraussetzung: Der Charakter muss Dämmerungssicht oder Nachtsicht besitzen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gierig_leicht": {
+            "name": "Gierig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gierig_schwer": {
+            "name": "Gierig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Große Klappe": {
+            "name": "Große Klappe",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Kann kein Geheimnis bewahren, und verrät ständig private Informationen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Heldenhaft": {
+            "name": "Heldenhaft",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter hilft immer anderen, die in Not sind.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Hilflos_leicht": {
+            "name": "Hilflos",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dieser Charakter stand einst hilflos dabei, als einem geliebten Menschen großes Leid widerfuhr, und diese Lähmung kehrt manchmal zurück. Wann immer ein Verbündeter eine Wunde erleidet, ist dieser Charakter Abgelenkt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Hilflos_schwer": {
+            "name": "Hilflos",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Dieser Charakter stand einst hilflos dabei, als einem geliebten Menschen großes Leid widerfuhr, und diese Lähmung kehrt manchmal zurück. Wann immer ein Verbündeter eine Wunde erleidet, ist dieser Charakter Abgelenkt und Verwundbar.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Hässlich_leicht": {
+            "name": "Hässlich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –1 von Überredenproben ab.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Hässlich_schwer": {
+            "name": "Hässlich",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –2 von Überredenproben ab.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Impulsiv": {
+            "name": "Impulsiv",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Held springt, ehe er schaut.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Jung_leicht": {
+            "name": "Jung",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "4 Attributspunkte, 10 Fertigkeitspunkte, einen zusätzlichen Benny pro Sitzung.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Jung_schwer": {
+            "name": "Jung",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "3 Attributspunkte, 10 Fertigkeitspunkte, zwei zusätzliche Bennys pro Sitzung.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Klein": {
+            "name": "Klein",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Größe und Robustheit sinken um 1. Größe kann nicht unter –1 liegen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Kränklich": {
+            "name": "Kränklich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–2 Konstitution beim Widerstand gegen Erschöpfung.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Kurzsichtig_leicht": {
+            "name": "Kurzsichtig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Manche Abenteurer verfolgen Dinge bis zum bitteren Ende und erschöpfen jede Option – das ist nicht dein Held. Dieser Charakter kann keine Überzeugung ausgeben, um eine zusätzliche Nutzung von einmal-pro-Begegnung-, -Sitzung- oder -Tages-Fähigkeiten zu erhalten.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Kurzsichtig_schwer": {
+            "name": "Kurzsichtig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Manche Abenteurer verfolgen Dinge bis zum bitteren Ende und erschöpfen jede Option – das ist nicht dein Held. Der Charakter kann Überzeugung für zusätzliche Nutzungen von Fähigkeiten ausgeben, aber der Überzeugungswürfel ist dabei ein W4.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Langsam_leicht": {
+            "name": "Langsam",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Bewegungsweite –1, verringere den Sprintwürfel um eine Stufe.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Langsam_schwer": {
+            "name": "Langsam",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Bewegungsweite –2, –2 auf Athletikproben und Würfe, um Athletik zu widerstehen, kann nicht das Talent Flink wählen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Lebensaufgabe": {
+            "name": "Lebensaufgabe",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Held will sterben, nachdem er eine epische Aufgabe abgeschlossen hat.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Loyal": {
+            "name": "Loyal",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Held ist seinen Freunden und Verbündeten gegenüber loyal.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Magischer Tollpatsch": {
+            "name": "Magischer Tollpatsch",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dein Held wurde an einem Ort mit einer Fülle seltsam interagierender Magie geboren, und Magie ist gefährlich begierig, um ihn herum aktiv zu werden. Das Aktivieren eines magischen Gegenstands ist eine beschränkte Aktion statt einer regulären Aktion. Erforderte der Gegenstand normalerweise bereits eine beschränkte Aktion, kann der Charakter keine Mehrfachaktion durchführen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Misstrauisch_leicht": {
+            "name": "Misstrauisch",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter ist paranoid.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Misstrauisch_schwer": {
+            "name": "Misstrauisch",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter ist paranoid und Verbündete, die ihn unterstützen wollen, ziehen –2 von ihren Würfen ab.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Neugierig": {
+            "name": "Neugierig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter will immer alles wissen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Nichtschwimmer": {
+            "name": "Nichtschwimmer",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–2 auf Proben mit Athletik (Schwimmen); jedes Zoll Bewegung im Wasser kostet 3ʺ Bewegungsweite.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Pazifist_leicht": {
+            "name": "Pazifist",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Kämpft nur in Selbstverteidigung.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Pazifist_schwer": {
+            "name": "Pazifist",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Kämpft gar nicht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Pech": {
+            "name": "Pech",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter beginnt jede Spielsitzung mit einem Benny weniger.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Phobie_leicht": {
+            "name": "Phobie",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter hat vor etwas Angst und zieht –1 von allen Eigenschaftsproben in dessen Gegenwart ab.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Phobie_schwer": {
+            "name": "Phobie",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter hat vor etwas Angst und zieht –2 von allen Eigenschaftsproben in dessen Gegenwart ab.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Rachsüchtig_leicht": {
+            "name": "Rachsüchtig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Rachsüchtig_schwer": {
+            "name": "Rachsüchtig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen. Bei einem schweren Handicap greift er auch zu körperlicher Gewalt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Rüstungsbeschränkung_jede": {
+            "name": "Rüstungsbeschränkung (jede)",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter darf keine Rüstung tragen und keine Schilde verwenden.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Rüstungsbeschränkung_leicht": {
+            "name": "Rüstungsbeschränkung (leicht)",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er mittelschwere oder schwere Rüstung trägt oder mittlere/schwere Schilde verwendet.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Rüstungsbeschränkung_mittelschwer": {
+            "name": "Rüstungsbeschränkung (mittelschwer)",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er schwere Rüstung trägt oder einen schweren Schild verwendet.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Sanftmütig": {
+            "name": "Sanftmütig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–2 auf Einschüchternproben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schattenentblößung": {
+            "name": "Schattenentblößung",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Held wirft überhaupt keinen Schatten, oder sein Schatten ist monströs. Unter normalen Lichtbedingungen ist dies nicht schwer zu beobachten, aber ungewöhnlich zu bemerken. Jeder, der den Schatten dieses Charakters bemerkt, reagiert schlechter auf ihn (schlechtere Anfangsreaktion bei Überredung).",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schlechte Augen_leicht": {
+            "name": "Schlechte Augen",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–1 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schlechte Augen_schwer": {
+            "name": "Schlechte Augen",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–2 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schreckhaft": {
+            "name": "Schreckhaft",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Eine traumatische Erfahrung in jungen Jahren mit einem Geist, einem Untoten oder einem anderen übernatürlichen Wesen prägt die Reaktionen deines Helden. Immer wenn er ein Feenwesen, einen Außenseiter oder einen Untoten innerhalb von 10\" (20 Yards) wahrnimmt, muss er eine Schreckensprobe ablegen. Verursacht das Wesen von Natur aus Schrecken, erleidet er zusätzlich –2 auf die Probe. Gegenüber Schrecken abgehärtet zu sein gilt beim Schreckhaften nur für das spezifische Individuum, nicht für den gesamten Kreaturtyp.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schwerhörig_leicht": {
+            "name": "Schwerhörig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–4 auf Wahrnehmung bei Geräuschen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schwerhörig_schwer": {
+            "name": "Schwerhörig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Automatischer Fehlschlag bei vollständiger Taubheit.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schwerzüngig": {
+            "name": "Schwerzüngig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter sagt oft das Falsche oder bekommt seine Worte nicht heraus; –1 auf Einschüchtern, Überreden und Provozieren.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schwur_leicht": {
+            "name": "Schwur",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schwur_schwer": {
+            "name": "Schwur",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Skrupellos_leicht": {
+            "name": "Skrupellos",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Skrupellos_schwer": {
+            "name": "Skrupellos",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Stumm": {
+            "name": "Stumm",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter kann nicht sprechen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Stur": {
+            "name": "Stur",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter will seinen Willen durchsetzen und gibt selten Fehler zu.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Tick": {
+            "name": "Tick",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter hat eine kleine, aber hartnäckige Marotte, die anderen oft auf die Nerven geht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Tollpatschig": {
+            "name": "Tollpatschig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–2 auf Proben mit Athletik und Heimlichkeit.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Unaufmerksam": {
+            "name": "Unaufmerksam",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dein Held hat Schwierigkeiten, den Wirkungsbereich von Flächenangriffen zu erfassen. Dieser Charakter erleidet halben Schaden, wenn er einen erfolgreichen Ausweichmanöver-Wurf erzielt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verbittert": {
+            "name": "Verbittert",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Dieser Held wurde wiederholt von Menschen enttäuscht, denen er vertraute, und fällt es ihm schwer, Hilfe anzunehmen. Andere Charaktere, die diesen Charakter heilen wollen, erleiden –2 auf ihre Probe. Dies gilt für gewöhnliche und magische Heilung, nicht jedoch für natürliche Heilungswürfe.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verpeilt": {
+            "name": "Verpeilt",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "–1 auf Proben mit Allgemeinwissen und Wahrnehmung.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verpflichtung_leicht": {
+            "name": "Verpflichtung",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 20 Stunden.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verpflichtung_schwer": {
+            "name": "Verpflichtung",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 40 Stunden.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Von der Natur gemieden": {
+            "name": "Von der Natur gemieden",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Tiere empfinden deinen Charakter als besonders beunruhigend. Selbst die am besten abgerichteten Tiere müssen zum Umgang mit ihm überredet werden. Tiere nähern sich freiwillig nicht innerhalb von 10\" (20 Yards) des Charakters, außer sie werden dazu überredet. Zusätzlich erleidet der Held –2 auf alle Proben zur Kontrolle von Tieren, einschließlich Reiten.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Vorsichtig": {
+            "name": "Vorsichtig",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter schmiedet aufwendige Pläne und/oder ist übermäßig vorsichtig.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Wahnvorstellungen_leicht": {
+            "name": "Wahnvorstellungen",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm manchmal Schwierigkeiten macht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Wahnvorstellungen_schwer": {
+            "name": "Wahnvorstellungen",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm oft Schwierigkeiten macht.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zwei linke Hände": {
+            "name": "Zwei linke Hände",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "–2 bei der Verwendung von mechanischen oder elektrischen Geräten.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zögerlich": {
+            "name": "Zögerlich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Ziehe zwei Aktionskarten und nimm die schlechtere (außer Joker, die darfst du behalten).",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Übermütig": {
+            "name": "Übermütig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Der Held glaubt, dass er alles tun kann.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schlank": {
+            "name": "Schlank",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 Robustheit, -1 auf Konstitutionsproben",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Größe -1 (Reduzierte Robustheit)": {
+            "name": "Größe -1 (Reduzierte Robustheit)",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Reduzierte Robustheit um 1",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Größe -1 (Reduzierte Größe und Robustheit)": {
+            "name": "Größe -1 (Reduzierte Größe und Robustheit)",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Reduzierte Größe und Robustheit um 1",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verringerte Bewegungsweite (Typ)": {
+            "name": "Verringerte Bewegungsweite (Typ)",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verringerte Bewegungsweite (Schritt)": {
+            "name": "Verringerte Bewegungsweite (Schritt)",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zwanghaft": {
+            "name": "Zwanghaft",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Beginnt mit einer verstandsbasierten Fertigkeit auf W4",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zerbrechlich": {
+            "name": "Zerbrechlich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 Robustheit",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verringerte Stärke": {
+            "name": "Verringerte Stärke",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 auf alle Stärkeproben",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verringerte Fertigkeiten": {
+            "name": "Verringerte Fertigkeiten",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Beginnen nicht mit W4 in Allgemeinwissen und Wahrnehmung – diese starten auf W4-2",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Lichtempfindlich": {
+            "name": "Lichtempfindlich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 auf Eigenschaftswürfe bei Sichterfordernissen im hellen Licht",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verringerte Vitalität": {
+            "name": "Verringerte Vitalität",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "-1 Robustheit",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Anhänglich": {
+            "name": "Anhänglich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Erleidet einen Malus auf Willenskraft-Proben, wenn ein Bezugsobjekt weggenommen wird.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Brandempfindlich": {
+            "name": "Brandempfindlich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dein Held hat Schwierigkeiten, sich zu konzentrieren, wenn er offenen Flammen nahe ist.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Feigling": {
+            "name": "Feigling",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Egal, woher die Furcht stammt, der Charakter läuft davor davon.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Grausam": {
+            "name": "Grausam",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Erleidet einen Malus auf Angriffe, wenn er sich nicht auf den am schwersten verwundeten Gegner konzentriert.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zweifel_leicht": {
+            "name": "Zweifel",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Erleidet nach dem Misslingen einer Fertigkeitsprobe für eine Stunde –1 auf diese Fertigkeit.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Familienbande": {
+            "name": "Familienbande",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Der Charakter hat eine Familie, der er verpflichtet ist zu helfen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Vergesslich": {
+            "name": "Vergesslich",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Es besteht die Chance, gewöhnliche Gegenstände zurückzulassen, wenn man verweilt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Anspruchsvoll": {
+            "name": "Anspruchsvoll",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Waren und Dienstleistungen kosten mehr, da dein Held nur das Beste kauft.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Paranoid": {
+            "name": "Paranoid",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dein Charakter hat Schwierigkeiten, sich von anderen unterstützen zu lassen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schlafmütze": {
+            "name": "Schlafmütze",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Dein Held braucht mehr Schlaf als die meisten Leute.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Eitel": {
+            "name": "Eitel",
+            "stufe": "leicht",
+            "punkte": 1,
+            "beschreibung": "Wenn er beschmutzt ist, erleidet dein Held einen Malus auf Überreden- und Einschüchtern-Proben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zweifel_schwer": {
+            "name": "Zweifel",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Wie die leichte Version, zusätzlich sind auch Angriffsproben betroffen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Ungeduldig": {
+            "name": "Ungeduldig",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Kann keine Aktion aufschieben und verliert die Konzentration, wenn er nach allen Verbündeten im Kampf handelt.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Informationsüberflutung": {
+            "name": "Informationsüberflutung",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Kann keine Bennies ausgeben, um Akademiewissen-, Allgemeinwissen- oder Wissenschaft-Proben zu wiederholen.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Missraten": {
+            "name": "Missraten",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Es ist schwerer, geschicklichkeitsbasierte Fertigkeiten zu steigern.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Selbstzweifel": {
+            "name": "Selbstzweifel",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Erleidet –1 auf Willenskraft-Proben.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schattengezeichnet": {
+            "name": "Schattengezeichnet",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Dein Held ist verletzlich bei Dämmerlicht, Dunkelheit oder völliger Finsternis.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Abergläubisch": {
+            "name": "Abergläubisch",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Es besteht die Chance, dass befreundete Mächte den Charakter behindern.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Ungebildet": {
+            "name": "Ungebildet",
+            "stufe": "schwer",
+            "punkte": 2,
+            "beschreibung": "Es ist schwerer, verstandbasierte Fertigkeiten zu steigern.",
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         }
-      ],
-      "beschreibung": "Einmal pro Zug kann der Charakter bei einer Probe für eine Macht seiner Schule oder Blutlinie bis zu 2 Punkte Abzüge ignorieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
     },
-    "Jägerverbund": {
-      "name": "Jägerverbund",
-      "kategorie": "Waldläufer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Waldläufer"
-      ],
-      "beschreibung": "Der Waldläufer teilt per freier Aktion seinen Erzfeind-Bonus einmal pro Runde mit allen Verbündeten in Sichtweite (12'') für eine Runde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Inspiration der Größe": {
-      "name": "Inspiration der Größe",
-      "kategorie": "Barde",
-      "rang": "V",
-      "voraussetzungen": [
-        "Heldentum inspirieren"
-      ],
-      "beschreibung": "Der Barde kann jetzt 7 Inspirations-Marker pro Einsatz generieren (statt 5). Zudem erhalten alle Verbündeten mit aktiven Inspirations-Markern +1 auf ihre Robustheit.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystische Mächte (Schurke)": {
-      "name": "Mystische Mächte (Schurke)",
-      "kategorie": "Schurke",
-      "rang": "F",
-      "voraussetzungen": [
-        "Schurke"
-      ],
-      "beschreibung": "Der Schurke erhält 10 gewidmete Machtpunkte für folgende Mächte: Eigenschaft erhöhen (Athletik, Heimlichkeit oder Diebeskunst), Dunkelsicht, Lärm/Stille und Wandläufer. Alle Mächte wirken nur auf den Schurken selbst.",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bebende Handfläche": {
-      "name": "Bebende Handfläche",
-      "kategorie": "Mönch",
-      "rang": "H",
-      "voraussetzungen": [
-        "Mönch",
-        "Kämpfen W10"
-      ],
-      "beschreibung": "Ki-Aktion (2 Machtpunkte): Bei einem Treffer pflanzt der Mönch vibrierende Energie ins Ziel. Zu einem beliebigen späteren Zeitpunkt (innerhalb derselben Szene) kann der Mönch die Energie auslösen: Das Ziel legt sofort eine Konstitutionsprobe mit –2 ab oder gilt als Kampfunfähig.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zeitloser Körper": {
-      "name": "Zeitloser Körper",
-      "kategorie": "Druide",
-      "rang": "F",
-      "voraussetzungen": [
-        "KON W8",
-        "AH (Druide)"
-      ],
-      "beschreibung": "Der Druide altert nicht mehr (Alterungseffekte gelten nicht). Zudem wird er immun gegen Gift und Krankheiten jeder Art.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Waffenspezialisierung": {
-      "name": "Waffenspezialisierung",
-      "kategorie": "Kämpfer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfer"
-      ],
-      "beschreibung": "Der Kämpfer wählt eine bevorzugte Waffe. Misslingt ein Angriff mit dieser Waffe und trifft das Ziel nicht mindestens Erschüttert, kann der Kämpfer den Schadenswurf einmal kostenlos wiederholen. Kann mehrfach für verschiedene Waffenarten genommen werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bevorzugte Mächte (Zauberer)": {
-      "name": "Bevorzugte Mächte (Zauberer)",
-      "kategorie": "Zauberer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Zauberer"
-      ],
-      "beschreibung": "Als begrenzte freie Aktion kann der Zauberer bis zu zwei Punkte von Abzügen ignorieren, wenn er Geschoss, Elementarmanipulation oder Schutz wirkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Meisterschaft (Zauberer)": {
-      "name": "Arkane Meisterschaft (Zauberer)",
-      "kategorie": "Zauberer",
-      "rang": "V",
-      "voraussetzungen": [
-        "Zauberer"
-      ],
-      "beschreibung": "Der Zauberer kann Epische Machtmodifikatoren verwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mächtige Blutlinie": {
-      "name": "Mächtige Blutlinie",
-      "kategorie": "Zauberer",
-      "rang": "H",
-      "voraussetzungen": [
-        "Zauberer"
-      ],
-      "beschreibung": "Der Zauberer erhält die mächtige Fähigkeit seiner Blutlinie.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Formationskämpfer": {
-      "name": "Formationskämpfer",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Erhöht Überzahlbonus um zusätzlich +1 (Maximum +4).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kampf mit zwei Waffen": {
-      "name": "Kampf mit zwei Waffen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Mach einen zusätzlichen Kämpfen- oder Athletik-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelles Nachladen": {
-      "name": "Schnelles Nachladen",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Schießen W6"
-      ],
-      "beschreibung": "Verringere den Nachlade-Wert der Waffe um 1.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelles Schießen": {
-      "name": "Schnelles Schießen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Schießen W6"
-      ],
-      "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verbessertes Schießen": {
-      "name": "Verbessertes Schießen",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schnelles Schießen"
-      ],
-      "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Rüstung": {
-      "name": "Arkane Rüstung",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Die Behindernde Rüstung des Charakters wird um eine Stufe verbessert (beispielsweise von mittelschwer auf leicht)",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkaner Bogenschütze": {
-      "name": "Arkaner Bogenschütze",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH oder MM",
-        "Schießen W8"
-      ],
-      "beschreibung": "Pfeile verstärken für +1 Schießen und Schaden, oder Pfeile erhalten eine Ausprägung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkaner Bogenschütze II": {
-      "name": "Arkaner Bogenschütze II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Arkaner Bogenschütze"
-      ],
-      "beschreibung": "Phasenpfeile durchdringen Barrieren, oder Pfeilhagel gilt in großer Flächenschablone.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkaner Bogenschütze III": {
-      "name": "Arkaner Bogenschütze III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Arkaner Bogenschütze II"
-      ],
-      "beschreibung": "Ermächtigter Pfeil mit Flächeneffekt-Macht einmal pro Zug, oder Todespfeil einmal pro Tag (Opfer das durch Pfeil Angeschlagen wird oder eine Wunde erleidet, muss Konstitutionsprobe schaffen, oder es stirbt)",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkaner Betrüger": {
-      "name": "Arkaner Betrüger",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH",
-        "Diebeskunst W8"
-      ],
-      "beschreibung": "Weitreichende Fingerfertigkeit: kann Diebeskunst mit –2 auf Entfernung von 5'' verwenden; Spontaner Angriff: Einmal pro Begegnung kann der Schwindler Hinterhältiger Angriff ohne Überraschungsangriff oder Verwundbar verwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkaner Betrüger II": {
-      "name": "Arkaner Betrüger II",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Arkaner Betrüger"
-      ],
-      "beschreibung": "Unsichtbarer Dieb: einmal pro Tag automatisch Unsichtbarkeit für 1 Machtpunkt mit automatischer Steigerung (kein Wurf)",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkaner Betrüger III": {
-      "name": "Arkaner Betrüger III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Arkaner Betrüger II"
-      ],
-      "beschreibung": "Überraschungszauber: Die Zauber des Helden profitieren von Hinterhältiger Angriff.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Assassine": {
-      "name": "Assassine",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [],
-      "beschreibung": "Todesangriff: Wenn Assassine mit Überraschungsangriff angreift und mindestens eine Wunde erzielt, muss Opfer Konstitutionsprobe schaffen oder sterben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Assassine II": {
-      "name": "Assassine II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Assassine"
-      ],
-      "beschreibung": "Meisterliches Verstecken: –4 um Assassinen zu sehen, wenn er sich nicht bewegt. Widerstand gegen Gift: +4 Widerstand gegen Gift",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Assassine III": {
-      "name": "Assassine III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Assassine II"
-      ],
-      "beschreibung": "Todesengel: Der Assassine lässt ein getötetes Opfer zu Staub zerfallen und verhindert eine Wiederauferstehung. Schneller Tod: Einmal pro Tag erhält der Assassine einen Überraschungsangriff gegen ein Opfer seiner Wahl.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Drachenjünger": {
-      "name": "Drachenjünger",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH oder MM",
-        "Okkultismus W6"
-      ],
-      "beschreibung": "Odemangriff: 3W6 Schaden plus Ausprägung, Kegelschablone, einmal pro Begegnung",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Drachenjünger II": {
-      "name": "Drachenjünger II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Drachenjünger"
-      ],
-      "beschreibung": "Schwingen: Charakter erhält Flügel für Flug, Bewegungsweite 8.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Drachenjünger III": {
-      "name": "Drachenjünger III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Drachenjünger II"
-      ],
-      "beschreibung": "Drachengestalt: Zweimal pro Tag kann der Drachenjünger als beschränkte Aktion die Gestalt eines Drachens seiner Blutlinie annehmen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Duellant": {
-      "name": "Duellant",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Geschicklichkeit W8",
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Chirurgischer Schlag: +2 Schaden mit bestimmten Waffen. Parieren: Duellant kann sich Verteidigen, wenn er noch nicht gehandelt hat, mit Paradebonus +6.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Duellant II": {
-      "name": "Duellant II",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Duellant"
-      ],
-      "beschreibung": "Schwächender Schlag: Verringere Bewegungsweite des Gegners um 2 bis geheilt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Duellant III": {
-      "name": "Duellant III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Duellant II"
-      ],
-      "beschreibung": "Geschosse abwehren: –2, um mit physischen Fernkampfangriffen getroffen zu werden",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kundschafter-Chronist": {
-      "name": "Kundschafter-Chronist",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Überleben W6",
-        "Allgemeinwissen oder Okkultismus W8"
-      ],
-      "beschreibung": "Finden des Weges: Erhöht Reisegeschwindigkeit um 10 %, kann feindliche Begegnung umgehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kundschafter-Chronist II": {
-      "name": "Kundschafter-Chronist II",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kundschafter-Chronist"
-      ],
-      "beschreibung": "Epische Geschichten: Erzähle bei der Rast eine Geschichte, um Gruppe einen Benny zu gewähren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kundschafter-Chronist III": {
-      "name": "Kundschafter-Chronist III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Kundschafter-Chronist II"
-      ],
-      "beschreibung": "Rufen der Legenden: Beschwöre 5 Schatten für eine Stunde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Ritter": {
-      "name": "Mystischer Ritter",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH",
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Mystische Aufladung: Erhalte Machtpunkt bei Steigerung mit Angriff oder arkaner Fertigkeit.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Ritter II": {
-      "name": "Mystischer Ritter II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Mystischer Ritter"
-      ],
-      "beschreibung": "Mystischer Schlag: Gib 2 Machtpunkte nach Angriff aus, und addiere +2 auf Angriff.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Ritter III": {
-      "name": "Mystischer Ritter III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Mystischer Ritter II"
-      ],
-      "beschreibung": "Verb. Mystischer Schlag: Gib zwei Machtpunkte aus, nachdem du einen erfolgreichen Angriffswurf abgelegt hat, um den Schaden des Angriffs um +2 zu erhöhen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Theurg": {
-      "name": "Mystischer Theurg",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Magiefusion: Wirke zwei Zauber auf einmal und würfle eine arkane Fertigkeit für jede sowie den Wildcard-Würfel.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Theurg II": {
-      "name": "Mystischer Theurg II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Mystischer Theurg"
-      ],
-      "beschreibung": "Zaubersynergie: Verringere die Kosten beider Zauber wenn du Magiefusion verwendest.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Theurg III": {
-      "name": "Mystischer Theurg III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Mystischer Theurg II"
-      ],
-      "beschreibung": "Zaubersynthese: Klassentalente sind für alle Mächte verfügbar.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schattentänzer": {
-      "name": "Schattentänzer",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Darbietung W6",
-        "Heimlichkeit W8",
-        "Diebeskunst W6"
-      ],
-      "beschreibung": "Mächtige Dunkelsicht: Sehen in absoluter oder magischer Dunkelheit",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schattentänzer II": {
-      "name": "Schattentänzer II",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Schattentänzer"
-      ],
-      "beschreibung": "Schattenmantel: freies Schaden wegstecken mit –2 in Düsterer oder Dunkler Beleuchtung",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schattentänzer III": {
-      "name": "Schattentänzer III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schattentänzer II"
-      ],
-      "beschreibung": "Mystische Mächte (Schattenkraft): 10 gewidmete Machtpunkte zum Wirken von Flächenschlag, Illusion, Teleportation oder Verbündeten beschwören (nur Schatten) (nur selbst)",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wissenshüter": {
-      "name": "Wissenshüter",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Ver W8"
-      ],
-      "beschreibung": "Legendenkunde: freie Wiederholung bei Allgemeinwissen, Geisteswissenschaften, Okkultismus oder Naturwissenschaften",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wissenshüter II": {
-      "name": "Wissenshüter II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Wissenshüter"
-      ],
-      "beschreibung": "Geheimnis: Erhalte eine Fähigkeit eines Kern-Klassentalents.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wissenshüter III": {
-      "name": "Wissenshüter III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Wissenshüter II"
-      ],
-      "beschreibung": "Höhere Legendenkunde: Erhalte 2 neue Mächte, die in der Kampagne verfügbar sind.",
-      "neue_maechte": 2,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Chi": {
-      "name": "Chi",
-      "kategorie": "Übersinnlich",
-      "rang": "V",
-      "voraussetzungen": [
-        "Kampfkunstmeister"
-      ],
-      "beschreibung": "Einmal pro Kampf kannst du eine misslungene Kämpfenprobe wiederholen, einen Gegner einen erfolgreichen Angriff wiederholen lassen oder +W6 Schaden auf einen waffenlosen Angriff addieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mut in Flaschen": {
-      "name": "Mut in Flaschen",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "KON W8"
-      ],
-      "beschreibung": "Alkohol erhöht Konstitution um einen Würfeltyp und du ignorierst eine Stufe Wundabzüge; –1 Geschicklichkeit, Verstand und verknüpfte Fertigkeiten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Eiserner Wille": {
-      "name": "Eiserner Wille",
-      "kategorie": "Sozial",
-      "rang": "F",
-      "voraussetzungen": [
-        "Mutig",
-        "Starker Wille"
-      ],
-      "beschreibung": "Der Bonus gilt jetzt zum Widerstehen und Erholen von Mächten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnell": {
-      "name": "Schnell",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Held kann Aktionskarten von 5 oder weniger abwerfen und neu ziehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Riesentöter": {
-      "name": "Riesentöter",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "+1W6 Schaden gegen Kreaturen, deren Größe die eigene um 3 oder mehr übersteigt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ermittler": {
-      "name": "Ermittler",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W8",
-        "Geisteswissenschaften W8"
-      ],
-      "beschreibung": "+2 Geisteswissenschaften und auf bestimmte Wahrnehmungsproben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gelehrter": {
-      "name": "Gelehrter",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W8"
-      ],
-      "beschreibung": "+2 auf eine Wissensfertigkeit",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Reparaturgenie": {
-      "name": "Reparaturgenie",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Reparieren W8"
-      ],
-      "beschreibung": "+2 auf Reparieren, halbe Zeit bei Steigerung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Alchemist)": {
-      "name": "AH (Alchemist)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Arkane Fertigkeit: Alchemie (Verstand)",
-      "neue_maechte": 3,
-      "machtpunkte": 15,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Chemiker": {
-      "name": "Chemiker",
-      "kategorie": "Alchemist",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Alchemist)",
-        "Alchemie W8"
-      ],
-      "beschreibung": "Die Gebräue des Alchemisten halten eine Woche statt 48 Stunden, wenn sie an andere weitergegeben werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterlicher Alchemist": {
-      "name": "Meisterlicher Alchemist",
-      "kategorie": "Alchemist",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Alchemist)",
-        "Alchemie W10"
-      ],
-      "beschreibung": "Erlaubt die Herstellung permanenter Tränke zu halb so hohen Kosten mit improvisierten Vorräten oder einer Alchemistentasche.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Grabgesang": {
-      "name": "Grabgesang",
-      "kategorie": "Barde",
-      "rang": "H",
-      "voraussetzungen": [
-        "AH (Barde)"
-      ],
-      "beschreibung": "Löst Furcht aus und reduziert Proben von Feinden um -2, wenn sie Bennys verwenden. Der Barde muss singen oder ein Instrument spielen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heldentum inspirieren": {
-      "name": "Heldentum inspirieren",
-      "kategorie": "Barde",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Barde)",
-        "Darbietung W8"
-      ],
-      "beschreibung": "Erlaubt es, fünf Inspirations-Marker zu generieren, die Kameraden Boni auf Proben oder Schadenswürfe geben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Instrument": {
-      "name": "Instrument",
-      "kategorie": "Barde",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Barde)"
-      ],
-      "beschreibung": "Bietet +1 auf Darbietungsproben, wenn ein Instrument beim Zaubern verwendet wird.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Diabolist)": {
-      "name": "AH (Diabolist)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-      "neue_maechte": 5,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Elementarist)": {
-      "name": "AH (Elementarist)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-      "neue_maechte": 5,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Illusionist)": {
-      "name": "AH (Illusionist)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-      "neue_maechte": 5,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Nekromant)": {
-      "name": "AH (Nekromant)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Arkane Fertigkeit: Zaubern (Verstand)",
-      "neue_maechte": 5,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Schamane)": {
-      "name": "AH (Schamane)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6"
-      ],
-      "beschreibung": "Arkane Fertigkeit: Glaube (Willenskraft)",
-      "neue_maechte": 5,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "AH (Tüftler)": {
-      "name": "AH (Tüftler)",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Arkane Fertigkeit: Reparieren (Verstand)",
-      "neue_maechte": 2,
-      "machtpunkte": 15,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Stärkung": {
-      "name": "Arkane Stärkung",
-      "kategorie": "Beschwörer",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Beschwörer)"
-      ],
-      "beschreibung": "Beschworene Tiere erhalten einen magischen Harnisch, der ihre Robustheit um +2 erhöht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ungezügelte Beschwörung": {
-      "name": "Ungezügelte Beschwörung",
-      "kategorie": "Beschwörer",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Beschwörer)"
-      ],
-      "beschreibung": "Erlaubt dem Beschwörer, beschworenen Monstern ein Kampftalent seines Rangs oder niedriger zu gewähren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Höhere Beschwörung": {
-      "name": "Höhere Beschwörung",
-      "kategorie": "Beschwörer",
-      "rang": "H",
-      "voraussetzungen": [
-        "AH (Beschwörer)"
-      ],
-      "beschreibung": "Erlaubt das Beschwören mächtiger Kreaturen wie Barghest, Mammut, Frostmammut, Tyrannosaurus Rex oder jungen Drachen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zorn der Hölle": {
-      "name": "Zorn der Hölle",
-      "kategorie": "Diabolist",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Diabolist)"
-      ],
-      "beschreibung": "Mächte wie Flächenschlag, Geschoss und Strahl verursachen +2 Schaden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Infernale Rüstung": {
-      "name": "Infernale Rüstung",
-      "kategorie": "Diabolist",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Diabolist)"
-      ],
-      "beschreibung": "Verleiht +2 Rüstung durch eine höllische Aura, macht Heimlichkeit jedoch nahezu unmöglich.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Herzholzstab": {
-      "name": "Herzholzstab",
-      "kategorie": "Druide",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Druide)"
-      ],
-      "beschreibung": "Ein Kampfstab, der zusätzlichen Schaden verursacht und bei Verlust durch ein Ritual ersetzt werden kann.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wahre Form": {
-      "name": "Wahre Form",
-      "kategorie": "Druide",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Druide)"
-      ],
-      "beschreibung": "Ermöglicht Druiden, in Tierform zu sprechen und Mächte zu wirken, mit Risiken bei längerem Verweilen in Tiergestalt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Elementare Absorption": {
-      "name": "Elementare Absorption",
-      "kategorie": "Elementarmagier",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Elementarmagier)"
-      ],
-      "beschreibung": "Erhöht Robustheit um +2 während der Nutzung von Elementarsynergie.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Elementarer Meister": {
-      "name": "Elementarer Meister",
-      "kategorie": "Elementarmagier",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Elementarist)"
-      ],
-      "beschreibung": "Erlaubt die Beherrschung eines zusätzlichen Elements, Mächte können zwischen Elementen gewechselt werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Böser Blick": {
-      "name": "Böser Blick",
-      "kategorie": "Hexer/Hexe",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Hexer/Hexe)"
-      ],
-      "beschreibung": "Zwingt Feinde zu Willenskraftproben mit -2 bei der Nutzung von Bennys, die fehlschlagen können.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Hexenzeit": {
-      "name": "Hexenzeit",
-      "kategorie": "Hexer/Hexe",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Hexer/Hexe)"
-      ],
-      "beschreibung": "Verleiht Boni während einer besonderen Stunde, z. B. keine Kritischen Fehlschläge und kostenloses Wegstecken von Schaden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tödliche Illusion": {
-      "name": "Tödliche Illusion",
-      "kategorie": "Illusionist",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Illusionist)",
-        "Zaubern W10"
-      ],
-      "beschreibung": "Erlaubt den Einsatz des Machtmodifikators Tödliche Illusion ohne zusätzliche Machtpunkte.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterlicher Illusionist": {
-      "name": "Meisterlicher Illusionist",
-      "kategorie": "Illusionist",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Illusionist)",
-        "Zaubern W8"
-      ],
-      "beschreibung": "Illusionen erhalten die Machtmodifikatoren Beweglich und Geräusch ohne zusätzliche Machtpunkte.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Untote zerstören": {
-      "name": "Untote zerstören",
-      "kategorie": "Kleriker",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Kleriker)"
-      ],
-      "beschreibung": "Kanalisierung positiver Energie, um Untote mit 2W6 (oder 3W6 für 2 Machtpunkte) Schaden zu treffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gnade": {
-      "name": "Gnade",
-      "kategorie": "Kleriker",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Kleriker)",
-        "Glaube W8"
-      ],
-      "beschreibung": "Hebt Abgelenkt, Angeschlagen oder Verwundbar durch Einsatz von 1 Machtpunkt auf.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unheimliche Inspiration": {
-      "name": "Unheimliche Inspiration",
-      "kategorie": "Magier",
-      "rang": "H",
-      "voraussetzungen": [
-        "AH (Magier)"
-      ],
-      "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht mit einem Benny, solange Zugang zu Zauberbüchern besteht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zauberbücher": {
-      "name": "Zauberbücher",
-      "kategorie": "Magier",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Magie)"
-      ],
-      "beschreibung": "Erhält drei neue Mächte bei Wahl des Talents Neue Mächte und sofort eine Macht des eigenen Ranges.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Seelengefäß": {
-      "name": "Seelengefäß",
-      "kategorie": "Nekromant",
-      "rang": "L",
-      "voraussetzungen": [
-        "AH (Nekromant)",
-        "Okkultismus W10"
-      ],
-      "beschreibung": "Versteckt die Seele in einem Behälter, um nach dem Tod in einen vorbereiteten Leichnam zurückzukehren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Untoter Vertrauter": {
-      "name": "Untoter Vertrauter",
-      "kategorie": "Nekromant",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Nekromant)"
-      ],
-      "beschreibung": "Erhält einen untoten Tiergefährten mit speziellen Boni, ähnlich wie das Talent Vertrauter.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Urtümliche Magie": {
-      "name": "Urtümliche Magie",
-      "kategorie": "Schamane",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Schamane)"
-      ],
-      "beschreibung": "Erhöht Schaden von Mächten um +2, verursacht jedoch bei Kritischen Fehlschlägen Betäubung im Umkreis.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Geweihter Fetisch": {
-      "name": "Geweihter Fetisch",
-      "kategorie": "Schamane",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Schamane)",
-        "Glaube W8"
-      ],
-      "beschreibung": "Verleiht eine Freie Wurfwiederholung bei Glaubensproben, wenn ein geweihter Fetisch genutzt wird.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Konstrukt-Vertrauter": {
-      "name": "Konstrukt-Vertrauter",
-      "kategorie": "Tüftler",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Tüftler)"
-      ],
-      "beschreibung": "Erhält einen mechanischen Tiergefährten mit speziellen Vorteilen, ähnlich wie das Talent Vertrauter.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tüftlerrüstung": {
-      "name": "Tüftlerrüstung",
-      "kategorie": "Tüftler",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Tüftler)"
-      ],
-      "beschreibung": "Ermöglicht modifizierte Rüstung mit Boni auf Arme, Rumpf oder Beine, unterliegt jedoch Ausfällen bei Wunden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Große Macht": {
-      "name": "Große Macht",
-      "kategorie": "Zauberer",
-      "rang": "V",
-      "voraussetzungen": [
-        "AH (Zauberer)"
-      ],
-      "beschreibung": "Ermöglicht das Wirken einer beliebigen Macht bis 20 Machtpunkte mit einem Abzug von -2 auf die Zaubernprobe.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Phänomenale Macht": {
-      "name": "Phänomenale Macht",
-      "kategorie": "Zauberer",
-      "rang": "H",
-      "voraussetzungen": [
-        "AH (Zauberer)",
-        "Große Macht"
-      ],
-      "beschreibung": "Erlaubt das Wirken jeder Macht mit Entschlossenheit und fügt den Entschlossenheitsbonus dem Zauberwurf hinzu.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Auserkoren": {
-      "name": "Auserkoren",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Entschlossenheit hält bis zum Ende der Begegnung an, ohne dass sie mit Bennys aufrechterhalten werden muss. Der Charakter hat ein unverkennbares Mal und wird von mächtigen Feinden verfolgt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bevorzugtes Gelände": {
-      "name": "Bevorzugtes Gelände",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Überleben W6"
-      ],
-      "beschreibung": "Wähle ein Geländetyp. In diesem Gelände erhält der Charakter eine freie Wiederholung bei Überlebens- und Wahrnehmungsproben sowie eine zusätzliche Aktionskarte zur Initiative.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Erbstück": {
-      "name": "Erbstück",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Gewährt einen magischen Gegenstand im Wert von bis zu 10.000 Goldmünzen. Der Gegenstand muss bei Verlust durch ein Abenteuer wiedergefunden werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Erzfeind": {
-      "name": "Erzfeind",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Athletik W6",
-        "Kämpfen oder Schießen W6"
-      ],
-      "beschreibung": "Wähle eine Art von Feind. Der Charakter erhält eine freie Wiederholung bei Überlebensproben, um diese zu verfolgen, und bei Angriffen auf diese Feinde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Feenblütig": {
-      "name": "Feenblütig",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Gewährt eine freie Wiederholung, um feindlichen Mächten und zauberähnlichen Effekten zu widerstehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Betäubungsschlag": {
-      "name": "Betäubungsschlag",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "STÄ W8"
-      ],
-      "beschreibung": "Schläge mit stumpfen Waffen zwingen Gegner zu Konstitutionsproben. Bei einem Misserfolg wird der Gegner Betäubt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Böe": {
-      "name": "Böe",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [],
-      "beschreibung": "Mächtige Flügelschläge können Gegner in einem Kegel Angeschlagen machen oder Betäuben, wenn ein Joker gezogen wird.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Doppelschuss": {
-      "name": "Doppelschuss",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Athletik W8 für Wurfwaffen oder Schießen W8 für Bögen"
-      ],
-      "beschreibung": "Erlaubt das Schießen oder Werfen von zwei Geschossen in einem Angriff mit separaten Angriffswürfen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Vierfachschuss": {
-      "name": "Vierfachschuss",
-      "kategorie": "Kampf",
-      "rang": "H",
-      "voraussetzungen": [
-        "Doppelschuss",
-        "Athletik W10 für Wurfwaffen oder Schießen W10 für Bögen"
-      ],
-      "beschreibung": "Erlaubt das zweimalige Nutzen des Talents Doppelschuss pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unglaubliche Reflexe": {
-      "name": "Unglaubliche Reflexe",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Geschicklichkeit W8",
-        "Athletik W8"
-      ],
-      "beschreibung": "Der Charakter ignoriert den üblichen -2 Geschicklichkeits-Abzug beim Wegspringen und kann bei Flächeneffekten oder Angriffen wie Strahl oder Verwirrung Wegspringen anwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Versengen": {
-      "name": "Versengen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "KON W8"
-      ],
-      "beschreibung": "Erhöht den Schaden einer Odemwaffe um einen Würfeltyp und erlaubt die Wahl zwischen Kegel- und Strahlschablone.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verteidiger": {
-      "name": "Verteidiger",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Erlaubt das Teilen des Parade- und Deckungsbonus eines Schildes mit einem Verbündeten in der Nähe als freie Aktion.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wildling": {
-      "name": "Wildling",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Ein Rücksichtsloser Angriff verursacht +4 Schaden statt +2.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zerschmettern": {
-      "name": "Zerschmettern",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W8"
-      ],
-      "beschreibung": "Fügt bei Angriffen auf Objekte +W6 Schaden hinzu, wobei die Schadenswürfel nicht explodieren können.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Artefakterschaffer": {
-      "name": "Artefakterschaffer",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Erlaubt die Herstellung von temporären Arkane Apparaturen und permanenter magischer Gegenstände.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterlicher Artefakterschaffer": {
-      "name": "Meisterlicher Artefakterschaffer",
-      "kategorie": "Macht",
-      "rang": "H",
-      "voraussetzungen": [
-        "Artefakterschaffer",
-        "Okkultismus W10"
-      ],
-      "beschreibung": "Erhöht die Belohnung für Okkultismusproben bei der Herstellung magischer Gegenstände auf 1000 G pro Erfolg oder Steigerung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bevorzugte Macht": {
-      "name": "Bevorzugte Macht",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (beliebig)",
-        "Glaube oder Zaubern W8"
-      ],
-      "beschreibung": "Erlaubt das Ignorieren von bis zu zwei Punkten Abzügen bei der Aktivierung einer ausgewählten Macht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Blutmagie": {
-      "name": "Blutmagie",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Gewährt W6 Machtpunkte zurück, wenn der Charakter einem bewussten Wesen eine Wunde zufügt, die nicht weggesteckt wird.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Epische Meisterschaft": {
-      "name": "Epische Meisterschaft",
-      "kategorie": "Macht",
-      "rang": "V",
-      "voraussetzungen": [
-        "AH (beliebig)",
-        "Glaube oder Zaubern W6"
-      ],
-      "beschreibung": "Gewährt Zugang zu epischen Machtmodifikatoren für alle Mächte des Helden. Gilt für alle arkanen Hintergründe, die der Charakter besitzt, wenn er die Voraussetzungen erfüllt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystische Kräfte": {
-      "name": "Mystische Kräfte",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "Fortgeschritten"
-      ],
-      "beschreibung": "Erlaubt das Erlernen von 10 dedizierten Machtpunkten mit ausgewählten Mächten, die automatisch aktiviert werden können. Die Mächte und Einschränkungen sind abhängig vom gewählten Paket (z. B. Barbar, Kämpfer, Mönch, etc.).",
-      "neue_maechte": 0,
-      "machtpunkte": 10,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schlachtenmagie": {
-      "name": "Schlachtenmagie",
-      "kategorie": "Macht",
-      "rang": "V",
-      "voraussetzungen": [
-        "AH (beliebig)",
-        "Glaube oder Zaubern W10"
-      ],
-      "beschreibung": "Erlaubt das Wirken von Zaubern auf große Einheiten von Statisten. Siehe Regeln für Schlachtenmagie.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Stillzauberer": {
-      "name": "Stillzauberer",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (jeder außer Barde)",
-        "Okkultismus W8"
-      ],
-      "beschreibung": "Erlaubt das Wirken von Zaubern ohne zu sprechen. Funktioniert auch unter Wasser, in einem Vakuum, oder innerhalb der Macht Stille.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Übertragung": {
-      "name": "Übertragung",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Erlaubt das Übertragen von bis zu fünf Machtpunkten auf eine andere Person in Sichtweite als begrenzte freie Aktion.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Vertrauter": {
-      "name": "Vertrauter",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Diabolist, Druide, Elementarmagier, Schamane, Hexer, Nekromant, Hexer, Zauberer, Hexenmeister)"
-      ],
-      "beschreibung": "Gewährt einen loyalen magischen Begleiter, der 5 eigene Machtpunkte hat und als Wildcard fungiert. Der Vertraute kann keine Zauber wirken, aber der Meister kann auf seine Machtpunkte zugreifen.",
-      "neue_maechte": 0,
-      "machtpunkte": 5,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Entdecker": {
-      "name": "Entdecker",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "KON W6",
-        "Überleben W8"
-      ],
-      "beschreibung": "Ermöglicht eine zusätzliche Aktionskarte bei Reisen und verkürzt die Reisezeit der Gruppe um 10%.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Fallengespür": {
-      "name": "Fallengespür",
-      "kategorie": "Experte",
-      "rang": "F",
-      "voraussetzungen": [
-        "Reparieren W6"
-      ],
-      "beschreibung": "Ermöglicht eine Wahrnehmungsprobe zum Erkennen von Fallen in 10 Metern Entfernung und ignoriert 2 Punkte Abzüge beim Entschärfen von Fallen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Giftmischer": {
-      "name": "Giftmischer",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Alchemie, Heilen oder Überleben W6"
-      ],
-      "beschreibung": "Erstellt Gifte in der Hälfte der Zeit, die Kontaktgifte halten 12 statt 4 Stunden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Im Sattel geboren": {
-      "name": "Im Sattel geboren",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Geschicklichkeit W8",
-        "Reiten W6"
-      ],
-      "beschreibung": "Verleiht eine freie Wiederholung bei Reitenproben, erhöht die Bewegungsweite des Reittiers um 2 und den Sprintwürfel um einen Würfeltyp.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kundschafter": {
-      "name": "Kundschafter",
-      "kategorie": "Experte",
-      "rang": "F",
-      "voraussetzungen": [
-        "Überleben W6"
-      ],
-      "beschreibung": "Ermöglicht Wahrnehmungsproben zum frühzeitigen Erkennen von Gefahren, verbessert Wachsamkeit und gibt Boni auf Allgemeinwissen über bereiste Orte.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Reittier": {
-      "name": "Reittier",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Reiten W6"
-      ],
-      "beschreibung": "Gewährt ein treues, aufsteigbares Reittier mit besonderen Fähigkeiten. Ermöglicht die Wahl eines mächtigen Reittiers auf höheren Rängen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ritter": {
-      "name": "Ritter",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "STÄ W8",
-        "KON W8",
-        "Kämpfen W8",
-        "Reiten W6"
-      ],
-      "beschreibung": "Repräsentiert einen Lehnsherrn, gewährt +1 auf Einschüchtern- oder Überredenproben gegenüber Autorität-respektierenden Personen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schatzjäger": {
-      "name": "Schatzjäger",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Wahrnehmung W8",
-        "Okkultismus W8"
-      ],
-      "beschreibung": "Erlaubt Verstandsproben zur Einschätzung von Schätzen und magischen Gegenständen. Ermöglicht das Neuwürfeln von magischen Gegenstandseffekten mit einem Benny.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Steingespür": {
-      "name": "Steingespür",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Reparieren W6"
-      ],
-      "beschreibung": "Erhöht Wahrnehmungsproben um +2, um Fallen oder versteckte Türen in Stein zu entdecken.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Troubadour": {
-      "name": "Troubadour",
-      "kategorie": "Experte",
-      "rang": "F",
-      "voraussetzungen": [
-        "Allgemeinwissen W6",
-        "Darbietung W8"
-      ],
-      "beschreibung": "Gewährt +2 auf Allgemeinwissenproben und erlaubt die Nutzung von Darbietung statt Kriegskunst für Anführertalente.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Täuscher": {
-      "name": "Täuscher",
-      "kategorie": "Sozial",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W8"
-      ],
-      "beschreibung": "Erlaubt das Ziel, bei Herausforderungen entweder mit Verstand oder Willenskraft zu widerstehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Aura der Tapferkeit": {
-      "name": "Aura der Tapferkeit",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Verbündete im Umkreis von 20 Metern erhalten +1 auf Furchtproben und -1 auf der Furchttabelle.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bestienflüsterer": {
-      "name": "Bestienflüsterer",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Erlaubt es, mit einer Tiergattung zu kommunizieren und Informationen von ihnen zu erhalten, abhängig von ihrer Intelligenz.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelle Verwandlung": {
-      "name": "Schnelle Verwandlung",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Erlaubt eine Formveränderung als begrenzte Aktion statt der üblichen 10 Minuten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Aristokrat": {
-      "name": "Aristokrat",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "+2 auf Allgemeinwissen und Informationsbeschaffung in der Oberschicht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Resistenz": {
-      "name": "Arkane Resistenz",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –2 verringert.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Starke Arkane Resistenz": {
-      "name": "Starke Arkane Resistenz",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Arkane Resistenz"
-      ],
-      "beschreibung": "Arkane Fertigkeiten, die den Helden als Ziel haben, erleiden einen Abzug von –2 (gilt auch für Verbündete); magischer Schaden wird um –4 verringert.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Attraktiv": {
-      "name": "Attraktiv",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "KON W6"
-      ],
-      "beschreibung": "+1 auf Darbietung und Überreden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Sehr Attraktiv": {
-      "name": "Sehr Attraktiv",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Attraktiv"
-      ],
-      "beschreibung": "+2 auf Darbietung und Überreden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Aufmerksamkeit": {
-      "name": "Aufmerksamkeit",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "+2 auf Wahrnehmungsproben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Beidhändig": {
-      "name": "Beidhändig",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Ignoriere den Abzug von –2 für Aktionen mit der falschen Hand.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bekannt": {
-      "name": "Bekannt",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "+1 auf Überredenproben, wenn erkannt (Allgemeinwissen), doppelte normale Summe für Darbietung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Berühmt": {
-      "name": "Berühmt",
-      "kategorie": "Hintergrund",
-      "rang": "F",
-      "voraussetzungen": [
-        "Bekannt"
-      ],
-      "beschreibung": "+2 auf Überredenproben, wenn erkannt (Allgemeinwissen), fünffache normale Summe oder mehr für Darbietung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Charismatisch": {
-      "name": "Charismatisch",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Freie Wiederholung bei der Verwendung von Überreden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Elan": {
-      "name": "Elan",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "+2 beim Ausgeben eines Bennys für die Wiederholung einer Eigenschaftsprobe.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Flink": {
-      "name": "Flink",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W6"
-      ],
-      "beschreibung": "Bewegungsweite +2, erhöhe Sprintwürfel um einen Schritt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Glück": {
-      "name": "Glück",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "+1 Benny zu Beginn jeder Sitzung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Großes Glück": {
-      "name": "Großes Glück",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Glück"
-      ],
-      "beschreibung": "+2 Bennys zu Beginn jeder Sitzung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kräftig": {
-      "name": "Kräftig",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W6",
-        "KON W6"
-      ],
-      "beschreibung": "Größe (und somit Robustheit) +1. Behandle Stärke als einen Würfeltyp höher für Belastung und Mindeststärke bei Waffen, Rüstung und Ausrüstung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Linguist": {
-      "name": "Linguist",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Charakter hat einen W6 in Sprachen gleich halbem Verstandswürfel.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mutig": {
-      "name": "Mutig",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6"
-      ],
-      "beschreibung": "+2 auf Furchtproben und –2 bei Würfen auf der Furchttabelle.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Reich": {
-      "name": "Reich",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Charakter beginnt mit dreifachem Startkapital und einem Jahreseinkommen von $150.000.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Stinkreich": {
-      "name": "Stinkreich",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Reich"
-      ],
-      "beschreibung": "Fünffaches Startkapital und $500.000 Jahreseinkommen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Rohling": {
-      "name": "Rohling",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W6",
-        "KON W6"
-      ],
-      "beschreibung": "Verknüpfe Athletik mit Stärke anstelle von Geschicklichkeit (auch für Herausfordern). Kurze Entfernung von geworfenen Gegenständen +1. Verdopple den Bonus für die angepasste mittlere Entfernung und nochmal für die weite Entfernung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelle Heilung": {
-      "name": "Schnelle Heilung",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "KON W8"
-      ],
-      "beschreibung": "+2 Konstitution für natürliche Heilung, Wurf alle 3 Tage.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Engelsschwingen": {
-      "name": "Engelsschwingen",
-      "kategorie": "Hintergrund",
-      "rang": "F",
-      "voraussetzungen": [
-        "Volk: Aasimars"
-      ],
-      "beschreibung": "Der Charakter wächst Flügel aus göttlichem Licht. Er erhält eine Flug-Bewegungsweite von 6\" und muss sich pro Runde mindestens 1\" fortbewegen oder landen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Rüstung des Abgrunds": {
-      "name": "Rüstung des Abgrunds",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Tieflinge"
-      ],
-      "beschreibung": "+2 natürlicher Rüstungsschutz sowie Umgebungsresistenz gegen Kälte, Elektrizität oder Feuer (Wahl bei Erwerb des Talents).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Naturverbundenheit": {
-      "name": "Naturverbundenheit",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Elf"
-      ],
-      "beschreibung": "Im bevorzugten Gelände (aus dem Talent Bevorzugtes Gelände) kann der Charakter jede 24 Stunden einen natürlichen Heilungswurf mit +2 Bonus ablegen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bluttrinker": {
-      "name": "Bluttrinker",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Dhampire"
-      ],
-      "beschreibung": "Der Charakter kann einen natürlichen Heilungswurf durchführen, wenn er Blut trinkt (erfordert eine Aktion und einen willigen oder wehrlosen Spender).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Brenn! Brenn! Brenn!": {
-      "name": "Brenn! Brenn! Brenn!",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Goblin",
-        "Diebeskunst W6"
-      ],
-      "beschreibung": "Der Charakter verursacht mit natürlichem Feuer erhöhten Schaden: Brennende Gegenstände, Fackeln und ähnliche Lichtquellen fügen in seiner Hand +1 Würfeltyp Schaden zu.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Lässiger Illusionist": {
-      "name": "Lässiger Illusionist",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Gnom"
-      ],
-      "beschreibung": "Durch Ausgabe von Machtpunkten erhält der Charakter einen Bonus auf Täuschen- oder Heimlichkeitsproben: 1 MP für +1, 2 MP für +2, bis zu +4.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Himmlischer Diener": {
-      "name": "Himmlischer Diener",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Aasimars",
-        "Tiermeister"
-      ],
-      "beschreibung": "Der Begleiter des Aasimars erhält einen himmlischen Segen: +2 auf alle Eigenschaftswürfe und der Begleiter gilt als übernatürliches Wesen mit entsprechenden Widerstandsboni.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Krallensturz": {
-      "name": "Krallensturz",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Katzenfolk",
-        "GES W6",
-        "STÄ W6"
-      ],
-      "beschreibung": "Erfordert die Alternativfähigkeit Katzenkrallen. Bei einem Rücksichtslosen Angriff mit Klauen erhält der Charakter +2 Schaden zusätzlich zum normalen Bonus des Rücksichtslosen Angriffs.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tiefblick": {
-      "name": "Tiefblick",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        {
-          "oder": [
-            "Volk-Eigenschaft: dunkelsicht",
-            "Volk-Eigenschaft: nachtsicht"
-          ]
+    "maechte": {
+        "Abwehren": {
+            "name": "Abwehren",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "–2/–4 bei Angriffen auf Empfänger",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Arkaner Schutz": {
+            "name": "Arkaner Schutz",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Gegnerische Wirker ziehen –2 (–4 mit Steigerung) ab, wenn sie den Charakter mit Mächten angreifen; verringert Schaden um die gleiche Summe",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Arkanes entdecken/verbergen": {
+            "name": "Arkanes entdecken/verbergen",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5/1h",
+            "beschreibung": "Entdeckt Magie für Wirkungsdauer 5 oder verbirgt sie für 1 Stunde",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Aufheben": {
+            "name": "Aufheben",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Negiert magische Effekte",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Aufspüren": {
+            "name": "Aufspüren",
+            "rang": "A",
+            "machtpunkte": 3,
+            "reichweite": "Selbst",
+            "dauer": "10 Minuten",
+            "beschreibung": "Findet ein Objekt",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Ausspähung": {
+            "name": "Ausspähung",
+            "rang": "F",
+            "machtpunkte": 3,
+            "reichweite": "Selbst",
+            "dauer": "5",
+            "beschreibung": "Wirker kann ein Ziel und seine Umgebung auf Entfernung sehen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Barriere": {
+            "name": "Barriere",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Erschafft Barriere mit 5ʺ (10 Meter) Länge, 1ʺ (2 Meter) Höhe und Härte 10 (12 mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Betäuben": {
+            "name": "Betäuben",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Ziel ist Betäubt",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Bindender Ruf": {
+            "name": "Bindender Ruf",
+            "rang": "V",
+            "machtpunkte": 8,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Beschwört und bindet eine Kreatur von einer anderen Ebene",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Blenden": {
+            "name": "Blenden",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Verursacht Abzug von –2/–4 bei Opfern",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Böswillige Verwandlung": {
+            "name": "Böswillige Verwandlung",
+            "rang": "V",
+            "machtpunkte": 3,
+            "reichweite": "Ver",
+            "dauer": "5",
+            "beschreibung": "Tier von Größe –2 bis 3 wird in eine relativ harmlose Kreatur verwandelt",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Chaos": {
+            "name": "Chaos",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Ziele in MFS oder Kegel sind Abgelenkt und könnten geschleudert werden",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Dunkelsicht": {
+            "name": "Dunkelsicht",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver",
+            "dauer": "1 Stunde",
+            "beschreibung": "Ignoriere bis zu 4 Punkte Beleuchtungsabzüge, 6 bei Steigerung",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Ebenenwechsel": {
+            "name": "Ebenenwechsel",
+            "rang": "V",
+            "machtpunkte": 5,
+            "reichweite": "Ver",
+            "dauer": "5",
+            "beschreibung": "Erlaubt Reisen zu anderen Existenzebenen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Eigenschaft erhöhen/senken": {
+            "name": "Eigenschaft erhöhen/senken",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5/Sofort",
+            "beschreibung": "Erhöht oder senkt Fertigkeit oder Attribut",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Elementarmanipulation": {
+            "name": "Elementarmanipulation",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Erlaubt einfache Manipulation der grundlegenden Elemente",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Empathie": {
+            "name": "Empathie",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Vergleichender Wurf gegen Willenskraft, für +1/+2 auf Darbietung, Einschüchtern, Provozieren und Überreden gegen das Ziel",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Fernsicht": {
+            "name": "Fernsicht",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Sieht Details auf größere Entfernung; halbiert Entfernungsabzüge bei Steigerung",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Flächenschlag": {
+            "name": "Flächenschlag",
+            "rang": "F",
+            "machtpunkte": 3,
+            "reichweite": "Ver×2",
+            "dauer": "Sofort",
+            "beschreibung": "2W6 Schaden in mittlerer Flächenschablone",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Fliegen": {
+            "name": "Fliegen",
+            "rang": "V",
+            "machtpunkte": 3,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Ziel fliegt mit Bewegungsweite 12",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Fluch": {
+            "name": "Fluch",
+            "rang": "F",
+            "machtpunkte": 5,
+            "reichweite": "Berührung",
+            "dauer": "Speziell",
+            "beschreibung": "Legt Fluch auf Ziel",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Furcht": {
+            "name": "Furcht",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Verursacht Furchtproben",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gedankenleere": {
+            "name": "Gedankenleere",
+            "rang": "V",
+            "machtpunkte": 3,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Entfernt oder verändert Erinnerungen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gedankenlesen": {
+            "name": "Gedankenlesen",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Vergleichender Wurf gegen Verstand zum Gedankenlesen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gedankenverbindung": {
+            "name": "Gedankenverbindung",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 30m",
+            "dauer": "5",
+            "beschreibung": "Geistige Verbindung auf 1,5 Kilometer (8 mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gegenstand beschwören": {
+            "name": "Gegenstand beschwören",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "1 Stunde",
+            "beschreibung": "Beschwört Gegenstand, 1 Pfund pro 2 Machtpunkte",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Geräusch/Stille": {
+            "name": "Geräusch/Stille",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver×5/Ver",
+            "dauer": "5/Sofort",
+            "beschreibung": "Erzeugt oder dämpft Geräusche",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Geschoss": {
+            "name": "Geschoss",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver×2",
+            "dauer": "Sofort",
+            "beschreibung": "2W6 Fernkampfangriff",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gestaltwandeln": {
+            "name": "Gestaltwandeln",
+            "rang": "A",
+            "machtpunkte": 3,
+            "reichweite": "Selbst",
+            "dauer": "5",
+            "beschreibung": "Wirker nimmt die Gestalt verschiedener Wesen an",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Graben": {
+            "name": "Graben",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Ziel gräbt sich durch die Erde",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Heiligtum": {
+            "name": "Heiligtum",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Berührung",
+            "dauer": "5",
+            "beschreibung": "Feinde müssen Willenskraftprobe machen, um angreifen zu können",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Heilung": {
+            "name": "Heilung",
+            "rang": "A",
+            "machtpunkte": 3,
+            "reichweite": "Berührung",
+            "dauer": "Sofort",
+            "beschreibung": "Stellt Wunden wieder her, die weniger als eine Stunde alt sind",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Illusion": {
+            "name": "Illusion",
+            "rang": "A",
+            "machtpunkte": 3,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Erschafft eine visuelle Szene oder Abbildung von so gut wie allem, was der Wirker sich vorstellen kann",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Kriegersegen": {
+            "name": "Kriegersegen",
+            "rang": "F",
+            "machtpunkte": 4,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Gewährt Ziel ein Kampftalent",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Licht/Dunkelheit": {
+            "name": "Licht/Dunkelheit",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 10m",
+            "dauer": "5",
+            "beschreibung": "Erschafft oder verbannt Beleuchtung",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Linderung": {
+            "name": "Linderung",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver",
+            "dauer": "Sofort/1h",
+            "beschreibung": "Entfernt Zustände Angeschlagen, Abgelenkt oder Verwundbar (2 mit Steigerung) oder ignoriert 1 Punkt Wund- und Erschöpfungsabzüge (2 mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Machtpunkte entziehen": {
+            "name": "Machtpunkte entziehen",
+            "rang": "V",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Entzieht Gegner W6 Machtpunkte bei erfolgreichem vergleichendem Wurf",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Magisches Glas": {
+            "name": "Magisches Glas",
+            "rang": "H",
+            "machtpunkte": 5,
+            "reichweite": "Ver",
+            "dauer": "5 Stunden",
+            "beschreibung": "Überträgt die Seele des Wirkers in ein verzaubertes Gefäß (Kristall oder Edelstein). Der Wirker kann zwischen Gefäß und Körper wechseln (Körper wirkt leblos) und versuchen, andere Körper zu besetzen (vergleichender Wurf arkane Fertigkeit vs. Geist). Bei Erfolg wird die Seele des Opfers im Gefäß gefangen. Verstand, Willenskraft, Gesinnung und Vorteile des Wirkers bleiben erhalten; Körperattribute und Wunden stammen vom Wirt.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Marionette": {
+            "name": "Marionette",
+            "rang": "V",
+            "machtpunkte": 3,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Ziel zu kontrollieren",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Objekt auslesen": {
+            "name": "Objekt auslesen",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Berührung",
+            "dauer": "Speziell",
+            "beschreibung": "Offenbart vage Erinnerungen der Geschichte des Ziels (mehr Details mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schadensfeld": {
+            "name": "Schadensfeld",
+            "rang": "F",
+            "machtpunkte": 4,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Erschafft Aura, die 2W4 Schaden verursacht",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schlummer": {
+            "name": "Schlummer",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "1 Stunde",
+            "beschreibung": "Lässt Opfer einschlafen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schutz": {
+            "name": "Schutz",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Gewährt Panzerung +2 bei Erfolg, Robustheit +2 bei Steigerung",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Schutz vor Naturgewalten": {
+            "name": "Schutz vor Naturgewalten",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "1 Stunde",
+            "beschreibung": "Beschützt Ziel vor schädlichen Umwelteinflüssen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Sprachen sprechen": {
+            "name": "Sprachen sprechen",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 10m",
+            "dauer": "5",
+            "beschreibung": "Wirker kann Sprachen sprechen und verstehen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Strahl": {
+            "name": "Strahl",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Kegel",
+            "dauer": "Sofort",
+            "beschreibung": "Kegelförmiger Angriff mit 2W6 Schaden",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Telekinese": {
+            "name": "Telekinese",
+            "rang": "F",
+            "machtpunkte": 5,
+            "reichweite": "Ver×2",
+            "dauer": "5",
+            "beschreibung": "Bewegt Gegenstände mit Stärke W10 (W12 mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Teleportation": {
+            "name": "Teleportation",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Charakter teleportiert sich bis zu 12ʺ weit",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Tierfreund": {
+            "name": "Tierfreund",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Ver 10m",
+            "dauer": "5",
+            "beschreibung": "Kontrolliert Tiere",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Trägheit/Beschleunigung": {
+            "name": "Trägheit/Beschleunigung",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort/5",
+            "beschreibung": "Erhöht oder verlangsamt Bewegung",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Unberührbarkeit": {
+            "name": "Unberührbarkeit",
+            "rang": "V",
+            "machtpunkte": 5,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Ziel wird körperlos",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Unsichtbarkeit": {
+            "name": "Unsichtbarkeit",
+            "rang": "F",
+            "machtpunkte": 5,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Ziel wird unsichtbar (–4/–6, um es zu beeinflussen)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verbannen": {
+            "name": "Verbannen",
+            "rang": "V",
+            "machtpunkte": 3,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Wesenheiten zu verbannen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verbündeten beschwören": {
+            "name": "Verbündeten beschwören",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Beschwört verschiedene Verbündete",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verkleiden": {
+            "name": "Verkleiden",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver 10m",
+            "dauer": "5",
+            "beschreibung": "Ziel sieht aus wie jemand anders",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verstricken": {
+            "name": "Verstricken",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Feind wird Gebunden oder Festgehalten",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verwirrung": {
+            "name": "Verwirrung",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver",
+            "dauer": "Speziell",
+            "beschreibung": "Macht Ziel Abgelenkt und Verwundbar",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Wachsen/Schrumpfen": {
+            "name": "Wachsen/Schrumpfen",
+            "rang": "F",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Erhöht oder verringert Größe",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Waffe verbessern": {
+            "name": "Waffe verbessern",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Erhöht Schaden einer Waffe um +2/+4",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Wandkrabbler": {
+            "name": "Wandkrabbler",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Ver 5",
+            "dauer": "5",
+            "beschreibung": "Charakter kann mit halber Bewegungsweite an Wänden laufen (volle Bewegungsweite mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Wiederauferstehung": {
+            "name": "Wiederauferstehung",
+            "rang": "H",
+            "machtpunkte": 20,
+            "reichweite": "Berührung",
+            "dauer": "Sofort",
+            "beschreibung": "Erweckt die Toten zum Leben",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Wunsch": {
+            "name": "Wunsch",
+            "rang": "L",
+            "machtpunkte": 20,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Wähle eines von mehreren realitätsverändernden Ereignissen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zeitstopp": {
+            "name": "Zeitstopp",
+            "rang": "H",
+            "machtpunkte": 8,
+            "reichweite": "Ver",
+            "dauer": "Sofort",
+            "beschreibung": "Wirker erhält einen zusätzlichen Zug (bis zu 4 Aktionen mit Steigerung)",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zombie": {
+            "name": "Zombie",
+            "rang": "V",
+            "machtpunkte": 3,
+            "reichweite": "Ver",
+            "dauer": "1 Stunde",
+            "beschreibung": "Erhebt und kontrolliert Untote",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zwiesprache": {
+            "name": "Zwiesprache",
+            "rang": "F",
+            "machtpunkte": 5,
+            "reichweite": "Selbst",
+            "dauer": "5 Minuten",
+            "beschreibung": "Wirker kann anderweltlichen Wesenheit Fragen stellen",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Gegenstand Beschwören": {
+            "name": "Gegenstand Beschwören",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Verstand",
+            "dauer": "Eine Stunde",
+            "beschreibung": "Erschafft einen Gegenstand bis 0,5 kg pro 2 Machtpunkte.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Monster Beschwören": {
+            "name": "Monster Beschwören",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Verstand",
+            "dauer": "5",
+            "beschreibung": "Beschwört ein mächtiges Monster.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Mystisches Eingreifen": {
+            "name": "Mystisches Eingreifen",
+            "rang": "Legendär",
+            "machtpunkte": 20,
+            "reichweite": "Speziell",
+            "dauer": "Speziell",
+            "beschreibung": "Bittet um Hilfe von größeren Mächten.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Segen": {
+            "name": "Segen",
+            "rang": "F",
+            "machtpunkte": 10,
+            "reichweite": "Eine Stadt/Gemeinde",
+            "dauer": "Ein Jahr",
+            "beschreibung": "Segnet Gemeinschaften und Ressourcen.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Tier Beschwören": {
+            "name": "Tier Beschwören",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Verstand",
+            "dauer": "5",
+            "beschreibung": "Beschwört Tiere zur Unterstützung.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Untoten Beschwören": {
+            "name": "Untoten Beschwören",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Verstand",
+            "dauer": "5",
+            "beschreibung": "Beschwört einfache Untote.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Verriegeln/Entriegeln": {
+            "name": "Verriegeln/Entriegeln",
+            "rang": "A",
+            "machtpunkte": 1,
+            "reichweite": "Verstand",
+            "dauer": "Permanent (Verriegeln); Sofort (Entriegeln)",
+            "beschreibung": "Verriegelt oder entriegelt magisch.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
+        },
+        "Zuflucht": {
+            "name": "Zuflucht",
+            "rang": "A",
+            "machtpunkte": 2,
+            "reichweite": "Berührung",
+            "dauer": "5",
+            "beschreibung": "Schützt vor Angriffen und Flächeneffekten; erfordert Willenskraftprobe bei bösen Kreaturen.",
+            "voraussetzungen": [],
+            "ausgewaehlt": false,
+            "aktiv": true,
+            "custom": false
         }
-      ],
-      "beschreibung": "Der Charakter verbessert seine Sehfähigkeit im Dunkeln: Er ignoriert alle Beleuchtungsabzüge vollständig (entspricht Nachtsicht auf höchster Stufe).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
     },
-    "Glücklicher Halbling": {
-      "name": "Glücklicher Halbling",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Halbling",
-        "Selbstlos"
-      ],
-      "beschreibung": "Der Charakter kann einen Benny ausgeben, um einem Verbündeten in Sichtweite eine Wiederholung für eine Eigenschaftsprobe mit +2 Bonus zu ermöglichen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Flinker Angreifer": {
-      "name": "Flinker Angreifer",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk-Eigenschaft: sprinter",
-        "GES W8"
-      ],
-      "beschreibung": "Der Charakter erleidet keinen Abzug, wenn er in derselben Runde rennt und eine einzelne Aktion ausführt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Klingenzahn": {
-      "name": "Klingenzahn",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Halbork"
-      ],
-      "beschreibung": "Der Charakter erhält durch seine verlängerten Stoßzähne einen Biss als natürliche Waffe (Stärke+W4 Schaden, gilt als natürliche Waffe nach Pathfinder-Regeln).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zauberbrecher": {
-      "name": "Zauberbrecher",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Volk: Zwerg"
-      ],
-      "beschreibung": "Der Charakter kann als begrenzte freie Aktion (einmal pro Zug) versuchen, eine aktive Macht in Nahkampfreichweite aufzuheben (wie der Zauber Aufheben, mit STÄ als arkaner Fertigkeit).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Rüstungsausbildung": {
-      "name": "Rüstungsausbildung",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Handicap: Rüstungsbeschränkung"
-      ],
-      "beschreibung": "Der Charakter ist im Umgang mit Rüstungen geübt: Die Abzüge durch Rüstungsbeschränkung werden um 2 reduziert (Rüstungsbeschränkung (leicht) → kein GES-Abzug; Rüstungsbeschränkung (mittelschwer) → Abzüge wie bei leichter Beschränkung).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Deckende Verteidigung": {
-      "name": "Deckende Verteidigung",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Wenn der Charakter den Verteidigungsmanöver einsetzt (beide Aktionen, +4 Parade), erhalten alle Verbündeten in Reichweite von 2'' ebenfalls +2 auf ihre Parade.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Lähmender Angriff": {
-      "name": "Lähmender Angriff",
-      "kategorie": "Kampf",
-      "rang": "H",
-      "voraussetzungen": [
-        "Lieblingswaffe"
-      ],
-      "beschreibung": "Mit einer Erhöhung bei einem Angriff mit der Lieblingswaffe wird die Bewegungsweite des Ziels um 2 reduziert (Minimum 1). Dieser Malus gilt bis zur Heilung oder bis zum Ende der Begegnung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Armbrustmeisterschaft": {
-      "name": "Armbrustmeisterschaft",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schnelles Nachladen",
-        "Schießen W8"
-      ],
-      "beschreibung": "Der Charakter schießt mit einer Armbrust so schnell wie mit einem Bogen (kein Nachteil durch Nachladezeit; Armbrust gilt als Nachladen 0). Zudem kann er eine Armbrust im Nahkampf als schwere Keule einsetzen (STÄ+W6 Schaden, kein Abzug).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystische Klauen": {
-      "name": "Mystische Klauen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Erfordert natürliche Klauenangriffe (z.B. Katzenkrallen). Die Klauen lösen Umgebungsschwächen von Kreaturen aus (z.B. Silber bei Werwölfen, Feuer bei Untoten) und gelten als magische Waffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wilde Klauen": {
-      "name": "Wilde Klauen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "STÄ W6"
-      ],
-      "beschreibung": "Erfordert natürliche Klauenangriffe (z.B. Katzenkrallen). Die Klauen verursachen erhöhten Schaden (STÄ+W6 statt STÄ+W4) und gelten als Panzerbrecher (AP 2).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Reißende Klauen": {
-      "name": "Reißende Klauen",
-      "kategorie": "Kampf",
-      "rang": "H",
-      "voraussetzungen": [
-        "Wilde Klauen",
-        "STÄ W8"
-      ],
-      "beschreibung": "Die Klauen des Charakters verursachen Reißende Angriffe: Bei einem Treffer mit einer Erhöhung muss das Ziel eine Konstitutionsprobe ablegen oder erleidet eine zusätzliche Wunde durch Blutung/Reißen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heldenhafter Widerstand": {
-      "name": "Heldenhafter Widerstand",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "KON W8"
-      ],
-      "beschreibung": "Einmal pro Szene kann der Charakter als begrenzte freie Aktion automatisch einen der folgenden negativen Zustände aufheben: Erschüttert, Abgelenkt oder Erschöpft.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Geschossabwehr": {
-      "name": "Geschossabwehr",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [],
-      "beschreibung": "Der Charakter erhält +2 Robustheit gegen alle Fernkampfangriffe (Schießen, Athletik-Würfe für Wurfwaffen und ähnliche Distanzangriffe).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Berittener Schild": {
-      "name": "Berittener Schild",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Der Charakter kann seinen Schildbonus (Parade und Robustheit) auf sein Reittier übertragen, solange er berittenen Kampf führt und das Schild hält.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Nahschussmeister": {
-      "name": "Nahschussmeister",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schießen W10"
-      ],
-      "beschreibung": "Der Charakter erleidet keinen Abzug auf Schießen-Proben, wenn er sich im Nahkampf befindet oder angebunden ist. Zudem kann er im Nahkampf schießen, ohne einen automatischen Kritischen Fehlschlag zu riskieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schattenangriff": {
-      "name": "Schattenangriff",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Hinterhältiger Angriff",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Der Charakter kann den Hinterhältigen Angriff in Gebieten mit schlechter Beleuchtung (Düster oder Dunkel) einsetzen, auch ohne volle Deckung oder direkten Überraschungsangriff.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Berührung der Stille": {
-      "name": "Berührung der Stille",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "WIL W8",
-        "Waffenloser Schlag",
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Ki-Aktion (1 Machtpunkt): Bei einem erfolgreichen unbewaffneten Treffer muss das Ziel eine Willenskraftprobe ablegen oder kann bis zum Ende seines nächsten Zuges keine Aktionen ausführen (gilt als Erschöpft).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Stolperschlag": {
-      "name": "Stolperschlag",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Mit einer Erhöhung bei einem Nahkampfangriff kann der Charakter das Ziel zu Boden werfen: Das Ziel fällt hin (Hingeworfen, –2 auf alle Proben; Angreifer erhalten +2 auf Angriffe gegen das Ziel).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unter dem Riesen": {
-      "name": "Unter dem Riesen",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Handicap: Klein",
-        "Athletik W8"
-      ],
-      "beschreibung": "Wenn ein Gegner der Größe 1 oder größer diesen Charakter angreift, kann der Charakter als freie Aktion eine Athletik-Probe ablegen. Bei Erfolg fällt der Gegner hin (Hingeworfen). Einmal pro Zug einsetzbar.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ausweichen": {
-      "name": "Ausweichen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "–2 bei Angriffen durch Fernkampfwaffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelles Ausweichen": {
-      "name": "Schnelles Ausweichen",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Ausweichen"
-      ],
-      "beschreibung": "+2 auf Wegspringen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Beidhändiger Fernkampf": {
-      "name": "Beidhändiger Fernkampf",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Führe einen zusätzlichen Angriff mit Athletik (Werfen) oder Schießen mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Beidhändiger Kampf": {
-      "name": "Beidhändiger Kampf",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Führe einen zusätzlichen Kämpfen-Angriff mit der falschen Hand ohne Mehrfachaktionsabzug aus.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Berechnend": {
-      "name": "Berechnend",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W8"
-      ],
-      "beschreibung": "Ignoriere 2 Punkte Abzüge bei einer Aktion mit einer Aktionskarte von 5 oder weniger.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Block": {
-      "name": "Block",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "+1 Parade, ignoriere 1 Punkt Überzahlbonus.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Harter Block": {
-      "name": "Harter Block",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Block"
-      ],
-      "beschreibung": "+2 Parade, ignoriere 2 Punkt Überzahlbonus.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Eisenkiefer": {
-      "name": "Eisenkiefer",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "KON W8"
-      ],
-      "beschreibung": "+2 auf Schaden wegstecken und Konstitutionsproben, um K.O.-Schlägen zu widerstehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Erstschlag": {
-      "name": "Erstschlag",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Freier Kämpfen-Angriff einmal pro Runde, wenn sich ein Feind in Reichweite bewegt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schneller Erstschlag": {
-      "name": "Schneller Erstschlag",
-      "kategorie": "Kampf",
-      "rang": "H",
-      "voraussetzungen": [
-        "Erstschlag"
-      ],
-      "beschreibung": "Freie Kämpfen-Angriffe gegen bis zu drei Gegner, wenn sie sich in Reichweite bewegen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Finte": {
-      "name": "Finte",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Du kannst einen Feind bei einer Kämpfen-Herausforderung mit Verstand statt mit Geschicklichkeit widerstehen lassen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Improvisationsgabe": {
-      "name": "Improvisationsgabe",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "Ignoriere den Abzug von –2, wenn du mit improvisierten Waffen angreifst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kampfkünstler": {
-      "name": "Kampfkünstler",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Unbewaffnetes Kämpfen +1, Fäuste und Füße zählen als Natürliche Waffen, addiere W4 auf den Schaden unbewaffneter Angriffe (oder erhöhe den Schaden um einen Würfeltyp, wenn du bereits einen Würfel hast).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kampfkunstmeister": {
-      "name": "Kampfkunstmeister",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kampfkünstler"
-      ],
-      "beschreibung": "Unbewaffnetes Kämpfen +2, erhöhe Schadenswürfel um einen Würfeltyp.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kampfreflexe": {
-      "name": "Kampfreflexe",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [],
-      "beschreibung": "+2 Erholungsproben gegen Angeschlagen oder Betäubt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Keine Gnade": {
-      "name": "Keine Gnade",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [],
-      "beschreibung": "+2 Schaden, wenn du einen Benny ausgibst, um den Schadenswurf zu wiederholen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Killerinstinkt": {
-      "name": "Killerinstinkt",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [],
-      "beschreibung": "Freie Wiederholung für vergleichende Proben, wenn er Herausfordern einleitet.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kühler Kopf": {
-      "name": "Kühler Kopf",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W8"
-      ],
-      "beschreibung": "Ziehe jede Runde eine zusätzliche Aktionskarte und wähle, welche du verwenden willst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Sehr Kühler Kopf": {
-      "name": "Sehr Kühler Kopf",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kühler Kopf"
-      ],
-      "beschreibung": "Ziehe jede Runde zwei zusätzliche Aktionskarten und wähle, welche du verwenden willst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Lieblingswaffe": {
-      "name": "Lieblingswaffe",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfen oder Schießen W8"
-      ],
-      "beschreibung": "+1 auf Athletik (Werfen), Kämpfen oder Schießen mit einer bestimmten Waffe; +1 Parade, wenn die Waffe bereit ist.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Absolute Lieblingswaffe": {
-      "name": "Absolute Lieblingswaffe",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Lieblingswaffe"
-      ],
-      "beschreibung": "Der Bonus auf Angriff und Parade steigt auf +2.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mächtiger Hieb": {
-      "name": "Mächtiger Hieb",
-      "kategorie": "Kampf",
-      "rang": "WC",
-      "voraussetzungen": [
-        "A",
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden des ersten erfolgreichen Kämpfen-Angriffs in dieser Runde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterschütze": {
-      "name": "Meisterschütze",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Athletik oder Schießen W8"
-      ],
-      "beschreibung": "Bei erster Aktion +1 Bonus oder ignoriere bis zu 2 Punkte Abzüge auf Athletik (Werfen) oder Schießen, wenn du dich nicht bewegst und nicht mehr als FR 1 verwendest.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Parkour": {
-      "name": "Parkour",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Ignoriere Schwieriges Gelände und addiere +2 auf Athletikproben in Verfolgungsjagden zu Fuß.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Raufbold": {
-      "name": "Raufbold",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W8",
-        "KON W8"
-      ],
-      "beschreibung": "Robustheit +1, addiere W4 zum Schaden von Fäusten oder erhöhe Würfeltyp bei Kombination mit Kampfkünstler, Klauen oder ähnlichen Fähigkeiten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schläger": {
-      "name": "Schläger",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Raufbold"
-      ],
-      "beschreibung": "Erhöhe unbewaffneten Schaden um einen Würfeltyp und Robustheit noch einmal um +1.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Riposte": {
-      "name": "Riposte",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Freier Angriff gegen einen Feind, der eine Kämpfenprobe nicht geschafft hat.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Geschickte Riposte": {
-      "name": "Geschickte Riposte",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Riposte"
-      ],
-      "beschreibung": "Wie Riposte, jedoch bei bis zu drei Angriffen pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Rückzug": {
-      "name": "Rückzug",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Ein angrenzender Gegner erhält keinen freien Angriff, wenn du dich aus dem Nahkampf zurückziehst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wendiger Rückzug": {
-      "name": "Wendiger Rückzug",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Rückzug"
-      ],
-      "beschreibung": "Drei angrenzende Gegner erhalten keine freien Angriffe, wenn du dich aus dem Nahkampf zurückziehst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ruhige Hände": {
-      "name": "Ruhige Hände",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Ignoriere den Abzug für Unsicheren Grund; verringere Abzüge für Sprinten auf –1.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Rundumschlag": {
-      "name": "Rundumschlag",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "STÄ W8",
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Kämpfen-Wurf mit –2 gegen alle Ziele in der Reichweite der Waffe, nicht öfter als einmal pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kontrollierter Rundumschlag": {
-      "name": "Kontrollierter Rundumschlag",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Rundumschlag"
-      ],
-      "beschreibung": "Wie oben, aber ohne den Abzug von –2.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schmerzresistenz": {
-      "name": "Schmerzresistenz",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "KON W8"
-      ],
-      "beschreibung": "Ignoriere eine Stufe Wundabzüge.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Stärkere Schmerzresistenz": {
-      "name": "Stärkere Schmerzresistenz",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "Schmerzresistenz"
-      ],
-      "beschreibung": "Ignoriere bis zu zwei Stufen Wundabzüge.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schneller Angriff": {
-      "name": "Schneller Angriff",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei einem Nahkampfangriff pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Blitzschneller Angriff": {
-      "name": "Blitzschneller Angriff",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schneller Angriff"
-      ],
-      "beschreibung": "Wirf einen zweiten Kämpfen-Würfel bei bis zu zwei Nahkampfangriffen pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnellfeuer": {
-      "name": "Schnellfeuer",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Schießen W6"
-      ],
-      "beschreibung": "Erhöhe die FR um 1 für einen Schießen-Angriff pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verbessertes Schnellfeuer": {
-      "name": "Verbessertes Schnellfeuer",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schnellfeuer"
-      ],
-      "beschreibung": "Erhöhe die FR um 1 für bis zu zwei Schießen-Angriffe pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schwer zu töten": {
-      "name": "Schwer zu töten",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Ignoriere Wundabzüge, wenn du Konstitutionsproben machst, um Verbluten zu verhindern.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wirklich schwer zu töten": {
-      "name": "Wirklich schwer zu töten",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schwer zu töten"
-      ],
-      "beschreibung": "Wirf einen Würfel, wenn der Charakter umkommt. Auch wenn er Ausgeschaltet ist, überlebt er irgendwie.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Volles Rohr!": {
-      "name": "Volles Rohr!",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Schießen W8"
-      ],
-      "beschreibung": "Sofern du dich in deinem Zug nicht bewegst, ignoriere den Rückstoß-Malus, wenn du Waffen mit einer FR von 2 oder mehr verwendest.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Volltreffer": {
-      "name": "Volltreffer",
-      "kategorie": "Kampf",
-      "rang": "WC",
-      "voraussetzungen": [
-        "A",
-        "Athletik oder Schießen W8"
-      ],
-      "beschreibung": "Wenn Du einen Joker hast, verdopple den Schaden deines ersten erfolgreichen Angriffs mit Athletik (Werfen) oder Schießen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Anführer": {
-      "name": "Anführer",
-      "kategorie": "Anführer",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "+1 auf Erholungsproben gegen Angeschlagen und Betäubt von Statisten im Befehlsradius.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Großer Anführer": {
-      "name": "Großer Anführer",
-      "kategorie": "Anführer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Anführer"
-      ],
-      "beschreibung": "Erhöhe Befehlsradius auf 10“ (20 m).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Anheizen": {
-      "name": "Anheizen",
-      "kategorie": "Anführer",
-      "rang": "V",
-      "voraussetzungen": [
-        "WIL W8",
-        "Anführer"
-      ],
-      "beschreibung": "+1 auf Kämpfen-Schadenswürfe von Statisten im Befehlsradius.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Geborener Anführer": {
-      "name": "Geborener Anführer",
-      "kategorie": "Anführer",
-      "rang": "F",
-      "voraussetzungen": [
-        "WIL W8",
-        "Anführer"
-      ],
-      "beschreibung": "Anführertalente gelten nun auch für Wildcards.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Haltet die Stellung!": {
-      "name": "Haltet die Stellung!",
-      "kategorie": "Anführer",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W8",
-        "Anführer"
-      ],
-      "beschreibung": "+1 auf Robustheit der Statisten im Befehlsradius.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Inspirieren": {
-      "name": "Inspirieren",
-      "kategorie": "Anführer",
-      "rang": "F",
-      "voraussetzungen": [
-        "Anführer"
-      ],
-      "beschreibung": "Einmal pro Zug kann der Held auf Kriegskunst würfeln, um alle Statisten im Befehlsradius bei einer Art von Eigenschaftsprobe zu unterstützen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Taktiker": {
-      "name": "Taktiker",
-      "kategorie": "Anführer",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W8",
-        "Anführer",
-        "Kriegskunst W6"
-      ],
-      "beschreibung": "Ziehe eine zusätzliche Aktionskarte pro Zug und weise sie einem verbündeten Statisten im Befehlsradius zu.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meistertaktiker": {
-      "name": "Meistertaktiker",
-      "kategorie": "Anführer",
-      "rang": "V",
-      "voraussetzungen": [
-        "Taktiker"
-      ],
-      "beschreibung": "Ziehe und verteile zwei zusätzliche Aktionskarten anstelle von einer.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Energieschub": {
-      "name": "Energieschub",
-      "kategorie": "Macht",
-      "rang": "WC",
-      "voraussetzungen": [
-        "A",
-        "Glaube oder Zaubern W8",
-        "AH"
-      ],
-      "beschreibung": "Erhalte 10 Machtpunkte zurück, wenn du im Kampf einen Joker ziehst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heiliger/Unheiliger Krieger": {
-      "name": "Heiliger/Unheiliger Krieger",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Wunder)",
-        "Glaube W6"
-      ],
-      "beschreibung": "Addiere +1 bis +4 auf Schaden wegstecken für jeden Machtpunkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kanalisieren": {
-      "name": "Kanalisieren",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH"
-      ],
-      "beschreibung": "Verringere Machtpunktekosten um –1 nach einer Steigerung beim Aktivierungswurf.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Konzentration": {
-      "name": "Konzentration",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH"
-      ],
-      "beschreibung": "Wirkungsdauer von Mächten wird verdoppelt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Machtpunkte": {
-      "name": "Machtpunkte",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH"
-      ],
-      "beschreibung": "Erhalte 5 zusätzliche Machtpunkte, nur einmal pro Rang.",
-      "neue_maechte": 0,
-      "machtpunkte": 5,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Neue Mächte": {
-      "name": "Neue Mächte",
-      "kategorie": "Macht",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH"
-      ],
-      "beschreibung": "Dein Charakter kennt zwei neue Mächte.",
-      "neue_maechte": 2,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelle Machtregeneration": {
-      "name": "Schnelle Machtregeneration",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "WIL W6",
-        "AH"
-      ],
-      "beschreibung": "Regeneriere 10 Machtpunkte pro Stunde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnellere Machtregeneration": {
-      "name": "Schnellere Machtregeneration",
-      "kategorie": "Macht",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schnelle Machtregeneration"
-      ],
-      "beschreibung": "Regeneriere 20 Machtpunkte pro Stunde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Seelenentzug": {
-      "name": "Seelenentzug",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH",
-        "Glaube oder Zaubern W10"
-      ],
-      "beschreibung": "Erhalte 5 Machtpunkte für eine Stufe Erschöpfung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zusätzliche Anstrengung": {
-      "name": "Zusätzliche Anstrengung",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Begabt)",
-        "Fokus W6"
-      ],
-      "beschreibung": "Erhöhe Fokus um +1 für 1 Machtpunkt oder +2 für 3 Machtpunkte.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Akrobat": {
-      "name": "Akrobat",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8",
-        "Athletik W8"
-      ],
-      "beschreibung": "Wurfwiederholung bei akrobatischen Athletik-Aktionen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kampfakrobat": {
-      "name": "Kampfakrobat",
-      "kategorie": "Experte",
-      "rang": "F",
-      "voraussetzungen": [
-        "Akrobat"
-      ],
-      "beschreibung": "–1 für Gegner zum Treffen mit Fernkampf- und Nahkampfangriffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Alleskönner": {
-      "name": "Alleskönner",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W10"
-      ],
-      "beschreibung": "Du erhältst W4 in einer Fertigkeit (oder W6 bei einer Steigerung), bis du sie ersetzt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ass am Steuer": {
-      "name": "Ass am Steuer",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Charakter kann Bennys ausgeben, um für sein Fahrzeug Schaden wegstecken anzuwenden und ignoriert bis zu 2 Punkte Abzüge.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Dieb": {
-      "name": "Dieb",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8",
-        "Heimlichkeit W6",
-        "Diebeskunst W6"
-      ],
-      "beschreibung": "+1 Diebeskunst, Athletik zum Klettern, Heimlichkeit in urbanen Umgebungen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "McGyver": {
-      "name": "McGyver",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6",
-        "Reparieren W8",
-        "Wahrnehmung W8"
-      ],
-      "beschreibung": "Du kannst schnell improvisierte Gerätschaften aus Schrott erfinden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Naturbursche": {
-      "name": "Naturbursche",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "Überleben W8"
-      ],
-      "beschreibung": "+2 Überleben und Heimlichkeit in der Wildnis.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Soldat": {
-      "name": "Soldat",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W6",
-        "KON W6"
-      ],
-      "beschreibung": "Stärke ist einen Würfeltyp höher für Belastung und Mindeststärke. Wiederhole Konstitutionsproben beim Widerstand gegen Umweltgefahren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Aufwiegler": {
-      "name": "Aufwiegler",
-      "kategorie": "Sozial",
-      "rang": "F",
-      "voraussetzungen": [
-        "Heimlichkeit W8"
-      ],
-      "beschreibung": "Einmal pro Zug kannst du alle Feinde in einer mittleren Flächenschablone mit einer Einschüchtern- oder Provozieren-Herausforderung beeinflussen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bedrohlich": {
-      "name": "Bedrohlich",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "+2 auf Einschüchtern.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Beziehungen": {
-      "name": "Beziehungen",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Kontakte bieten einmal pro Sitzung Unterstützung oder andere Gefallen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ermutigen": {
-      "name": "Ermutigen",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Kann den Zustand Abgelenkt oder Verwundbar nach Herausfordern aufheben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Erniedrigen": {
-      "name": "Erniedrigen",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "Provozieren W8"
-      ],
-      "beschreibung": "Freie Wiederholung bei Provozieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Erzürnen": {
-      "name": "Erzürnen",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "Provozieren W6"
-      ],
-      "beschreibung": "Kann Feinde mit einer Steigerung bei einer Provozierenprobe „erzürnen“.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gassenwissen": {
-      "name": "Gassenwissen",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6"
-      ],
-      "beschreibung": "+2 auf Proben mit Allgemeinwissen und Informationsbeschaffung in kriminellen Kreisen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Konter": {
-      "name": "Konter",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "Provozieren W6"
-      ],
-      "beschreibung": "Eine Steigerung beim Widerstand gegen Provozieren oder Einschüchtern verursacht beim Feind Abgelenkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Rampensau": {
-      "name": "Rampensau",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Einmal pro Zug wirf einen zweiten Würfel, wenn du mit Darbietung oder Überreden unterstützt und wende das Ergebnis auf einen Verbündeten an.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Echte Rampensau": {
-      "name": "Echte Rampensau",
-      "kategorie": "Sozial",
-      "rang": "F",
-      "voraussetzungen": [
-        "Rampensau"
-      ],
-      "beschreibung": "Wie oben, aber bis zu zweimal pro Zug.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Selbstlos": {
-      "name": "Selbstlos",
-      "kategorie": "Sozial",
-      "rang": "WC",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Der Held kann anderen seine Bennys geben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Starker Wille": {
-      "name": "Starker Wille",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "+2 um Herausfordern mit Verstand oder Willenskraft zu widerstehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verlässlich": {
-      "name": "Verlässlich",
-      "kategorie": "Sozial",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Freie Wiederholung bei Unterstützung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Auserwählter": {
-      "name": "Auserwählter",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "+2 Schaden gegen übernatürlich böse (oder gute) Kreaturen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heiler": {
-      "name": "Heiler",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "+2 auf Heilungsproben, magisch oder anderweitig.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Sammler": {
-      "name": "Sammler",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "Glück"
-      ],
-      "beschreibung": "Kann einmal pro Begegnung einen benötigten Gegenstand finden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Sechster Sinn": {
-      "name": "Sechster Sinn",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Wahrnehmungsprobe mit +2 zum Spüren von Hinterhalten oder ähnlichen Ereignissen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tierempathie": {
-      "name": "Tierempathie",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Der Held kann Bennys für Tiere unter seiner Kontrolle ausgeben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tiermeister": {
-      "name": "Tiermeister",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "WIL W8"
-      ],
-      "beschreibung": "Tiere mögen deinen Helden und er hat eine Art von Haustier.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gefolgsleute": {
-      "name": "Gefolgsleute",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "WC"
-      ],
-      "beschreibung": "Der Held hat fünf Gefolgsleute.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Handlanger": {
-      "name": "Handlanger",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "WC"
-      ],
-      "beschreibung": "Der Charakter erhält einen Wildcard-Handlanger.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Profi": {
-      "name": "Profi",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [],
-      "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Experte": {
-      "name": "Experte",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Profi"
-      ],
-      "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen weiteren Schritt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meister": {
-      "name": "Meister",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Experte"
-      ],
-      "beschreibung": "Der Wildcard-Würfel des Charakters für die Eigenschaft ist ein W10.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Waffenmeister": {
-      "name": "Waffenmeister",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Kämpfen W12"
-      ],
-      "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W8.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meister aller Waffen": {
-      "name": "Meister aller Waffen",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Waffenmeister"
-      ],
-      "beschreibung": "Parade steigt um +1 und Kämpfen-Schadensbonuswürfel ist W10.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zäh wie Leder": {
-      "name": "Zäh wie Leder",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Konstitution W8"
-      ],
-      "beschreibung": "Der Held kann vier Wunden einstecken, ehe er Ausgeschaltet ist.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zäher als Leder": {
-      "name": "Zäher als Leder",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Zäh wie Leder",
-        "KON W12"
-      ],
-      "beschreibung": "Der Held kann fünf Wunden einstecken, ehe er Ausgeschaltet ist.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Behände": {
-      "name": "Behände",
-      "kategorie": "Barbar",
-      "rang": "A",
-      "voraussetzungen": [
-        "Barbar"
-      ],
-      "beschreibung": "Bewegungsweite +2.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kampfrausch": {
-      "name": "Kampfrausch",
-      "kategorie": "Barbar",
-      "rang": "A",
-      "voraussetzungen": [
-        "Barbar"
-      ],
-      "beschreibung": "Der Barbar kann freiwillig in einen Kampfrausch verfallen. Nach Angeschlagen oder Wunde: Rücksichtslose Angriffe erzwungen, +1 Würfeltyp Stärke, +2 Robustheit, ignoriere eine Stufe Wundabzüge. Endet nach 5 Runden mit Erschöpfung oder Verstandsprobe mit -2.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Scharfzüngig": {
-      "name": "Scharfzüngig",
-      "kategorie": "Barde",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Barde)"
-      ],
-      "beschreibung": "Der Barde kann Darbietung statt Provozieren verwenden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bindung mit der Natur": {
-      "name": "Bindung mit der Natur",
-      "kategorie": "Druide",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Druide)"
-      ],
-      "beschreibung": "Der Druide kann ein Tier beschwören, das als sein Begleiter dient.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Naturgespür": {
-      "name": "Naturgespür",
-      "kategorie": "Druide",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Druide)"
-      ],
-      "beschreibung": "-2 auf Überreden und Einschüchtern in der Stadt, +2 in der Wildnis.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kriegerische Anpassungsfähigkeit": {
-      "name": "Kriegerische Anpassungsfähigkeit",
-      "kategorie": "Kämpfer",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfer"
-      ],
-      "beschreibung": "Einmal pro Begegnung kann der Kämpfer als begrenzte freie Aktion die Vorteile eines Kampftalents erhalten. Er muss alle Voraussetzungen erfüllen, und die Vorteile enden nach fünf Runden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Energie fokussieren": {
-      "name": "Energie fokussieren",
-      "kategorie": "Kleriker",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Kleriker)"
-      ],
-      "beschreibung": "Der Kleriker kann die Macht Heilung auf eine Entfernung gleich seiner Willenskraft wirken. Er erhält außerdem den Machtmodifikator Zusätzlicher Empfänger, sodass er für jeweils 1 Machtpunkt nahe Verbündete heilen kann.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Arkane Verbindung": {
-      "name": "Arkane Verbindung",
-      "kategorie": "Magier",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Magier)"
-      ],
-      "beschreibung": "Der Magier wählt eine Arkane Verbindung: einen Gegenstand (+1 auf Zaubern) oder einen Vertrauten (siehe Regeln).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schule": {
-      "name": "Schule",
-      "kategorie": "Magier",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Magier)"
-      ],
-      "beschreibung": "Der Magier wählt eine Schule, die bestimmt, auf welche Arten von Mächten er sich spezialisiert.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Betäubende Fäuste": {
-      "name": "Betäubende Fäuste",
-      "kategorie": "Mönch",
-      "rang": "A",
-      "voraussetzungen": [
-        "Mönch"
-      ],
-      "beschreibung": "Bei einer Steigerung beim Kämpfen-Wurf kann der Mönch einen Feind betäuben oder einen Verursacher machen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Beweglichkeit": {
-      "name": "Beweglichkeit",
-      "kategorie": "Mönch",
-      "rang": "A",
-      "voraussetzungen": [
-        "Mönch"
-      ],
-      "beschreibung": "Der Mönch ist schnell und wendig und erhält +1 auf Sprint und Ausweichen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kämpferische Disziplin": {
-      "name": "Kämpferische Disziplin",
-      "kategorie": "Mönch",
-      "rang": "A",
-      "voraussetzungen": [
-        "Mönch"
-      ],
-      "beschreibung": "Der Mönch erhält +1 Robustheit, wenn er keine Rüstung trägt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Waffenloser Schlag": {
-      "name": "Waffenloser Schlag",
-      "kategorie": "Mönch",
-      "rang": "A",
-      "voraussetzungen": [
-        "Mönch"
-      ],
-      "beschreibung": "Der Mönch erhält +1 auf Kampfwürfe und verursacht STÄ+W4 Schaden bei waffenlosen Angriffen. Dieser Schadenswürfel steigt mit dem Rang.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Böses Entdecken": {
-      "name": "Böses Entdecken",
-      "kategorie": "Paladin",
-      "rang": "A",
-      "voraussetzungen": [
-        "Paladin"
-      ],
-      "beschreibung": "Als freie Aktion kann der Paladin eine Wahrnehmungsprobe ablegen, um böse übernatürliche Kreaturen oder Charaktere in einer Entfernung von 5'' (10 Metern) zu entdecken.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Böses Niederstrecken": {
-      "name": "Böses Niederstrecken",
-      "kategorie": "Paladin",
-      "rang": "A",
-      "voraussetzungen": [
-        "Paladin"
-      ],
-      "beschreibung": "Einmal pro Begegnung erhält der Paladin eine freie Wiederholung bei allen Angriffswürfen gegen einen gewählten bösen Gegner.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Hinterhältiger Angriff": {
-      "name": "Hinterhältiger Angriff",
-      "kategorie": "Schurke",
-      "rang": "A",
-      "voraussetzungen": [
-        "Schurke"
-      ],
-      "beschreibung": "Der Schurke addiert +W6 auf den Schaden, wenn er einen Überraschungsangriff gegen ein Ziel durchführen kann und das Opfer verwundbar ist. Dies gilt für Angriffe mit Athletik (Werfen), Kämpfen oder Schießen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wildnis durchqueren": {
-      "name": "Wildnis durchqueren",
-      "kategorie": "Waldläufer",
-      "rang": "A",
-      "voraussetzungen": [
-        "Waldläufer"
-      ],
-      "beschreibung": "Der Waldläufer ignoriert Abzüge für Schwieriges Gelände in der Wildnis.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Blutlinie": {
-      "name": "Blutlinie",
-      "kategorie": "Zauberer",
-      "rang": "A",
-      "voraussetzungen": [
-        "AH (Zauberer)"
-      ],
-      "beschreibung": "Der Zauberer muss eine Blutlinie wählen (siehe Seite 69). Bei der Beschreibung jeder Blutlinie findest du auch die zusätzliche Spezialfähigkeit, die du erhältst, wenn du das Talent Mächtige Blutlinie wählst.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gemeinsamer Angriff": {
-      "name": "Gemeinsamer Angriff",
-      "kategorie": "Anführer",
-      "rang": "V",
-      "voraussetzungen": [
-        "VER W8",
-        "Anführer"
-      ],
-      "beschreibung": "Erlaubt Verbündeten, begrenzte Aktionen und begrenzte freie Aktionen einmal zusätzlich pro Runde zu nutzen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Abprallende Zauber": {
-      "name": "Abprallende Zauber",
-      "kategorie": "Macht",
-      "rang": "V",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Leite den Zauber des Helden auf einen Gegner um, falls das ursprüngliche Ziel dem Zauber widersteht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Störende Zauber": {
-      "name": "Störende Zauber",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Die Zauber dieses Charakters erschweren es Gegnern, Mystische Kräfte und Angeborene Kräfte zu aktivieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schlachtherold": {
-      "name": "Schlachtherold",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kavalier oder Paladin",
-        "Anführer",
-        "Einschüchtern W4",
-        "Überreden W6"
-      ],
-      "beschreibung": "Inspirierender Befehl: Verleiht den Verbündeten des Helden erhöhte Kampffähigkeiten im Kampf.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schlachtherold II": {
-      "name": "Schlachtherold II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Schlachtherold"
-      ],
-      "beschreibung": "Stimme der Autorität: Verleiht Verbündeten eines der Kampftalente dieses Charakters.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schlachtherold III": {
-      "name": "Schlachtherold III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Schlachtherold II"
-      ],
-      "beschreibung": "Letztes Gefecht: Bringe Verbündete vom Rande des Todes zurück.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heiliger Verteidiger": {
-      "name": "Heiliger Verteidiger",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kanalisieren",
-        "Okkultismus W6"
-      ],
-      "beschreibung": "Stigmata: Der Charakter erhält einen Bonus auf Heilungsproben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heiliger Verteidiger II": {
-      "name": "Heiliger Verteidiger II",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Heiliger Verteidiger"
-      ],
-      "beschreibung": "Blutfeuer: Der Schaden der Waffe dieses Charakters wird erhöht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heiliger Verteidiger III": {
-      "name": "Heiliger Verteidiger III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Heiliger Verteidiger II"
-      ],
-      "beschreibung": "Blutregen: Die Stigmata des Helden verursachen Schaden bei Gegnern.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Horizontwanderer": {
-      "name": "Horizontwanderer",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Überleben W6"
-      ],
-      "beschreibung": "Geländemeisterschaft: Unterstützt Verbündete in einem bestimmten Geländetyp. Erhält bevorzugtes Gelände.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Horizontwanderer II": {
-      "name": "Horizontwanderer II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Horizontwanderer"
-      ],
-      "beschreibung": "Geländedominanz: Erhält besondere Fähigkeiten basierend auf bevorzugten Geländetypen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisteralchemist": {
-      "name": "Meisteralchemist",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Mutagene"
-      ],
-      "beschreibung": "Mutagene Form: Verwandele dich in ein Alter Ego mit verbesserten Fähigkeiten. Gewährt Mutieren-Fähigkeit.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisteralchemist II": {
-      "name": "Meisteralchemist II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Meisteralchemist"
-      ],
-      "beschreibung": "Brutalität: Verursache +2 Schaden mit Nahkampfangriffen und natürlichen Angriffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisteralchemist III": {
-      "name": "Meisteralchemist III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Meisteralchemist II"
-      ],
-      "beschreibung": "Fortgeschrittene Mutagene: Erhalte eine einzigartige Fähigkeit in mutagener Form.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterspion": {
-      "name": "Meisterspion",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Aufmerksamkeit W6",
-        "Auftreten W6",
-        "Überreden W8"
-      ],
-      "beschreibung": "Meister der Verkleidung: Reduziert den Malus für das Verkleiden als Völker mit anderer Größe, anderem Alter oder Geschlecht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterspion II": {
-      "name": "Meisterspion II",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Meisterspion"
-      ],
-      "beschreibung": "Oberflächliches Wissen: Ignoriert Mali für verstandbasierte Fertigkeitsproben, die die Tarnidentität betreffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterspion III": {
-      "name": "Meisterspion III",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Meisterspion II"
-      ],
-      "beschreibung": "Annahme: Werde unsichtbar für Wahrsagungszauber und Gedankenlesen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Naturwächter": {
-      "name": "Naturwächter",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Tiermeister",
-        "Glaube W6 oder MP",
-        "Überleben W4"
-      ],
-      "beschreibung": "Überlebenskünstler: Parade +1, erhält eine kostenlose Wiederholung auf Überleben- und Aufmerksamkeit-Proben im gewählten Gelände und ignoriert Schwieriges Gelände sowie Gefahren durch natürliche Elemente.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Naturwächter II": {
-      "name": "Naturwächter II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Naturwächter"
-      ],
-      "beschreibung": "Eisenpranke: Teile Zaubereffekte mit Begleitern.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Naturwächter III": {
-      "name": "Naturwächter III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Naturwächter II"
-      ],
-      "beschreibung": "Begleiterseele: Erhalte übernatürliche Fähigkeiten mit dem Begleiter dieses Charakters.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zornprophet": {
-      "name": "Zornprophet",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (Wunder oder Orakel)",
-        "Kampfrausch",
-        "Okkultismus W4"
-      ],
-      "beschreibung": "Zornzauberer: Zauber, die im Kampfrausch gewirkt werden, sind schwerer zu widerstehen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zornprophet II": {
-      "name": "Zornprophet II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Zornprophet"
-      ],
-      "beschreibung": "Zornzauberstärke: Zauber, die auf den Zaubernden zielen, sind begrenzte freie Aktionen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zornprophet III": {
-      "name": "Zornprophet III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Zornprophet II"
-      ],
-      "beschreibung": "Geisterkrieger: Der Zornprophet ist besser darin, Feenwesen, Externare und Untote zu töten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unbeugsamer Verteidiger": {
-      "name": "Unbeugsamer Verteidiger",
-      "kategorie": "Prestige",
-      "rang": "F",
-      "voraussetzungen": [
-        "Nerven aus Stahl",
-        "Keine Rüstungsbeschränkung oder Behindernde Rüstung"
-      ],
-      "beschreibung": "Verteidigungshaltung: Der Charakter wird zu einem Bollwerk der Verteidigung und erhöht seine Attribute auf Kosten der Bewegungsfreiheit.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unbeugsamer Verteidiger II": {
-      "name": "Unbeugsamer Verteidiger II",
-      "kategorie": "Prestige",
-      "rang": "V",
-      "voraussetzungen": [
-        "Unbeugsamer Verteidiger"
-      ],
-      "beschreibung": "Letztes Wort: Führe einen Angriff aus, bevor du kampfunfähig wirst. Behandle den Angriff, als hättest du einen Joker erhalten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unbeugsamer Verteidiger III": {
-      "name": "Unbeugsamer Verteidiger III",
-      "kategorie": "Prestige",
-      "rang": "H",
-      "voraussetzungen": [
-        "Unbeugsamer Verteidiger II"
-      ],
-      "beschreibung": "Bollwerk: Erhöhungen verursachen nur zusätzlichen Schaden gegen den Verteidiger, lösen aber keine anderen Effekte wie Betäubender Schlag aus.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schnelle Unterstützung": {
-      "name": "Schnelle Unterstützung",
-      "kategorie": "Sozial",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W8"
-      ],
-      "beschreibung": "Unterstütze Verbündete als begrenzte freie Aktion, wenn deine Aktionskarte eine Bildkarte oder ein Joker ist.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ducken und Deckung": {
-      "name": "Ducken und Deckung",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [],
-      "beschreibung": "Der Charakter und ein Verbündeter können die Würfe des jeweils anderen beim Ausweichen nutzen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zertrümmern": {
-      "name": "Zertrümmern",
-      "kategorie": "Übersinnlich",
-      "rang": "A",
-      "voraussetzungen": [
-        "Halb-Ork",
-        "STÄ W10"
-      ],
-      "beschreibung": "Der Charakter kann Schadenswürfe explodieren lassen, wenn er versucht, Objekte zu zerstören.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tödliche Darbietung": {
-      "name": "Tödliche Darbietung",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Barde-Talente"
-      ],
-      "beschreibung": "Nutze Auftreten, um Zuhörer zu Betäuben oder Kampfunfähig zu machen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heiliger Champion": {
-      "name": "Heiliger Champion",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Paladin-Talente"
-      ],
-      "beschreibung": "+2 Robustheit und verbanne Externare bei Böses-Niederstrecken-Angriffen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Heimvorteil": {
-      "name": "Heimvorteil",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "WIL W8",
-        "Mindestens zwei Druiden-Talente"
-      ],
-      "beschreibung": "Gib einen Benny aus, um alle Machtpunkte wiederherzustellen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meisterangriff": {
-      "name": "Meisterangriff",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Schurken-Talente"
-      ],
-      "beschreibung": "Hinterhältige Angriffe dieses Charakters können lähmen, töten oder Gegner in Schlaf versetzen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Mystischer Jäger": {
-      "name": "Mystischer Jäger",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [],
-      "beschreibung": "Ignoriere Unaufhaltsam bei einer Bildkarte und hindere Gegner daran, die Angriffe dieses Charakters zu absorbieren, wenn du einen Joker hast.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Perfekter Körper": {
-      "name": "Perfekter Körper",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Mönch-Talente"
-      ],
-      "beschreibung": "Erhalte +4 Robustheit und werde zu einem Externar.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Schon gesehen": {
-      "name": "Schon gesehen",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Waldläufer-Talente"
-      ],
-      "beschreibung": "Der Waldläufer wird gegenüber Fähigkeiten seiner bevorzugten Feinde nahezu unempfindlich.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Einzigartige Blutlinie": {
-      "name": "Einzigartige Blutlinie",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Zauberer-Talente"
-      ],
-      "beschreibung": "Erhalte eine zusätzliche fortgeschrittene Blutlinie.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unaufhaltsame Wut": {
-      "name": "Unaufhaltsame Wut",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Barbar-Talente"
-      ],
-      "beschreibung": "Erhalte Unaufhaltsam während des Kampfrausches.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Veteran des ewigen Krieges": {
-      "name": "Veteran des ewigen Krieges",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Kämpfer-Talente"
-      ],
-      "beschreibung": "Gegner erhalten keinen Bonus für Rücksichtslose Angriffe gegen diesen Helden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gut vorbereitet": {
-      "name": "Gut vorbereitet",
-      "kategorie": "Legendär",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Magier-Talente"
-      ],
-      "beschreibung": "Wirke einen Zauber als begrenzte freie Aktion für +1 Machtpunkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wasserabstammung": {
-      "name": "Wasserabstammung",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Undinen"
-      ],
-      "beschreibung": "Gewährt die Fähigkeit Wasseratmung und schnellere Bewegung im Wasser.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kletterranke": {
-      "name": "Kletterranke",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Weinranken-Leshy",
-        "STÄ W6"
-      ],
-      "beschreibung": "Gewährt die Kletterer-Fähigkeit (Wandkletterer).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Elementare Reise": {
-      "name": "Elementare Reise",
-      "kategorie": "Hintergrund",
-      "rang": "F",
-      "voraussetzungen": [
-        "Ifrits oder Oreads oder Sylphen oder Undinen"
-      ],
-      "beschreibung": "Gewährt die Fähigkeit, zur Ebene zu reisen, die eng mit deiner Blutlinie verbunden ist. Du bist immun gegen die negativen Effekte dieser Ebene.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Innerer Atem": {
-      "name": "Innerer Atem",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Sylphen"
-      ],
-      "beschreibung": "Dein Held muss nicht mehr atmen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kudzu-Ringer": {
-      "name": "Kudzu-Ringer",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Weinranken-Leshy",
-        "GES W6",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Behindert die Sicht eines Gegners beim Ringen und erschwert diesem das Ausführen von Aktionen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Oread-Gräber": {
-      "name": "Oread-Gräber",
-      "kategorie": "Hintergrund",
-      "rang": "A",
-      "voraussetzungen": [
-        "Oreads"
-      ],
-      "beschreibung": "Gewährt die Fähigkeit, unter der Erde zu graben.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Versengende Waffe": {
-      "name": "Versengende Waffe",
-      "kategorie": "Hintergrund",
-      "rang": "F",
-      "voraussetzungen": [
-        "Ifrits"
-      ],
-      "beschreibung": "Waffenlose Angriffe verursachen Feuerschaden. Kann auf Metallwaffen übertragen werden.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Flügel der Luft": {
-      "name": "Flügel der Luft",
-      "kategorie": "Hintergrund",
-      "rang": "F",
-      "voraussetzungen": [
-        "Sylphen"
-      ],
-      "beschreibung": "Gewährt die Fähigkeit zu fliegen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Revolverheld": {
-      "name": "Revolverheld",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W6",
-        "Schießen W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (leicht), Taten, Schneid.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_leicht"
-      ]
-    },
-    "Zielen (Revolverheld)": {
-      "name": "Zielen (Revolverheld)",
-      "kategorie": "Revolverheld",
-      "rang": "F",
-      "voraussetzungen": [
-        "Revolverheld"
-      ],
-      "beschreibung": "Gib einen Benny aus, um einen Bonus auf gezielte Angriffe zu erhalten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Todesschuss (Revolverheld)": {
-      "name": "Todesschuss (Revolverheld)",
-      "kategorie": "Revolverheld",
-      "rang": "V",
-      "voraussetzungen": [
-        "Revolverheld"
-      ],
-      "beschreibung": "Gib einen Benny aus, um den Schusswaffenschaden zu verdoppeln.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Betrug des Todes": {
-      "name": "Betrug des Todes",
-      "kategorie": "Revolverheld",
-      "rang": "H",
-      "voraussetzungen": [
-        "Revolverheld"
-      ],
-      "beschreibung": "Gib einen Benny aus, um das Wundemaximum zu reduzieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Todesschütze": {
-      "name": "Todesschütze",
-      "kategorie": "Revolverheld",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Revolverheld-Talente"
-      ],
-      "beschreibung": "Gib einen Benny aus, um ein angeschlagenes oder verwundetes Ziel zu einer Konstitutionsprobe zu zwingen oder kampfunfähig zu machen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Magus": {
-      "name": "Magus",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "VER W6",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Arkaner Hintergrund (Magus), Rüstungsbehinderung (leicht), Magus-Arkana, Zauberbücher, Zauberhieb.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Behindernde Rüstung_leicht"
-      ]
-    },
-    "Zauberstab-Meisterschaft": {
-      "name": "Zauberstab-Meisterschaft",
-      "kategorie": "Magus",
-      "rang": "F",
-      "voraussetzungen": [
-        "Magus"
-      ],
-      "beschreibung": "Der Magus kann einen Zauberstab für Zauberhiebe nutzen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zaubererinnerung": {
-      "name": "Zaubererinnerung",
-      "kategorie": "Magus",
-      "rang": "V",
-      "voraussetzungen": [
-        "Magus"
-      ],
-      "beschreibung": "Stelle alle verlorenen Machtpunkte wieder her.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gegenschlag (Magus)": {
-      "name": "Gegenschlag (Magus)",
-      "kategorie": "Magus",
-      "rang": "H",
-      "voraussetzungen": [
-        "Magus"
-      ],
-      "beschreibung": "Erhalte einen freien Angriff gegen einen Gegner, der einen Zauber wirkt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wahrer Magus": {
-      "name": "Wahrer Magus",
-      "kategorie": "Magus",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Magus-Talente"
-      ],
-      "beschreibung": "Ignoriere Arkane Resistenz und Verbesserte Arkane Resistenz.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ninja": {
-      "name": "Ninja",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "Athletik W6",
-        "Heimlichkeit W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (leicht), Mystische Kräfte (Ninja).",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_leicht"
-      ]
-    },
-    "Keine Spur": {
-      "name": "Keine Spur",
-      "kategorie": "Ninja",
-      "rang": "F",
-      "voraussetzungen": [
-        "Ninja"
-      ],
-      "beschreibung": "Es ist schwerer, den Ninja zu verfolgen und zu identifizieren.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Meister-Ninja-Trick": {
-      "name": "Meister-Ninja-Trick",
-      "kategorie": "Ninja",
-      "rang": "V",
-      "voraussetzungen": [
-        "Ninja"
-      ],
-      "beschreibung": "Gewährt zusätzliche Mystische Kräfte.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Ki-Ladung": {
-      "name": "Ki-Ladung",
-      "kategorie": "Ninja",
-      "rang": "H",
-      "voraussetzungen": [
-        "Ninja"
-      ],
-      "beschreibung": "Lade eine Waffe mit mystischer Energie auf, um mehr Schaden zu verursachen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Unsichtbare Klinge": {
-      "name": "Unsichtbare Klinge",
-      "kategorie": "Ninja",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Ninja-Talente"
-      ],
-      "beschreibung": "Gewährt leichter das Überraschungsmoment gegen einen Gegner.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wandler": {
-      "name": "Wandler",
-      "kategorie": "Klasse",
-      "rang": "A",
-      "voraussetzungen": [
-        "Kämpfen W6",
-        "Überleben W6"
-      ],
-      "beschreibung": "Rüstungsbeschränkung (mittelschwer), Defensive Instinkte, Geheimsprache, Wandler-Aspekt, Wandlerklauen, Wildnisschritt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "auto_handicaps": [
-        "Rüstungsbeschränkung_mittelschwer"
-      ]
-    },
-    "Chimären-Aspekt": {
-      "name": "Chimären-Aspekt",
-      "kategorie": "Wandler",
-      "rang": "F",
-      "voraussetzungen": [
-        "Wandler"
-      ],
-      "beschreibung": "Gewährt einen zusätzlichen Aspekt.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Wandler-Tiergestalt": {
-      "name": "Wandler-Tiergestalt",
-      "kategorie": "Wandler",
-      "rang": "V",
-      "voraussetzungen": [
-        "Wandler"
-      ],
-      "beschreibung": "Verwandele dich in die Hauptform des Aspekts.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verbesserte Form (Wandler)": {
-      "name": "Verbesserte Form (Wandler)",
-      "kategorie": "Wandler",
-      "rang": "H",
-      "voraussetzungen": [
-        "Wandler"
-      ],
-      "beschreibung": "Werde eine mächtigere Version des Wandler-Aspekts.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verbesserte Defensive Instinkte": {
-      "name": "Verbesserte Defensive Instinkte",
-      "kategorie": "Wandler",
-      "rang": "L",
-      "voraussetzungen": [
-        "Mindestens zwei Wandler-Talente"
-      ],
-      "beschreibung": "Nutze Willenskraft und Konstitution zur Berechnung der Robustheit.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Gebrandmarkt für Vergeltung": {
-      "name": "Gebrandmarkt für Vergeltung",
-      "kategorie": "Inquisitor",
-      "rang": "V",
-      "voraussetzungen": [
-        "Inquisitor",
-        "Bann"
-      ],
-      "beschreibung": "Teile die Vorteile von Bann mit Verbündeten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Kranich-Stil": {
-      "name": "Kranich-Stil",
-      "kategorie": "Mönch",
-      "rang": "V",
-      "voraussetzungen": [
-        "Mönch"
-      ],
-      "beschreibung": "Greife einen Gegner an, der den Charakter beim Verteidigen treffen würde.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Erweiterter Aspekt": {
-      "name": "Erweiterter Aspekt",
-      "kategorie": "Wandler",
-      "rang": "A",
-      "voraussetzungen": [
-        "Wandler"
-      ],
-      "beschreibung": "Gewährt zusätzliche 15 Minuten in der Nebenform des Wandlers.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Extra Schneid": {
-      "name": "Extra Schneid",
-      "kategorie": "Revolverheld",
-      "rang": "F",
-      "voraussetzungen": [
-        "Revolverheld"
-      ],
-      "beschreibung": "Gewährt mehr als einen Benny zurück pro Kampf durch Schneid.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Hinterhalt-Gespür": {
-      "name": "Hinterhalt-Gespür",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Aufmerksamkeit W8"
-      ],
-      "beschreibung": "Würfle auf Aufmerksamkeit, um zu verhindern, dass jemand deinen Helden überrascht.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Bestienmeister-Stil": {
-      "name": "Bestienmeister-Stil",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "WIL W6",
-        "Tiermeister oder ähnliche Fähigkeit"
-      ],
-      "beschreibung": "Der Bestienmeister kann mit seinem tierischen Begleiter zusammenarbeiten, um zu verhindern, dass dieser Schaden erleidet.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Körperschild": {
-      "name": "Körperschild",
-      "kategorie": "Kampf",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8",
-        "Kämpfen W6"
-      ],
-      "beschreibung": "Benutze einen gepackten Gegner als Deckung.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Würgegriff": {
-      "name": "Würgegriff",
-      "kategorie": "Kampf",
-      "rang": "V",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Schalte einen Gegner bewusstlos, anstatt ihn weiter zu schädigen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verstärkte Rüstungsausbildung": {
-      "name": "Verstärkte Rüstungsausbildung",
-      "kategorie": "Kampf",
-      "rang": "F",
-      "voraussetzungen": [
-        "Kämpfen W8"
-      ],
-      "beschreibung": "Zerstöre die Rüstung oder den Schild des Trägers, um eine Erhöhung gegen ihn zu verhindern.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Fluchtweg": {
-      "name": "Fluchtweg",
-      "kategorie": "Anführer",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W6",
-        "Anführer"
-      ],
-      "beschreibung": "Verhindere freie Angriffe, wenn Verbündete sich aus dem Nahkampf mit jemandem zurückziehen, der mit dem Helden kämpft.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verseuchende Zauber": {
-      "name": "Verseuchende Zauber",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Fügt dem Ziel einen Zauberfluch zu.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Zerstörerische Bannung": {
-      "name": "Zerstörerische Bannung",
-      "kategorie": "Macht",
-      "rang": "V",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Beim Bannen einer Macht wird der Gegner abgelenkt, bei einer Erhöhung zusätzlich verletzlich.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Göttliche Einmischung": {
-      "name": "Göttliche Einmischung",
-      "kategorie": "Macht",
-      "rang": "H",
-      "voraussetzungen": [
-        "AH (Kleriker, Orakel, Wunder)"
-      ],
-      "beschreibung": "Gib Machtpunkte aus, um einen Gegner zu zwingen, einen Angriffswurf mit einem Malus zu wiederholen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Entwickelter Vertrauter": {
-      "name": "Entwickelter Vertrauter",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "VER W6",
-        "WIL W6",
-        "AH (beliebig)",
-        "Vertrauter"
-      ],
-      "beschreibung": "Der Vertraute deines Charakters erhält eine Entwicklung aus der Eidolon-Entwicklungsliste.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Verbesserter Vertrauter": {
-      "name": "Verbesserter Vertrauter",
-      "kategorie": "Macht",
-      "rang": "F",
-      "voraussetzungen": [
-        "AH (beliebig)",
-        "Vertrauter"
-      ],
-      "beschreibung": "Gewährt einen mächtigeren Vertrauten.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Durchdringender Zauber": {
-      "name": "Durchdringender Zauber",
-      "kategorie": "Macht",
-      "rang": "V",
-      "voraussetzungen": [
-        "AH (beliebig)"
-      ],
-      "beschreibung": "Reduziert den Malus durch Arkane Resistenz.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Feldreparatur": {
-      "name": "Feldreparatur",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "Reparieren W8"
-      ],
-      "beschreibung": "Repariere Objekte im Feld schnell zum halben Preis.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Fallensteller": {
-      "name": "Fallensteller",
-      "kategorie": "Experte",
-      "rang": "A",
-      "voraussetzungen": [
-        "GES W8"
-      ],
-      "beschreibung": "Gewährt die Fähigkeit, tödliche Fallen zu bauen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    },
-    "Tödlicher Fallensteller": {
-      "name": "Tödlicher Fallensteller",
-      "kategorie": "Experte",
-      "rang": "F",
-      "voraussetzungen": [
-        "Fallensteller"
-      ],
-      "beschreibung": "Gewährt einen freien Bonus beim Bau von Fallen.",
-      "neue_maechte": 0,
-      "machtpunkte": 0,
-      "ausgewaehlt": false,
-      "aktiv": true
-    }
-  },
-  "handicaps": {
-    "Ahnen-Schwäche_leicht": {
-      "name": "Ahnen-Schwäche",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Einige Familien können ihre Abstammungslinie weit genug zurückverfolgen, um einen Vorfahren von einer anderen Ebene zu entdecken. Wähle eines: Feuer, Kälte oder Elektrizität. Der Charakter erleidet +2 Schaden durch Angriffe dieses Typs.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Ahnen-Schwäche_schwer": {
-      "name": "Ahnen-Schwäche",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Einige Familien können ihre Abstammungslinie weit genug zurückverfolgen, um einen Vorfahren von einer anderen Ebene zu entdecken. Wähle eines: Feuer, Kälte oder Elektrizität. Der Charakter erleidet +4 Schaden durch Angriffe dieses Typs.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Akribisch": {
-      "name": "Akribisch",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dein Held plant und bereitet alles bis ins Detail vor und improvisiert schlecht, wenn die Dinge nicht nach Plan laufen. Dieser Charakter erleidet –4 auf ungelernte Fertigkeitsproben anstelle der üblichen –2.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Alt": {
-      "name": "Alt",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–1 auf Bewegungsweite, Sprint-Würfel, Geschicklichkeit, Stärke und Konstitution. Held erhält 5 zusätzliche Fertigkeitspunkte.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Analphabet": {
-      "name": "Analphabet",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter kann nicht lesen oder schreiben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Angetrieben_leicht": {
-      "name": "Angetrieben",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Angetrieben_schwer": {
-      "name": "Angetrieben",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Die Handlungen des Helden werden von einem wichtigen Ziel oder Glauben vorangetrieben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Angewohnheit_leicht": {
-      "name": "Angewohnheit",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Angewohnheit_schwer": {
-      "name": "Angewohnheit",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Held ist abhängig von etwas und erleidet Erschöpfung bei Entzug.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Arm": {
-      "name": "Arm",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Halbiere das Startkapital, und der Charakter ist immer pleite.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Arrogant": {
-      "name": "Arrogant",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Dominiert gerne seine Gegner, fordert den mächtigsten Feind im Kampf heraus.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Außenseiter_leicht": {
-      "name": "Außenseiter",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Außenseiter_schwer": {
-      "name": "Außenseiter",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter passt nicht in die örtliche Umgebung und zieht –2 von Überredenproben ab. Bei einem schweren Handicap hat er keine Rechte oder leidet unter anderen schweren Konsequenzen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Befleckter Geist": {
-      "name": "Befleckter Geist",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Als Kind schloss ein Elternteil oder eine Autoritätsperson einen Pakt mit einem Teufelswesen und stahl dabei einen Teil der Lebenskraft des Charakters als Pfand. Unmittelbar nachdem ein Kampf endet, muss dieser Charakter einen Konstitutionswurf ablegen oder erleidet eine Erschöpfungsstufe. Diese Erschöpfung dauert an, bis der Charakter 24 Stunden ohne Kampf verbracht hat.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Behindernde Rüstung_jede": {
-      "name": "Behindernde Rüstung (jede)",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er jede Art von Rüstung trägt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Behindernde Rüstung_leicht": {
-      "name": "Behindernde Rüstung (leicht)",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er leichte oder schwerere Rüstung trägt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Behindernde Rüstung_mittelschwer": {
-      "name": "Behindernde Rüstung (mittelschwer)",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter zieht -4 von arkanen Fertigkeitsproben ab, wenn er mittelschwere oder schwerere Rüstung trägt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Beschämt_leicht": {
-      "name": "Beschämt",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Beschämt_schwer": {
-      "name": "Beschämt",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter wird von einem tragischen Ereignis aus seiner Vergangenheit heimgesucht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Bevorzugte Klasse_leicht": {
-      "name": "Bevorzugte Klasse",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Wenn sich dein Held auf etwas einlässt, zieht er es bis zum Ende durch, auch auf Kosten anderer Studien. Wähle eine Kern-Klassen-Eigenschaft. Alle Merkmalsanforderungen für andere Klassen-Eigenschaften und Prestige-Eigenschaften werden um einen Würfeltyp erhöht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Bevorzugte Klasse_schwer": {
-      "name": "Bevorzugte Klasse",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Wenn sich dein Held auf etwas einlässt, zieht er es bis zum Ende durch, auch auf Kosten anderer Studien. Der Charakter kann nur eine Kern-Klassen-Eigenschaft haben und kann keine Prestige-Eigenschaften erwerben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Blind": {
-      "name": "Blind",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–6 auf alle Aufgaben, die Sicht erfordern (aber ein freies Talent zum Ausgleich).",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Blutrünstig": {
-      "name": "Blutrünstig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Nimmt niemals Gefangene.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Dünnhäutig_leicht": {
-      "name": "Dünnhäutig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –2, wenn er Provozieren-Angriffen widerstehen will.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Dünnhäutig_schwer": {
-      "name": "Dünnhäutig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter ist besonders empfindlich bei persönlichen Angriffen. Abzug von –4, wenn er Provozieren-Angriffen widerstehen will.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Ehrenkodex": {
-      "name": "Ehrenkodex",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter hält sein Wort und benimmt sich wie ein Gentleman.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Eifersüchtig_leicht": {
-      "name": "Eifersüchtig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter will das, was andere haben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Eifersüchtig_schwer": {
-      "name": "Eifersüchtig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter will das, was andere haben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Einarmig": {
-      "name": "Einarmig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–4 auf Aufgaben (wie Athletik), die beide Hände erfordern.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Eingeengt": {
-      "name": "Eingeengt",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Manche Menschen können die einengende Natur von Rüstungen nicht ertragen. Die enge Umhüllung aus Leder und erstickende Helme versetzen sie in Panik. Dieser Charakter erhält Rüstungsbeschränkung (mittelschwer) für eine seiner Klassen-Eigenschaften. Besitzt er bereits eine Rüstungsbeschränkung, wird diese um eine Stufe erhöht (mittelschwer zu leicht, leicht zu jede).",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Einzelgänger": {
-      "name": "Einzelgänger",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Aufgewachsen unter Piraten, Banditen oder anderen Unruhestiftern, die nicht bereit waren, für ihn den Kopf hinzuhalten, ist dieser Charakter es gewohnt, auf eigene Faust zu agieren. Die Anwesenheit von Verbündeten kann leicht zur Ablenkung werden. Dieser Charakter profitiert nicht von Überzahl-Boni.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Einäugig": {
-      "name": "Einäugig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–2 auf Aktionen auf 5ʺ (10 Meter) oder mehr Entfernung.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Feengeraubt": {
-      "name": "Feengeraubt",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Als Kind wurde dein Held von schelmischen Feenwesen für eine Zeit entführt. Als er zurückkehrte, galt er für immer als eigenartig und distanziert. Er sehnt sich zurück und findet die sterbliche Welt stumpf und manchmal abstoßend, isst schlecht und vertraut seltsamen Visionen. Der Charakter erleidet –2 auf Proben gegen Krankheiten und Gift sowie auf Proben gegen Zauber, Fähigkeiten und Konfrontationen von Feenwesen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Feige": {
-      "name": "Feige",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–2 auf Furchtproben und beim Widerstand gegen Einschüchtern.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Feind_leicht": {
-      "name": "Feind",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Feind_schwer": {
-      "name": "Feind",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter hat eine wiederkehrende Nemesis.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Fettleibig": {
-      "name": "Fettleibig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Größe +1, Bewegungsweite –1, Sprintwürfel W4. Behandle Stärke als einen Würfeltyp niedriger, wenn es um Mindeststärke geht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Fies": {
-      "name": "Fies",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–1 auf Überredenproben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Geheimnis_leicht": {
-      "name": "Geheimnis",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Held hat ein dunkles Geheimnis.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Geheimnis_schwer": {
-      "name": "Geheimnis",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Held hat ein dunkles Geheimnis.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gesucht_leicht": {
-      "name": "Gesucht",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gesucht_schwer": {
-      "name": "Gesucht",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter wird von den Obrigkeiten gesucht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gewöhnliche Sicht": {
-      "name": "Gewöhnliche Sicht",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Etwas – oft ein Fluch, eine Krankheit oder ein ähnlicher Effekt – hat dazu geführt, dass dein Held die übernatürliche Sicht seiner Abstammung verloren hat. Der Charakter verliert seine Dämmerungssicht oder Nachtsicht. Voraussetzung: Der Charakter muss Dämmerungssicht oder Nachtsicht besitzen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gierig_leicht": {
-      "name": "Gierig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gierig_schwer": {
-      "name": "Gierig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter ist von Reichtum und materiellen Besitztümern besessen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Große Klappe": {
-      "name": "Große Klappe",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Kann kein Geheimnis bewahren, und verrät ständig private Informationen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Heldenhaft": {
-      "name": "Heldenhaft",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter hilft immer anderen, die in Not sind.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Hilflos_leicht": {
-      "name": "Hilflos",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dieser Charakter stand einst hilflos dabei, als einem geliebten Menschen großes Leid widerfuhr, und diese Lähmung kehrt manchmal zurück. Wann immer ein Verbündeter eine Wunde erleidet, ist dieser Charakter Abgelenkt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Hilflos_schwer": {
-      "name": "Hilflos",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Dieser Charakter stand einst hilflos dabei, als einem geliebten Menschen großes Leid widerfuhr, und diese Lähmung kehrt manchmal zurück. Wann immer ein Verbündeter eine Wunde erleidet, ist dieser Charakter Abgelenkt und Verwundbar.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Hässlich_leicht": {
-      "name": "Hässlich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –1 von Überredenproben ab.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Hässlich_schwer": {
-      "name": "Hässlich",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter ist körperlich unattraktiv und zieht –2 von Überredenproben ab.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Impulsiv": {
-      "name": "Impulsiv",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Held springt, ehe er schaut.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Jung_leicht": {
-      "name": "Jung",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "4 Attributspunkte, 10 Fertigkeitspunkte, einen zusätzlichen Benny pro Sitzung.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Jung_schwer": {
-      "name": "Jung",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "3 Attributspunkte, 10 Fertigkeitspunkte, zwei zusätzliche Bennys pro Sitzung.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Klein": {
-      "name": "Klein",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Größe und Robustheit sinken um 1. Größe kann nicht unter –1 liegen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Kränklich": {
-      "name": "Kränklich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–2 Konstitution beim Widerstand gegen Erschöpfung.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Kurzsichtig_leicht": {
-      "name": "Kurzsichtig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Manche Abenteurer verfolgen Dinge bis zum bitteren Ende und erschöpfen jede Option – das ist nicht dein Held. Dieser Charakter kann keine Überzeugung ausgeben, um eine zusätzliche Nutzung von einmal-pro-Begegnung-, -Sitzung- oder -Tages-Fähigkeiten zu erhalten.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Kurzsichtig_schwer": {
-      "name": "Kurzsichtig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Manche Abenteurer verfolgen Dinge bis zum bitteren Ende und erschöpfen jede Option – das ist nicht dein Held. Der Charakter kann Überzeugung für zusätzliche Nutzungen von Fähigkeiten ausgeben, aber der Überzeugungswürfel ist dabei ein W4.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Langsam_leicht": {
-      "name": "Langsam",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Bewegungsweite –1, verringere den Sprintwürfel um eine Stufe.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Langsam_schwer": {
-      "name": "Langsam",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Bewegungsweite –2, –2 auf Athletikproben und Würfe, um Athletik zu widerstehen, kann nicht das Talent Flink wählen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Lebensaufgabe": {
-      "name": "Lebensaufgabe",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Held will sterben, nachdem er eine epische Aufgabe abgeschlossen hat.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Loyal": {
-      "name": "Loyal",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Held ist seinen Freunden und Verbündeten gegenüber loyal.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Magischer Tollpatsch": {
-      "name": "Magischer Tollpatsch",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dein Held wurde an einem Ort mit einer Fülle seltsam interagierender Magie geboren, und Magie ist gefährlich begierig, um ihn herum aktiv zu werden. Das Aktivieren eines magischen Gegenstands ist eine beschränkte Aktion statt einer regulären Aktion. Erforderte der Gegenstand normalerweise bereits eine beschränkte Aktion, kann der Charakter keine Mehrfachaktion durchführen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Misstrauisch_leicht": {
-      "name": "Misstrauisch",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter ist paranoid.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Misstrauisch_schwer": {
-      "name": "Misstrauisch",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter ist paranoid und Verbündete, die ihn unterstützen wollen, ziehen –2 von ihren Würfen ab.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Neugierig": {
-      "name": "Neugierig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter will immer alles wissen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Nichtschwimmer": {
-      "name": "Nichtschwimmer",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–2 auf Proben mit Athletik (Schwimmen); jedes Zoll Bewegung im Wasser kostet 3ʺ Bewegungsweite.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Pazifist_leicht": {
-      "name": "Pazifist",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Kämpft nur in Selbstverteidigung.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Pazifist_schwer": {
-      "name": "Pazifist",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Kämpft gar nicht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Pech": {
-      "name": "Pech",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter beginnt jede Spielsitzung mit einem Benny weniger.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Phobie_leicht": {
-      "name": "Phobie",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter hat vor etwas Angst und zieht –1 von allen Eigenschaftsproben in dessen Gegenwart ab.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Phobie_schwer": {
-      "name": "Phobie",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter hat vor etwas Angst und zieht –2 von allen Eigenschaftsproben in dessen Gegenwart ab.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Rachsüchtig_leicht": {
-      "name": "Rachsüchtig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Rachsüchtig_schwer": {
-      "name": "Rachsüchtig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Abenteurer strebt nach Rache für Kränkungen. Bei einem schweren Handicap greift er auch zu körperlicher Gewalt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Rüstungsbeschränkung_jede": {
-      "name": "Rüstungsbeschränkung (jede)",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter darf keine Rüstung tragen und keine Schilde verwenden.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Rüstungsbeschränkung_leicht": {
-      "name": "Rüstungsbeschränkung (leicht)",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er mittelschwere oder schwere Rüstung trägt oder mittlere/schwere Schilde verwendet.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Rüstungsbeschränkung_mittelschwer": {
-      "name": "Rüstungsbeschränkung (mittelschwer)",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter zieht -4 von allen Geschicklichkeitsproben und darauf basierenden Fertigkeitsproben ab, wenn er schwere Rüstung trägt oder einen schweren Schild verwendet.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Sanftmütig": {
-      "name": "Sanftmütig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–2 auf Einschüchternproben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schattenentblößung": {
-      "name": "Schattenentblößung",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Held wirft überhaupt keinen Schatten, oder sein Schatten ist monströs. Unter normalen Lichtbedingungen ist dies nicht schwer zu beobachten, aber ungewöhnlich zu bemerken. Jeder, der den Schatten dieses Charakters bemerkt, reagiert schlechter auf ihn (schlechtere Anfangsreaktion bei Überredung).",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schlechte Augen_leicht": {
-      "name": "Schlechte Augen",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–1 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schlechte Augen_schwer": {
-      "name": "Schlechte Augen",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–2 auf alle Eigenschaftsproben, die auf Sicht basieren. Eine Brille negiert den Abzug, bricht aber mit 50 % Wahrscheinlichkeit, wenn der Held Verletzungen o.ä. erleidet.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schreckhaft": {
-      "name": "Schreckhaft",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Eine traumatische Erfahrung in jungen Jahren mit einem Geist, einem Untoten oder einem anderen übernatürlichen Wesen prägt die Reaktionen deines Helden. Immer wenn er ein Feenwesen, einen Außenseiter oder einen Untoten innerhalb von 10\" (20 Yards) wahrnimmt, muss er eine Schreckensprobe ablegen. Verursacht das Wesen von Natur aus Schrecken, erleidet er zusätzlich –2 auf die Probe. Gegenüber Schrecken abgehärtet zu sein gilt beim Schreckhaften nur für das spezifische Individuum, nicht für den gesamten Kreaturtyp.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schwerhörig_leicht": {
-      "name": "Schwerhörig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–4 auf Wahrnehmung bei Geräuschen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schwerhörig_schwer": {
-      "name": "Schwerhörig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Automatischer Fehlschlag bei vollständiger Taubheit.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schwerzüngig": {
-      "name": "Schwerzüngig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter sagt oft das Falsche oder bekommt seine Worte nicht heraus; –1 auf Einschüchtern, Überreden und Provozieren.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schwur_leicht": {
-      "name": "Schwur",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schwur_schwer": {
-      "name": "Schwur",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter hat sich einer Sache verschrieben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Skrupellos_leicht": {
-      "name": "Skrupellos",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Skrupellos_schwer": {
-      "name": "Skrupellos",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter tut, was nötig ist, um seinen Willen durchzusetzen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Stumm": {
-      "name": "Stumm",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter kann nicht sprechen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Stur": {
-      "name": "Stur",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter will seinen Willen durchsetzen und gibt selten Fehler zu.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Tick": {
-      "name": "Tick",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter hat eine kleine, aber hartnäckige Marotte, die anderen oft auf die Nerven geht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Tollpatschig": {
-      "name": "Tollpatschig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–2 auf Proben mit Athletik und Heimlichkeit.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Unaufmerksam": {
-      "name": "Unaufmerksam",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dein Held hat Schwierigkeiten, den Wirkungsbereich von Flächenangriffen zu erfassen. Dieser Charakter erleidet halben Schaden, wenn er einen erfolgreichen Ausweichmanöver-Wurf erzielt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verbittert": {
-      "name": "Verbittert",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Dieser Held wurde wiederholt von Menschen enttäuscht, denen er vertraute, und fällt es ihm schwer, Hilfe anzunehmen. Andere Charaktere, die diesen Charakter heilen wollen, erleiden –2 auf ihre Probe. Dies gilt für gewöhnliche und magische Heilung, nicht jedoch für natürliche Heilungswürfe.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verpeilt": {
-      "name": "Verpeilt",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "–1 auf Proben mit Allgemeinwissen und Wahrnehmung.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verpflichtung_leicht": {
-      "name": "Verpflichtung",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 20 Stunden.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verpflichtung_schwer": {
-      "name": "Verpflichtung",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter hat eine wöchentliche Verpflichtung von 40 Stunden.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Von der Natur gemieden": {
-      "name": "Von der Natur gemieden",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Tiere empfinden deinen Charakter als besonders beunruhigend. Selbst die am besten abgerichteten Tiere müssen zum Umgang mit ihm überredet werden. Tiere nähern sich freiwillig nicht innerhalb von 10\" (20 Yards) des Charakters, außer sie werden dazu überredet. Zusätzlich erleidet der Held –2 auf alle Proben zur Kontrolle von Tieren, einschließlich Reiten.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Vorsichtig": {
-      "name": "Vorsichtig",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter schmiedet aufwendige Pläne und/oder ist übermäßig vorsichtig.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Wahnvorstellungen_leicht": {
-      "name": "Wahnvorstellungen",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm manchmal Schwierigkeiten macht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Wahnvorstellungen_schwer": {
-      "name": "Wahnvorstellungen",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Charakter glaubt etwas, das seltsam ist und ihm oft Schwierigkeiten macht.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zwei linke Hände": {
-      "name": "Zwei linke Hände",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "–2 bei der Verwendung von mechanischen oder elektrischen Geräten.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zögerlich": {
-      "name": "Zögerlich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Ziehe zwei Aktionskarten und nimm die schlechtere (außer Joker, die darfst du behalten).",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Übermütig": {
-      "name": "Übermütig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Der Held glaubt, dass er alles tun kann.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schlank": {
-      "name": "Schlank",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 Robustheit, -1 auf Konstitutionsproben",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Größe -1 (Reduzierte Robustheit)": {
-      "name": "Größe -1 (Reduzierte Robustheit)",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Reduzierte Robustheit um 1",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Größe -1 (Reduzierte Größe und Robustheit)": {
-      "name": "Größe -1 (Reduzierte Größe und Robustheit)",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Reduzierte Größe und Robustheit um 1",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verringerte Bewegungsweite (Typ)": {
-      "name": "Verringerte Bewegungsweite (Typ)",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 Bewegungsweite, Sprintwürfel um einen Typ reduziert",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verringerte Bewegungsweite (Schritt)": {
-      "name": "Verringerte Bewegungsweite (Schritt)",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 Bewegungsweite, Sprintwürfel um einen Schritt reduziert",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zwanghaft": {
-      "name": "Zwanghaft",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Beginnt mit einer verstandsbasierten Fertigkeit auf W4",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zerbrechlich": {
-      "name": "Zerbrechlich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 Robustheit",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verringerte Stärke": {
-      "name": "Verringerte Stärke",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 auf alle Stärkeproben",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verringerte Fertigkeiten": {
-      "name": "Verringerte Fertigkeiten",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Beginnen nicht mit W4 in Allgemeinwissen und Wahrnehmung – diese starten auf W4-2",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Lichtempfindlich": {
-      "name": "Lichtempfindlich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 auf Eigenschaftswürfe bei Sichterfordernissen im hellen Licht",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verringerte Vitalität": {
-      "name": "Verringerte Vitalität",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "-1 Robustheit",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Anhänglich": {
-      "name": "Anhänglich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Erleidet einen Malus auf Willenskraft-Proben, wenn ein Bezugsobjekt weggenommen wird.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Brandempfindlich": {
-      "name": "Brandempfindlich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dein Held hat Schwierigkeiten, sich zu konzentrieren, wenn er offenen Flammen nahe ist.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Feigling": {
-      "name": "Feigling",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Egal, woher die Furcht stammt, der Charakter läuft davor davon.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Grausam": {
-      "name": "Grausam",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Erleidet einen Malus auf Angriffe, wenn er sich nicht auf den am schwersten verwundeten Gegner konzentriert.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zweifel_leicht": {
-      "name": "Zweifel",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Erleidet nach dem Misslingen einer Fertigkeitsprobe für eine Stunde –1 auf diese Fertigkeit.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Familienbande": {
-      "name": "Familienbande",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Der Charakter hat eine Familie, der er verpflichtet ist zu helfen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Vergesslich": {
-      "name": "Vergesslich",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Es besteht die Chance, gewöhnliche Gegenstände zurückzulassen, wenn man verweilt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Anspruchsvoll": {
-      "name": "Anspruchsvoll",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Waren und Dienstleistungen kosten mehr, da dein Held nur das Beste kauft.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Paranoid": {
-      "name": "Paranoid",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dein Charakter hat Schwierigkeiten, sich von anderen unterstützen zu lassen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schlafmütze": {
-      "name": "Schlafmütze",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Dein Held braucht mehr Schlaf als die meisten Leute.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Eitel": {
-      "name": "Eitel",
-      "stufe": "leicht",
-      "punkte": 1,
-      "beschreibung": "Wenn er beschmutzt ist, erleidet dein Held einen Malus auf Überreden- und Einschüchtern-Proben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zweifel_schwer": {
-      "name": "Zweifel",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Wie die leichte Version, zusätzlich sind auch Angriffsproben betroffen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Ungeduldig": {
-      "name": "Ungeduldig",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Kann keine Aktion aufschieben und verliert die Konzentration, wenn er nach allen Verbündeten im Kampf handelt.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Informationsüberflutung": {
-      "name": "Informationsüberflutung",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Kann keine Bennies ausgeben, um Akademiewissen-, Allgemeinwissen- oder Wissenschaft-Proben zu wiederholen.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Missraten": {
-      "name": "Missraten",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Es ist schwerer, geschicklichkeitsbasierte Fertigkeiten zu steigern.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Selbstzweifel": {
-      "name": "Selbstzweifel",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Erleidet –1 auf Willenskraft-Proben.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schattengezeichnet": {
-      "name": "Schattengezeichnet",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Dein Held ist verletzlich bei Dämmerlicht, Dunkelheit oder völliger Finsternis.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Abergläubisch": {
-      "name": "Abergläubisch",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Es besteht die Chance, dass befreundete Mächte den Charakter behindern.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Ungebildet": {
-      "name": "Ungebildet",
-      "stufe": "schwer",
-      "punkte": 2,
-      "beschreibung": "Es ist schwerer, verstandbasierte Fertigkeiten zu steigern.",
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    }
-  },
-  "maechte": {
-    "Abwehren": {
-      "name": "Abwehren",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "–2/–4 bei Angriffen auf Empfänger",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Arkaner Schutz": {
-      "name": "Arkaner Schutz",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Gegnerische Wirker ziehen –2 (–4 mit Steigerung) ab, wenn sie den Charakter mit Mächten angreifen; verringert Schaden um die gleiche Summe",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Arkanes entdecken/verbergen": {
-      "name": "Arkanes entdecken/verbergen",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5/1h",
-      "beschreibung": "Entdeckt Magie für Wirkungsdauer 5 oder verbirgt sie für 1 Stunde",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Aufheben": {
-      "name": "Aufheben",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Negiert magische Effekte",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Aufspüren": {
-      "name": "Aufspüren",
-      "rang": "A",
-      "machtpunkte": 3,
-      "reichweite": "Selbst",
-      "dauer": "10 Minuten",
-      "beschreibung": "Findet ein Objekt",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Ausspähung": {
-      "name": "Ausspähung",
-      "rang": "F",
-      "machtpunkte": 3,
-      "reichweite": "Selbst",
-      "dauer": "5",
-      "beschreibung": "Wirker kann ein Ziel und seine Umgebung auf Entfernung sehen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Barriere": {
-      "name": "Barriere",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Erschafft Barriere mit 5ʺ (10 Meter) Länge, 1ʺ (2 Meter) Höhe und Härte 10 (12 mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Betäuben": {
-      "name": "Betäuben",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Ziel ist Betäubt",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Bindender Ruf": {
-      "name": "Bindender Ruf",
-      "rang": "V",
-      "machtpunkte": 8,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Beschwört und bindet eine Kreatur von einer anderen Ebene",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Blenden": {
-      "name": "Blenden",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Verursacht Abzug von –2/–4 bei Opfern",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Böswillige Verwandlung": {
-      "name": "Böswillige Verwandlung",
-      "rang": "V",
-      "machtpunkte": 3,
-      "reichweite": "Ver",
-      "dauer": "5",
-      "beschreibung": "Tier von Größe –2 bis 3 wird in eine relativ harmlose Kreatur verwandelt",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Chaos": {
-      "name": "Chaos",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Ziele in MFS oder Kegel sind Abgelenkt und könnten geschleudert werden",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Dunkelsicht": {
-      "name": "Dunkelsicht",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver",
-      "dauer": "1 Stunde",
-      "beschreibung": "Ignoriere bis zu 4 Punkte Beleuchtungsabzüge, 6 bei Steigerung",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Ebenenwechsel": {
-      "name": "Ebenenwechsel",
-      "rang": "V",
-      "machtpunkte": 5,
-      "reichweite": "Ver",
-      "dauer": "5",
-      "beschreibung": "Erlaubt Reisen zu anderen Existenzebenen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Eigenschaft erhöhen/senken": {
-      "name": "Eigenschaft erhöhen/senken",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5/Sofort",
-      "beschreibung": "Erhöht oder senkt Fertigkeit oder Attribut",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Elementarmanipulation": {
-      "name": "Elementarmanipulation",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Erlaubt einfache Manipulation der grundlegenden Elemente",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Empathie": {
-      "name": "Empathie",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Vergleichender Wurf gegen Willenskraft, für +1/+2 auf Darbietung, Einschüchtern, Provozieren und Überreden gegen das Ziel",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Fernsicht": {
-      "name": "Fernsicht",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Sieht Details auf größere Entfernung; halbiert Entfernungsabzüge bei Steigerung",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Flächenschlag": {
-      "name": "Flächenschlag",
-      "rang": "F",
-      "machtpunkte": 3,
-      "reichweite": "Ver×2",
-      "dauer": "Sofort",
-      "beschreibung": "2W6 Schaden in mittlerer Flächenschablone",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Fliegen": {
-      "name": "Fliegen",
-      "rang": "V",
-      "machtpunkte": 3,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Ziel fliegt mit Bewegungsweite 12",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Fluch": {
-      "name": "Fluch",
-      "rang": "F",
-      "machtpunkte": 5,
-      "reichweite": "Berührung",
-      "dauer": "Speziell",
-      "beschreibung": "Legt Fluch auf Ziel",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Furcht": {
-      "name": "Furcht",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Verursacht Furchtproben",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gedankenleere": {
-      "name": "Gedankenleere",
-      "rang": "V",
-      "machtpunkte": 3,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Entfernt oder verändert Erinnerungen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gedankenlesen": {
-      "name": "Gedankenlesen",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Vergleichender Wurf gegen Verstand zum Gedankenlesen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gedankenverbindung": {
-      "name": "Gedankenverbindung",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 30m",
-      "dauer": "5",
-      "beschreibung": "Geistige Verbindung auf 1,5 Kilometer (8 mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gegenstand beschwören": {
-      "name": "Gegenstand beschwören",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "1 Stunde",
-      "beschreibung": "Beschwört Gegenstand, 1 Pfund pro 2 Machtpunkte",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Geräusch/Stille": {
-      "name": "Geräusch/Stille",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver×5/Ver",
-      "dauer": "5/Sofort",
-      "beschreibung": "Erzeugt oder dämpft Geräusche",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Geschoss": {
-      "name": "Geschoss",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver×2",
-      "dauer": "Sofort",
-      "beschreibung": "2W6 Fernkampfangriff",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gestaltwandeln": {
-      "name": "Gestaltwandeln",
-      "rang": "A",
-      "machtpunkte": 3,
-      "reichweite": "Selbst",
-      "dauer": "5",
-      "beschreibung": "Wirker nimmt die Gestalt verschiedener Wesen an",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Graben": {
-      "name": "Graben",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Ziel gräbt sich durch die Erde",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Heiligtum": {
-      "name": "Heiligtum",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Berührung",
-      "dauer": "5",
-      "beschreibung": "Feinde müssen Willenskraftprobe machen, um angreifen zu können",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Heilung": {
-      "name": "Heilung",
-      "rang": "A",
-      "machtpunkte": 3,
-      "reichweite": "Berührung",
-      "dauer": "Sofort",
-      "beschreibung": "Stellt Wunden wieder her, die weniger als eine Stunde alt sind",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Illusion": {
-      "name": "Illusion",
-      "rang": "A",
-      "machtpunkte": 3,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Erschafft eine visuelle Szene oder Abbildung von so gut wie allem, was der Wirker sich vorstellen kann",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Kriegersegen": {
-      "name": "Kriegersegen",
-      "rang": "F",
-      "machtpunkte": 4,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Gewährt Ziel ein Kampftalent",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Licht/Dunkelheit": {
-      "name": "Licht/Dunkelheit",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 10m",
-      "dauer": "5",
-      "beschreibung": "Erschafft oder verbannt Beleuchtung",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Linderung": {
-      "name": "Linderung",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver",
-      "dauer": "Sofort/1h",
-      "beschreibung": "Entfernt Zustände Angeschlagen, Abgelenkt oder Verwundbar (2 mit Steigerung) oder ignoriert 1 Punkt Wund- und Erschöpfungsabzüge (2 mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Machtpunkte entziehen": {
-      "name": "Machtpunkte entziehen",
-      "rang": "V",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Entzieht Gegner W6 Machtpunkte bei erfolgreichem vergleichendem Wurf",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Magisches Glas": {
-      "name": "Magisches Glas",
-      "rang": "H",
-      "machtpunkte": 5,
-      "reichweite": "Ver",
-      "dauer": "5 Stunden",
-      "beschreibung": "Überträgt die Seele des Wirkers in ein verzaubertes Gefäß (Kristall oder Edelstein). Der Wirker kann zwischen Gefäß und Körper wechseln (Körper wirkt leblos) und versuchen, andere Körper zu besetzen (vergleichender Wurf arkane Fertigkeit vs. Geist). Bei Erfolg wird die Seele des Opfers im Gefäß gefangen. Verstand, Willenskraft, Gesinnung und Vorteile des Wirkers bleiben erhalten; Körperattribute und Wunden stammen vom Wirt.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Marionette": {
-      "name": "Marionette",
-      "rang": "V",
-      "machtpunkte": 3,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Ziel zu kontrollieren",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Objekt auslesen": {
-      "name": "Objekt auslesen",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Berührung",
-      "dauer": "Speziell",
-      "beschreibung": "Offenbart vage Erinnerungen der Geschichte des Ziels (mehr Details mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schadensfeld": {
-      "name": "Schadensfeld",
-      "rang": "F",
-      "machtpunkte": 4,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Erschafft Aura, die 2W4 Schaden verursacht",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schlummer": {
-      "name": "Schlummer",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "1 Stunde",
-      "beschreibung": "Lässt Opfer einschlafen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schutz": {
-      "name": "Schutz",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Gewährt Panzerung +2 bei Erfolg, Robustheit +2 bei Steigerung",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Schutz vor Naturgewalten": {
-      "name": "Schutz vor Naturgewalten",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "1 Stunde",
-      "beschreibung": "Beschützt Ziel vor schädlichen Umwelteinflüssen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Sprachen sprechen": {
-      "name": "Sprachen sprechen",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 10m",
-      "dauer": "5",
-      "beschreibung": "Wirker kann Sprachen sprechen und verstehen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Strahl": {
-      "name": "Strahl",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Kegel",
-      "dauer": "Sofort",
-      "beschreibung": "Kegelförmiger Angriff mit 2W6 Schaden",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Telekinese": {
-      "name": "Telekinese",
-      "rang": "F",
-      "machtpunkte": 5,
-      "reichweite": "Ver×2",
-      "dauer": "5",
-      "beschreibung": "Bewegt Gegenstände mit Stärke W10 (W12 mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Teleportation": {
-      "name": "Teleportation",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Charakter teleportiert sich bis zu 12ʺ weit",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Tierfreund": {
-      "name": "Tierfreund",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Ver 10m",
-      "dauer": "5",
-      "beschreibung": "Kontrolliert Tiere",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Trägheit/Beschleunigung": {
-      "name": "Trägheit/Beschleunigung",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort/5",
-      "beschreibung": "Erhöht oder verlangsamt Bewegung",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Unberührbarkeit": {
-      "name": "Unberührbarkeit",
-      "rang": "V",
-      "machtpunkte": 5,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Ziel wird körperlos",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Unsichtbarkeit": {
-      "name": "Unsichtbarkeit",
-      "rang": "F",
-      "machtpunkte": 5,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Ziel wird unsichtbar (–4/–6, um es zu beeinflussen)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verbannen": {
-      "name": "Verbannen",
-      "rang": "V",
-      "machtpunkte": 3,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Vergleichender Wurf gegen Willenskraft, um Wesenheiten zu verbannen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verbündeten beschwören": {
-      "name": "Verbündeten beschwören",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Beschwört verschiedene Verbündete",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verkleiden": {
-      "name": "Verkleiden",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver 10m",
-      "dauer": "5",
-      "beschreibung": "Ziel sieht aus wie jemand anders",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verstricken": {
-      "name": "Verstricken",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Feind wird Gebunden oder Festgehalten",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verwirrung": {
-      "name": "Verwirrung",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver",
-      "dauer": "Speziell",
-      "beschreibung": "Macht Ziel Abgelenkt und Verwundbar",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Wachsen/Schrumpfen": {
-      "name": "Wachsen/Schrumpfen",
-      "rang": "F",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Erhöht oder verringert Größe",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Waffe verbessern": {
-      "name": "Waffe verbessern",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Erhöht Schaden einer Waffe um +2/+4",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Wandkrabbler": {
-      "name": "Wandkrabbler",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Ver 5",
-      "dauer": "5",
-      "beschreibung": "Charakter kann mit halber Bewegungsweite an Wänden laufen (volle Bewegungsweite mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Wiederauferstehung": {
-      "name": "Wiederauferstehung",
-      "rang": "H",
-      "machtpunkte": 20,
-      "reichweite": "Berührung",
-      "dauer": "Sofort",
-      "beschreibung": "Erweckt die Toten zum Leben",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Wunsch": {
-      "name": "Wunsch",
-      "rang": "L",
-      "machtpunkte": 20,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Wähle eines von mehreren realitätsverändernden Ereignissen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zeitstopp": {
-      "name": "Zeitstopp",
-      "rang": "H",
-      "machtpunkte": 8,
-      "reichweite": "Ver",
-      "dauer": "Sofort",
-      "beschreibung": "Wirker erhält einen zusätzlichen Zug (bis zu 4 Aktionen mit Steigerung)",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zombie": {
-      "name": "Zombie",
-      "rang": "V",
-      "machtpunkte": 3,
-      "reichweite": "Ver",
-      "dauer": "1 Stunde",
-      "beschreibung": "Erhebt und kontrolliert Untote",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zwiesprache": {
-      "name": "Zwiesprache",
-      "rang": "F",
-      "machtpunkte": 5,
-      "reichweite": "Selbst",
-      "dauer": "5 Minuten",
-      "beschreibung": "Wirker kann anderweltlichen Wesenheit Fragen stellen",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Gegenstand Beschwören": {
-      "name": "Gegenstand Beschwören",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Verstand",
-      "dauer": "Eine Stunde",
-      "beschreibung": "Erschafft einen Gegenstand bis 0,5 kg pro 2 Machtpunkte.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Monster Beschwören": {
-      "name": "Monster Beschwören",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Verstand",
-      "dauer": "5",
-      "beschreibung": "Beschwört ein mächtiges Monster.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Mystisches Eingreifen": {
-      "name": "Mystisches Eingreifen",
-      "rang": "Legendär",
-      "machtpunkte": 20,
-      "reichweite": "Speziell",
-      "dauer": "Speziell",
-      "beschreibung": "Bittet um Hilfe von größeren Mächten.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Segen": {
-      "name": "Segen",
-      "rang": "F",
-      "machtpunkte": 10,
-      "reichweite": "Eine Stadt/Gemeinde",
-      "dauer": "Ein Jahr",
-      "beschreibung": "Segnet Gemeinschaften und Ressourcen.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Tier Beschwören": {
-      "name": "Tier Beschwören",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Verstand",
-      "dauer": "5",
-      "beschreibung": "Beschwört Tiere zur Unterstützung.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Untoten Beschwören": {
-      "name": "Untoten Beschwören",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Verstand",
-      "dauer": "5",
-      "beschreibung": "Beschwört einfache Untote.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Verriegeln/Entriegeln": {
-      "name": "Verriegeln/Entriegeln",
-      "rang": "A",
-      "machtpunkte": 1,
-      "reichweite": "Verstand",
-      "dauer": "Permanent (Verriegeln); Sofort (Entriegeln)",
-      "beschreibung": "Verriegelt oder entriegelt magisch.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    },
-    "Zuflucht": {
-      "name": "Zuflucht",
-      "rang": "A",
-      "machtpunkte": 2,
-      "reichweite": "Berührung",
-      "dauer": "5",
-      "beschreibung": "Schützt vor Angriffen und Flächeneffekten; erfordert Willenskraftprobe bei bösen Kreaturen.",
-      "voraussetzungen": [],
-      "ausgewaehlt": false,
-      "aktiv": true,
-      "custom": false
-    }
-  },
-  "ausruestung": {
-    "Angelhaken": {
-      "name": "Angelhaken",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Beutel, Gürtel": {
-      "name": "Beutel, Gürtel",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Fackel": {
-      "name": "Fackel",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.01,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Licht für 1 Stunde, 4'' Radius.",
-      "aktiv": true
-    },
-    "Feuerholz (pro Tag)": {
-      "name": "Feuerholz (pro Tag)",
-      "kategorie": "Allgemein",
-      "gewicht": 10,
-      "kosten": 0.01,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Feuerstein und Stahl": {
-      "name": "Feuerstein und Stahl",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Fischernetz (2,5 Quadratmeter)": {
-      "name": "Fischernetz (2,5 Quadratmeter)",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 4,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Flasche oder Krug, Keramik (leer)": {
-      "name": "Flasche oder Krug, Keramik (leer)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.03,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Flasche, Glas (leer)": {
-      "name": "Flasche, Glas (leer)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Flaschenzug": {
-      "name": "Flaschenzug",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Handschellen": {
-      "name": "Handschellen",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Behälter, Karte oder Schriftrolle": {
-      "name": "Behälter, Karte oder Schriftrolle",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Kerze": {
-      "name": "Kerze",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.01,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Brennt eine Stunde, spendet Licht in 2'' Radius.",
-      "aktiv": true
-    },
-    "Kette": {
-      "name": "Kette",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Krähenfüße": {
-      "name": "Krähenfüße",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Ein Beutel deckt eine kleine Flächenschablone ab, zwei eine mittlere und drei eine große. Zählt als Schwieriges Gelände; jeder der sich durch das Gebiet bewegt, muss Athletik würfeln, um nicht Angeschlagen zu werden. Ein Kritischer Fehlschlag verursacht eine Wunde an den Füßen (–2 Bewegungsweite bis geheilt).",
-      "aktiv": true
-    },
-    "Kreide": {
-      "name": "Kreide",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.01,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Lampe, klein": {
-      "name": "Lampe, klein",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "3'' Radius",
-      "aktiv": true
-    },
-    "Laterne, Blend-": {
-      "name": "Laterne, Blend-",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "10'' Kegel",
-      "aktiv": true
-    },
-    "Laterne, abdeckbar": {
-      "name": "Laterne, abdeckbar",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 7,
-      "setting": "savage_pathfinder",
-      "beschreibung": "6'' Radius",
-      "aktiv": true
-    },
-    "Nähnadel": {
-      "name": "Nähnadel",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Öl (für Laterne; halber Liter)": {
-      "name": "Öl (für Laterne; halber Liter)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
-      "aktiv": true
-    },
-    "Papier": {
-      "name": "Papier",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.4,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Pergament": {
-      "name": "Pergament",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Pfeife, Keramik": {
-      "name": "Pfeife, Keramik",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Phiole, klein": {
-      "name": "Phiole, klein",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Rucksack (leer)": {
-      "name": "Rucksack (leer)",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Halbiert das effektive Gewicht des Inhalts.",
-      "aktiv": true
-    },
-    "Sack (leer)": {
-      "name": "Sack (leer)",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Sanduhr": {
-      "name": "Sanduhr",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Schaufel": {
-      "name": "Schaufel",
-      "kategorie": "Allgemein",
-      "gewicht": 4,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Schlafsack": {
-      "name": "Schlafsack",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Schleifstein": {
-      "name": "Schleifstein",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.02,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Seife": {
-      "name": "Seife",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Seil, Hanf (10''/20 Meter)": {
-      "name": "Seil, Hanf (10''/20 Meter)",
-      "kategorie": "Allgemein",
-      "gewicht": 5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
-      "aktiv": true
-    },
-    "Seil, Seide (10''/20 Meter)": {
-      "name": "Seil, Seide (10''/20 Meter)",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Segeltuch (Quadratmeter)": {
-      "name": "Segeltuch (Quadratmeter)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Siegelwachs, Stange": {
-      "name": "Siegelwachs, Stange",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Spiegel, klein, Stahl": {
-      "name": "Spiegel, klein, Stahl",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Stachel (Kletterhaken)": {
-      "name": "Stachel (Kletterhaken)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 0.05,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Stange, 4 Meter": {
-      "name": "Stange, 4 Meter",
-      "kategorie": "Allgemein",
-      "gewicht": 4,
-      "kosten": 0.25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Brechstange": {
-      "name": "Brechstange",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Tintenstift (Schreibfeder)": {
-      "name": "Tintenstift (Schreibfeder)",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Topf, Eisen": {
-      "name": "Topf, Eisen",
-      "kategorie": "Allgemein",
-      "gewicht": 2,
-      "kosten": 0.8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Trinkkrug, Keramik": {
-      "name": "Trinkkrug, Keramik",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.02,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Truhe (klein, leer)": {
-      "name": "Truhe (klein, leer)",
-      "kategorie": "Allgemein",
-      "gewicht": 6,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wasserschlauch": {
-      "name": "Wasserschlauch",
-      "kategorie": "Allgemein",
-      "gewicht": 2,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Gewicht ist mit Inhalt",
-      "aktiv": true
-    },
-    "Wolldecke": {
-      "name": "Wolldecke",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wurfhaken": {
-      "name": "Wurfhaken",
-      "kategorie": "Allgemein",
-      "gewicht": 2,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Zelt, Tuch (2 Personen)": {
-      "name": "Zelt, Tuch (2 Personen)",
-      "kategorie": "Allgemein",
-      "gewicht": 10,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Bankett (pro Person)": {
-      "name": "Bankett (pro Person)",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Bier, 4 Liter": {
-      "name": "Bier, 4 Liter",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 4,
-      "kosten": 0.2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Bier, Krug": {
-      "name": "Bier, Krug",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0.5,
-      "kosten": 0.04,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Brot, Leib": {
-      "name": "Brot, Leib",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0.25,
-      "kosten": 0.02,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Käse, Klotz": {
-      "name": "Käse, Klotz",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Reiseproviant (pro Tag)": {
-      "name": "Reiseproviant (pro Tag)",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0.5,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Mahlzeit, schlicht (pro Tag)": {
-      "name": "Mahlzeit, schlicht (pro Tag)",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Mahlzeit, gewöhnlich (pro Tag)": {
-      "name": "Mahlzeit, gewöhnlich (pro Tag)",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0,
-      "kosten": 0.3,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Mahlzeit, gut (pro Tag)": {
-      "name": "Mahlzeit, gut (pro Tag)",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Tierfutter (pro Tag)": {
-      "name": "Tierfutter (pro Tag)",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 4,
-      "kosten": 0.05,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Trockenfrüchte, Beutel": {
-      "name": "Trockenfrüchte, Beutel",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0.5,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wein, 4 Liter": {
-      "name": "Wein, 4 Liter",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 4,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wein, Becher": {
-      "name": "Wein, Becher",
-      "kategorie": "Essen & Trinken",
-      "gewicht": 0.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Adeligenkleindung": {
-      "name": "Adeligenkleindung",
-      "kategorie": "Kleidung",
-      "gewicht": 5,
-      "kosten": 75,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Händlerkleidung": {
-      "name": "Händlerkleidung",
-      "kategorie": "Kleidung",
-      "gewicht": 2,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Handwerkerkleidung": {
-      "name": "Handwerkerkleidung",
-      "kategorie": "Kleidung",
-      "gewicht": 2,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Kaltwetterkleidung": {
-      "name": "Kaltwetterkleidung",
-      "kategorie": "Kleidung",
-      "gewicht": 3.5,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schützt vor Kälte",
-      "aktiv": true
-    },
-    "Königliche Kleidung": {
-      "name": "Königliche Kleidung",
-      "kategorie": "Kleidung",
-      "gewicht": 7.5,
-      "kosten": 100,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Reisekleidung": {
-      "name": "Reisekleidung",
-      "kategorie": "Kleidung",
-      "gewicht": 2.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Esel oder Maultier": {
-      "name": "Esel oder Maultier",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Hund, Wachhund": {
-      "name": "Hund, Wachhund",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Pferd, leicht": {
-      "name": "Pferd, leicht",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0,
-      "kosten": 75,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Siehe Seite 248",
-      "aktiv": true
-    },
-    "Pferd, schwer": {
-      "name": "Pferd, schwer",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0,
-      "kosten": 300,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Siehe Seite 248",
-      "aktiv": true
-    },
-    "Pony, leicht": {
-      "name": "Pony, leicht",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Siehe Seite 248",
-      "aktiv": true
-    },
-    "Pony, schwer": {
-      "name": "Pony, schwer",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0,
-      "kosten": 45,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Siehe Seite 248",
-      "aktiv": true
-    },
-    "Sattel, Kriegssattel": {
-      "name": "Sattel, Kriegssattel",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 15,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Freie Wiederholung bei Reitenproben, um im Sattel zu bleiben",
-      "aktiv": true
-    },
-    "Sattel, Reitsattel": {
-      "name": "Sattel, Reitsattel",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 12.5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Satteltaschen, leer": {
-      "name": "Satteltaschen, leer",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 4,
-      "kosten": 4,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Zaumzeug und Zügel": {
-      "name": "Zaumzeug und Zügel",
-      "kategorie": "Tiere & Ausrüstung",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Herberge, schlicht (pro Tag)": {
-      "name": "Herberge, schlicht (pro Tag)",
-      "kategorie": "Unterkunft",
-      "gewicht": 0,
-      "kosten": 0.2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Herberge, gewöhnlich (pro Tag)": {
-      "name": "Herberge, gewöhnlich (pro Tag)",
-      "kategorie": "Unterkunft",
-      "gewicht": 0,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Herberge, gut (pro Tag)": {
-      "name": "Herberge, gut (pro Tag)",
-      "kategorie": "Unterkunft",
-      "gewicht": 0,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Stall (pro Tag)": {
-      "name": "Stall (pro Tag)",
-      "kategorie": "Unterkunft",
-      "gewicht": 0,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Abenteurerausrüstung": {
-      "name": "Abenteurerausrüstung",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 2.5,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Blendlaterne, Feuerstein und Stahl, Hanfseil, Kerze, kleiner Spiegel, Kreide, Mahlzeiten für 1 Woche, Rucksack, Öl, Schaufel, Schlafsack, Schleifstein, Seife, Wasserschlauch, Wurfhaken, Zusatzkleidung, 3 x Fackeln",
-      "aktiv": true
-    },
-    "Diebeswerkzeug": {
-      "name": "Diebeswerkzeug",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.25,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Dietriche und Nadeln, Handschuhe, Ölflaschen, Schmiere, Seidenseil, –2 auf Diebeskunst ohne.",
-      "aktiv": true
-    },
-    "Fernrohr": {
-      "name": "Fernrohr",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.5,
-      "kosten": 1000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Wahrnehmung +2 auf Entfernung",
-      "aktiv": true
-    },
-    "Hammer": {
-      "name": "Hammer",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.25,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Werkzeug eines Handwerkers": {
-      "name": "Werkzeug eines Handwerkers",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 1.25,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Heilertasche": {
-      "name": "Heilertasche",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.25,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Rudimentäre medizinische Ausrüstung, inklusive Salben und Verbänden, –1 auf Heilen ohne.",
-      "aktiv": true
-    },
-    "Heiliges Symbol, Holz": {
-      "name": "Heiliges Symbol, Holz",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Heiliges Symbol, Silber": {
-      "name": "Heiliges Symbol, Silber",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.5,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Kaufmannswaage": {
-      "name": "Kaufmannswaage",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.25,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Kletterausrüstung": {
-      "name": "Kletterausrüstung",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 2.5,
-      "kosten": 80,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Hammer, Kletterhaken, Seil, Steigeisen und andere Ausrüstung zum Klettern. Diese Ausrüstung erlaubt es dem Anwender, bis zu 2 Punkte Abzüge beim Klettern zu ignorieren.",
-      "aktiv": true
-    },
-    "Musikinstrument": {
-      "name": "Musikinstrument",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.75,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Spitzhacke": {
-      "name": "Spitzhacke",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 1.25,
-      "kosten": 3,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Vergrößerungsglas": {
-      "name": "Vergrößerungsglas",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0,
-      "kosten": 100,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Verkleidungsausrüstung": {
-      "name": "Verkleidungsausrüstung",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 2,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schminke, Prothesen und falsches Haar. Gewährt eine freie Wiederholung bei Darbietungsproben bei Verwendung einer Verkleidung.",
-      "aktiv": true
-    },
-    "Vorschlaghammer": {
-      "name": "Vorschlaghammer",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 2.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Zauberbuch, Magier (leer)": {
-      "name": "Zauberbuch, Magier (leer)",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.75,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Zauberkomponentenbeutel": {
-      "name": "Zauberkomponentenbeutel",
-      "kategorie": "Werkzeuge & Ausrüstungssets",
-      "gewicht": 0.5,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Alchemistentasche": {
-      "name": "Alchemistentasche",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 25,
-      "setting": "fantasy",
-      "beschreibung": "Tragbares Labor mit Werkzeugen und Kräutern.",
-      "aktiv": true
-    },
-    "Artefakterschaffertasche": {
-      "name": "Artefakterschaffertasche",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 100,
-      "setting": "fantasy",
-      "beschreibung": "Werkzeuge zum Verzaubern von magischen Gegenständen.",
-      "aktiv": true
-    },
-    "Bandolier": {
-      "name": "Bandolier",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 0.5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Behälter für Karte oder Schriftrolle": {
-      "name": "Behälter für Karte oder Schriftrolle",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Buch": {
-      "name": "Buch",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 50,
-      "setting": "fantasy",
-      "beschreibung": "Ermöglicht Rechercheproben.",
-      "aktiv": true
-    },
-    "Diebeswerkzeuge": {
-      "name": "Diebeswerkzeuge",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 30,
-      "setting": "fantasy",
-      "beschreibung": "-2 auf Diebeskunst ohne Werkzeuge.",
-      "aktiv": true
-    },
-    "Fallenherstellungsset": {
-      "name": "Fallenherstellungsset",
-      "kategorie": "Allgemein",
-      "gewicht": 5,
-      "kosten": 150,
-      "setting": "fantasy",
-      "beschreibung": "-2 auf Reparieren ohne Set.",
-      "aktiv": true
-    },
-    "Fass": {
-      "name": "Fass",
-      "kategorie": "Allgemein",
-      "gewicht": 15,
-      "kosten": 2,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Feder": {
-      "name": "Feder",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Feldflasche (Metall)": {
-      "name": "Feldflasche (Metall)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Fernglas": {
-      "name": "Fernglas",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1000,
-      "setting": "fantasy",
-      "beschreibung": "Wahrnehmung +2, um entfernte Objekte zu erkennen.",
-      "aktiv": true
-    },
-    "Flasche": {
-      "name": "Flasche",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Flickzeug": {
-      "name": "Flickzeug",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Glocke": {
-      "name": "Glocke",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Gürteltasche": {
-      "name": "Gürteltasche",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Karren": {
-      "name": "Karren",
-      "kategorie": "Allgemein",
-      "gewicht": 40,
-      "kosten": 15,
-      "setting": "fantasy",
-      "beschreibung": "150 kg Ladevermögen.",
-      "aktiv": true
-    },
-    "Kette (10 Meter)": {
-      "name": "Kette (10 Meter)",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 30,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Kiste": {
-      "name": "Kiste",
-      "kategorie": "Allgemein",
-      "gewicht": 5,
-      "kosten": 5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Laterne": {
-      "name": "Laterne",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 12,
-      "setting": "fantasy",
-      "beschreibung": "Licht für 3 Stunden, 4'' Radius.",
-      "aktiv": true
-    },
-    "Öl (0,5 l)": {
-      "name": "Öl (0,5 l)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
-      "aktiv": true
-    },
-    "Pergament (pro Blatt)": {
-      "name": "Pergament (pro Blatt)",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Ruderboot": {
-      "name": "Ruderboot",
-      "kategorie": "Allgemein",
-      "gewicht": 50,
-      "kosten": 50,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Sack, klein": {
-      "name": "Sack, klein",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Seil, Hanf (20 Meter)": {
-      "name": "Seil, Hanf (20 Meter)",
-      "kategorie": "Allgemein",
-      "gewicht": 5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
-      "aktiv": true
-    },
-    "Stab (3,5 m)": {
-      "name": "Stab (3,5 m)",
-      "kategorie": "Allgemein",
-      "gewicht": 4,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Tagebuch, leer": {
-      "name": "Tagebuch, leer",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Tinte (Fläschchen)": {
-      "name": "Tinte (Fläschchen)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Krug, Keramik": {
-      "name": "Krug, Keramik",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Heiliges Symbol, Gold": {
-      "name": "Heiliges Symbol, Gold",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 100,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Schubkarre": {
-      "name": "Schubkarre",
-      "kategorie": "Allgemein",
-      "gewicht": 10,
-      "kosten": 10,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Schwertscheide": {
-      "name": "Schwertscheide",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 8,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Siegelwachs, Stab": {
-      "name": "Siegelwachs, Stab",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Kreide (Schachtel mit 12 Stück)": {
-      "name": "Kreide (Schachtel mit 12 Stück)",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Leinwand (m2)": {
-      "name": "Leinwand (m2)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Reitbedarf": {
-      "name": "Reitbedarf",
-      "kategorie": "Allgemein",
-      "gewicht": 12.5,
-      "kosten": 15,
-      "setting": "fantasy",
-      "beschreibung": "Sattel, Zaumzeug und Zügel. -2 auf Reiten ohne Ausrüstung.",
-      "aktiv": true
-    },
-    "Schaufel, klein": {
-      "name": "Schaufel, klein",
-      "kategorie": "Allgemein",
-      "gewicht": 2,
-      "kosten": 2,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Steigeisen/Kletterhaken (10)": {
-      "name": "Steigeisen/Kletterhaken (10)",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Bier, Becher": {
-      "name": "Bier, Becher",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Futter, Tier (1 Tag)": {
-      "name": "Futter, Tier (1 Tag)",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 2,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Grundrationen (1 Tag)": {
-      "name": "Grundrationen (1 Tag)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Mahlzeit, billig": {
-      "name": "Mahlzeit, billig",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Mahlzeit, durchschnittlich": {
-      "name": "Mahlzeit, durchschnittlich",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 0.5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Mahlzeit, gut": {
-      "name": "Mahlzeit, gut",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Rationen, edel (1 Tag)": {
-      "name": "Rationen, edel (1 Tag)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wasser, 1 Liter (1 Tag)": {
-      "name": "Wasser, 1 Liter (1 Tag)",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 0.25,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wein, Flasche": {
-      "name": "Wein, Flasche",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Wein, Glas": {
-      "name": "Wein, Glas",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 0.5,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Feine Kleidung": {
-      "name": "Feine Kleidung",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 100,
-      "setting": "fantasy",
-      "beschreibung": "+1 auf Überreden in Statussituationen.",
-      "aktiv": true
-    },
-    "Formelle Kleidung": {
-      "name": "Formelle Kleidung",
-      "kategorie": "Allgemein",
-      "gewicht": 2.5,
-      "kosten": 75,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Gewöhnliche Kleidung": {
-      "name": "Gewöhnliche Kleidung",
-      "kategorie": "Allgemein",
-      "gewicht": 1,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Stiefel, schwer": {
-      "name": "Stiefel, schwer",
-      "kategorie": "Allgemein",
-      "gewicht": 2,
-      "kosten": 2,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Umhang, leicht (mit Kapuze)": {
-      "name": "Umhang, leicht (mit Kapuze)",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 2,
-      "setting": "fantasy",
-      "beschreibung": "",
-      "aktiv": true
-    },
-    "Winterkleidung": {
-      "name": "Winterkleidung",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 8,
-      "setting": "fantasy",
-      "beschreibung": "Schützt vor Kälte (siehe SWAE, S. 118).",
-      "aktiv": true
-    },
-    "Abenteurerpaket": {
-      "name": "Abenteurerpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 11.5,
-      "kosten": 45,
-      "setting": "fantasy",
-      "beschreibung": "Rucksack, Schlafsack, Kerze, Kreide, gewöhnliche Kleidung, Feuerstein und Stahl, Wurfhaken, Laterne, Spiegel, Seil, Öl, Schaufel, Seife, 3 Fackeln, Wasserschlauch, Schleifstein, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Alchemistenpaket": {
-      "name": "Alchemistenpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 15.5,
-      "kosten": 50,
-      "setting": "fantasy",
-      "beschreibung": "Alchemistentasche, Rucksack, Feuerstein und Stahl, Schlafsack, Spiegel, Gürteltasche, Öl, Seil, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Diebespaket": {
-      "name": "Diebespaket",
-      "kategorie": "Allgemein",
-      "gewicht": 9.5,
-      "kosten": 65,
-      "setting": "fantasy",
-      "beschreibung": "Diebeswerkzeug, Rucksack, Spiegel, Feuerstein und Stahl, Gürteltasche, Wurfhaken, Seil, Krähenfüße, Sack (klein), Öl, Laterne, Wasserschlauch, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Gewölbeforscherpaket": {
-      "name": "Gewölbeforscherpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 15.5,
-      "kosten": 50,
-      "setting": "fantasy",
-      "beschreibung": "Seil, Wurfhaken, Rucksack, Feuerstein und Stahl, Hammer, Schlafsack, Brechstange, Laterne, Öl, Steigeisen, Schaufel, Wasserschläuche, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Klerikerpaket": {
-      "name": "Klerikerpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 6,
-      "kosten": 100,
-      "setting": "fantasy",
-      "beschreibung": "Heiliges Symbol, Schlafsack, Feuerstein und Stahl, Kerze, Heilertasche, Laterne, Öl, Pergament, Tinte, Feder, Rucksack, Wasserschlauch, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Magierpaket": {
-      "name": "Magierpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 8,
-      "kosten": 80,
-      "setting": "fantasy",
-      "beschreibung": "Zauberbuch, Rucksack, Schlafsack, Lampe, Feuerstein und Stahl, Tinte, Feder, Öl, Umhang, Buch, Wasserschlauch, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Söldnerpaket": {
-      "name": "Söldnerpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 12,
-      "kosten": 45,
-      "setting": "fantasy",
-      "beschreibung": "Schlafsack, Rucksack, Krähenfüße, Laterne, 1,5 l Öl, Bier (5 l), Feuerstein und Stahl, Krug, Seil, Handschellen, Wasserschlauch, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Unterhalterpaket": {
-      "name": "Unterhalterpaket",
-      "kategorie": "Allgemein",
-      "gewicht": 8,
-      "kosten": 120,
-      "setting": "fantasy",
-      "beschreibung": "Musikinstrument, Rucksack, Schlafsack, Spiegel, Tagebuch, Tinte und Federkiel, Feuerstein und Stahl, Mantel (leicht, mit Kapuze), formelle Kleidung, Verpflegung für 1 Woche, Flickzeug, Flasche Wein.",
-      "aktiv": true
-    },
-    "Wildnispaket": {
-      "name": "Wildnispaket",
-      "kategorie": "Allgemein",
-      "gewicht": 12,
-      "kosten": 36,
-      "setting": "fantasy",
-      "beschreibung": "Zelt (2 Personen), Rucksack, Seil, Schlafsack, Winterkleidung, Stiefel (schwer), Feuerstein und Stahl, Schaufel (klein), Umhang mit Kapuze, Wasserschlauch, Verpflegung für 1 Woche.",
-      "aktiv": true
-    },
-    "Blasrohrpfeile (20)": {
-      "name": "Blasrohrpfeile (20)",
-      "kategorie": "Allgemein",
-      "gewicht": 0,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "Nur für den Gebrauch mit dem Blasrohr. Enthält 20 Pfeile.",
-      "aktiv": true
-    },
-    "Brandpfeile (20)": {
-      "name": "Brandpfeile/-bolzen (20)",
-      "kategorie": "Allgemein",
-      "gewicht": 1.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "Halbe normale Reichweite, +1W6 Schaden, kann brennbare Gegenstände entzünden. Pro Stück.",
-      "aktiv": true
-    },
-    "Schießpulver (10)": {
-      "name": "Schießpulver (10)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "Für Schwarzpulverwaffen. Enthält 10 Schuss.",
-      "aktiv": true
-    },
-    "Schleudersteine (20)": {
-      "name": "Schleudersteine (20)",
-      "kategorie": "Allgemein",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "fantasy",
-      "beschreibung": "Polierte Steine für Schleudern. Enthält 20 Steine.",
-      "aktiv": true
-    },
-    "Beinlinge": {
-      "name": "Beinlinge",
-      "kategorie": "Rüstung",
-      "gewicht": 2.5,
-      "kosten": 5,
-      "setting": "mittelalterlich",
-      "beschreibung": "Leichte Stoffbeinlinge",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 1,
-      "kopf": 0,
-      "mindeststaerke": "W4"
-    },
-    "Robe mit Kapuze": {
-      "name": "Robe mit Kapuze",
-      "kategorie": "Rüstung",
-      "gewicht": 4,
-      "kosten": 10,
-      "setting": "mittelalterlich",
-      "beschreibung": "Robe mit Kapuze schützt Torso, Arme und Kopf",
-      "aktiv": true,
-      "torso": 1,
-      "arme": 1,
-      "beine": 0,
-      "kopf": 1,
-      "mindeststaerke": "W4"
-    },
-    "Tunika": {
-      "name": "Tunika",
-      "kategorie": "Rüstung",
-      "gewicht": 2.5,
-      "kosten": 10,
-      "setting": "mittelalterlich",
-      "beschreibung": "Leichte Stofftunika schützt Torso und Arme",
-      "aktiv": true,
-      "torso": 1,
-      "arme": 1,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W4"
-    },
-    "Umhang mit Kapuze": {
-      "name": "Umhang mit Kapuze",
-      "kategorie": "Rüstung",
-      "gewicht": 2.5,
-      "kosten": 5,
-      "setting": "mittelalterlich",
-      "beschreibung": "Leichter Umhang schützt Torso und Kopf",
-      "aktiv": true,
-      "torso": 1,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 1,
-      "mindeststaerke": "W4"
-    },
-    "Bronzearmschienen": {
-      "name": "Bronzearmschienen",
-      "kategorie": "Rüstung",
-      "gewicht": 2.5,
-      "kosten": 100,
-      "setting": "mittelalterlich",
-      "beschreibung": "Mittlere Armschienen aus Bronze",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 3,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W8"
-    },
-    "Bronzebeinschienen": {
-      "name": "Bronzebeinschienen",
-      "kategorie": "Rüstung",
-      "gewicht": 3,
-      "kosten": 200,
-      "setting": "mittelalterlich",
-      "beschreibung": "Mittlere Beinschienen aus Bronze",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 3,
-      "kopf": 0,
-      "mindeststaerke": "W8"
-    },
-    "Bronzebrustpanzer": {
-      "name": "Bronzebrustpanzer",
-      "kategorie": "Rüstung",
-      "gewicht": 6.5,
-      "kosten": 200,
-      "setting": "mittelalterlich",
-      "beschreibung": "Mittlerer Brustpanzer aus Bronze",
-      "aktiv": true,
-      "torso": 3,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W8"
-    },
-    "Schwerer geschlossener Helm": {
-      "name": "Schwerer geschlossener Helm",
-      "kategorie": "Rüstung",
-      "gewicht": 4,
-      "kosten": 300,
-      "setting": "mittelalterlich",
-      "beschreibung": "Schwerer Helm mit geschlossenem Visier",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 4,
-      "mindeststaerke": "W10"
-    },
-    "Kettenhose": {
-      "name": "Kettenhose",
-      "kategorie": "Rüstung",
-      "gewicht": 10,
-      "kosten": 100,
-      "setting": "mittelalterlich",
-      "beschreibung": "Mittlere Kettenhose schützt die Beine",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 3,
-      "kopf": 0,
-      "mindeststaerke": "W8"
-    },
-    "Bronzehelm": {
-      "name": "Bronzehelm",
-      "kategorie": "Rüstung",
-      "gewicht": 3,
-      "kosten": 120,
-      "setting": "mittelalterlich",
-      "beschreibung": "Mittlerer Helm aus Bronze",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 3,
-      "mindeststaerke": "W8"
-    },
-    "Beinlinge aus natürlicher Rüstung": {
-      "name": "Beinlinge aus natürlicher Rüstung",
-      "kategorie": "Rüstung",
-      "gewicht": 3.5,
-      "kosten": 20,
-      "setting": "mittelalterlich",
-      "beschreibung": "Beinlinge aus dicker natürlicher Rüstung",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 2,
-      "kopf": 0,
-      "mindeststaerke": "W6"
-    },
-    "Hemd aus natürlicher Rüstung": {
-      "name": "Hemd aus natürlicher Rüstung",
-      "kategorie": "Rüstung",
-      "gewicht": 5,
-      "kosten": 20,
-      "setting": "mittelalterlich",
-      "beschreibung": "Hemd aus natürlicher Rüstung schützt Torso und Arme",
-      "aktiv": true,
-      "torso": 2,
-      "arme": 2,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W6"
-    },
-    "Kleiner Schild": {
-      "name": "Kleiner Schild",
-      "kategorie": "Schild",
-      "gewicht": 2,
-      "kosten": 5,
-      "setting": "mittelalterlich",
-      "beschreibung": "Kleiner Schild für grundlegenden Schutz.",
-      "aktiv": true,
-      "parade": 1,
-      "deckung": 0,
-      "mindeststaerke": "W6"
-    },
-    "Mittlerer Schild": {
-      "name": "Mittlerer Schild",
-      "kategorie": "Schild",
-      "gewicht": 4,
-      "kosten": 9,
-      "setting": "mittelalterlich",
-      "beschreibung": "Mittlerer Schild für besseren Schutz.",
-      "aktiv": true,
-      "parade": 2,
-      "deckung": -2,
-      "mindeststaerke": "W8"
-    },
-    "Großer Schild": {
-      "name": "Großer Schild",
-      "kategorie": "Schild",
-      "gewicht": 6,
-      "kosten": 20,
-      "setting": "mittelalterlich",
-      "beschreibung": "Großer Schild für maximalen Schutz. Verringert die Bewegungsweite um 1.",
-      "aktiv": true,
-      "parade": 2,
-      "deckung": -4,
-      "mindeststaerke": "W10"
-    },
-    "Chakram": {
-      "name": "Chakram",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "mittelalterlich",
-      "beschreibung": "Parade +1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Dolch": {
-      "name": "Dolch",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "mittelalterlich",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Dreizack": {
-      "name": "Dreizack",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "mittelalterlich",
-      "beschreibung": "Reichweite 1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Haken-Schwert": {
-      "name": "Haken-Schwert",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 20,
-      "setting": "mittelalterlich",
-      "beschreibung": "+1 zum Entwaffnen.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Zweihandschwert": {
-      "name": "Zweihandschwert",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 50,
-      "setting": "mittelalterlich",
-      "beschreibung": "PB 2, Zweihändig.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W10",
-      "eigenschaften": {
-        "Schaden": "Stä+W10",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": 2
-      }
-    },
-    "Spalthammer": {
-      "name": "Spalthammer",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 12,
-      "setting": "mittelalterlich",
-      "beschreibung": "PB 2, Zweihändig, +2 Schaden gegen Gegenstände.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W10",
-      "eigenschaften": {
-        "Schaden": "Stä+W10",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": 2
-      }
-    },
-    "Stab": {
-      "name": "Stab",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 0,
-      "setting": "mittelalterlich",
-      "beschreibung": "Parade +1, Reichweite 1, Zweihändig.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Entermesser": {
-      "name": "Entermesser",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Keule, leicht": {
-      "name": "Keule, leicht",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 1,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Keule, schwer": {
-      "name": "Keule, schwer",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 2,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Menschenfänger": {
-      "name": "Menschenfänger",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 15,
-      "setting": "mittelalterlich",
-      "beschreibung": "Reichweite 2, Zweihändig, kein Bonusschaden bei einer Steigerung, aber das Opfer ist Gebunden",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "2",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Meteorhammer": {
-      "name": "Meteorhammer",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 12,
-      "setting": "mittelalterlich",
-      "beschreibung": "Reichweite 2, ignoriert Schildbonus, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "2",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Speer": {
-      "name": "Speer",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 2,
-      "setting": "mittelalterlich",
-      "beschreibung": "Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Speer, Kurz-": {
-      "name": "Speer, Kurz-",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 1,
-      "setting": "mittelalterlich",
-      "beschreibung": "Einhändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitflegel, Zweihand": {
-      "name": "Streitflegel, Zweihand",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 15,
-      "setting": "mittelalterlich",
-      "beschreibung": "Ignoriert Schildbonus, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitkolben, leicht": {
-      "name": "Streitkolben, leicht",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 5,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitkolben, schwer": {
-      "name": "Streitkolben, schwer",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 12,
-      "setting": "mittelalterlich",
-      "beschreibung": "PB 1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "-",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Handrepetierarmbrust": {
-      "name": "Handrepetierarmbrust",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 160,
-      "setting": "mittelalterlich",
-      "beschreibung": "Kartusche mit 5 Bolzen oder 1 Bolzen. Nachladen 1. Rückstoßabzug.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "5/10/20",
-        "FR": 2,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Donnerbüchse": {
-      "name": "Donnerbüchse",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 300,
-      "setting": "schwarzpulver",
-      "beschreibung": "Regeln wie Schrotflinte (SWAE S. 106). Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "1-3W6",
-        "Reichweite": "10/20/40",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Muskete": {
-      "name": "Muskete",
-      "kategorie": "Waffe",
-      "gewicht": 7.5,
-      "kosten": 300,
-      "setting": "schwarzpulver",
-      "beschreibung": "Schwere, lange Feuerwaffe. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W8",
-        "Reichweite": "10/20/40",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Blunderbuss": {
-      "name": "Blunderbuss",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 2000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Streuschuss. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Bucklergewehr": {
-      "name": "Bucklergewehr",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 750,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Muss zum Nachladen abgenommen werden. Immer Nebenhandabzug beim Schießen, Parade +1. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "2",
-        "PB": "2"
-      }
-    },
-    "Culverin": {
-      "name": "Culverin",
-      "kategorie": "Waffe",
-      "gewicht": 20,
-      "kosten": 4000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schießen ohne Unterstützung: –2. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "3W6",
-        "Reichweite": "10/20/40",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Doppelhakengewehr": {
-      "name": "Doppelhakengewehr",
-      "kategorie": "Waffe",
-      "gewicht": 9,
-      "kosten": 4000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schießen ohne Halterung: –2 und der Schütze wird zu Boden geworfen. Nachladen 3.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "3W8",
-        "Reichweite": "12/24/48",
-        "FR": "1",
-        "Schuss": "2",
-        "PB": "-"
-      }
-    },
-    "Muskete Pathfinder": {
-      "name": "Muskete",
-      "kategorie": "Waffe",
-      "gewicht": 4.5,
-      "kosten": 1500,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W10",
-        "Reichweite": "10/20/40",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "2"
-      }
-    },
-    "Muskete, Axt-/Kriegshammer-": {
-      "name": "Muskete, Axt-/Kriegshammer-",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 1600,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Als Nahkampfwaffe: entsprechende Waffenwerte. Bei Fehlfunktion: –1 auf Kämpfenproben bis zur Reparatur. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "8/16/32",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Muskete, doppelläufig": {
-      "name": "Muskete, doppelläufig",
-      "kategorie": "Waffe",
-      "gewicht": 5.5,
-      "kosten": 2500,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Doppelläufig. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W8+1",
-        "Reichweite": "10/20/40",
-        "FR": "1",
-        "Schuss": "2",
-        "PB": "2"
-      }
-    },
-    "Pfefferbüchse": {
-      "name": "Pfefferbüchse",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 3000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "6",
-        "PB": "1"
-      }
-    },
-    "Pistole": {
-      "name": "Pistole",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 1000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Pistole, Mantel-": {
-      "name": "Pistole, Mantel-",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 750,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W4+1",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Pistole, doppelläufig": {
-      "name": "Pistole, doppelläufig",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 1750,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Doppelläufig. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "2",
-        "PB": "1"
-      }
-    },
-    "Pistole, Drachen-": {
-      "name": "Pistole, Drachen-",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 1000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Streuschuss. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Stockdegenpistole": {
-      "name": "Stockdegenpistole",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 775,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Wahrnehmungsprobe erforderlich, um zu erkennen, dass es sich um mehr als einen Gehstock handelt. Nachladen 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W4+1",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Revolver": {
-      "name": "Revolver",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 4000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "6",
-        "PB": "1"
-      }
-    },
-    "Gewehr": {
-      "name": "Gewehr",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 5000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W8+1",
-        "Reichweite": "20/40/80",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Gewehr, Pfefferbüchse": {
-      "name": "Gewehr, Pfefferbüchse",
-      "kategorie": "Waffe",
-      "gewicht": 7.5,
-      "kosten": 7000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W8+1",
-        "Reichweite": "20/40/80",
-        "FR": "1",
-        "Schuss": "4",
-        "PB": "1"
-      }
-    },
-    "Schrotflinte": {
-      "name": "Schrotflinte",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 5000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Streuschuss. Nachladen 1.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "1",
-        "PB": "1"
-      }
-    },
-    "Schrotflinte, doppelläufig": {
-      "name": "Schrotflinte, doppelläufig",
-      "kategorie": "Waffe",
-      "gewicht": 7.5,
-      "kosten": 7000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Doppelläufig, Streuschuss. Nachladen 1.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "2",
-        "PB": "1"
-      }
-    },
-    "Armbrust, Leichte Repetier-": {
-      "name": "Armbrust, Leichte Repetier-",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 4,
-      "kosten": 250,
-      "setting": "mittelalterlich",
-      "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen. Verursacht einen Abzug für Rückstoß.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6",
-        "Reichweite": "10/20/40",
-        "FR": 1,
-        "Schuss": "5 (Kartusche)",
-        "PB": "2"
-      }
-    },
-    "Armbrust, Schwere Repetier-": {
-      "name": "Armbrust, Schwere Repetier-",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 6,
-      "kosten": 400,
-      "setting": "mittelalterlich",
-      "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "2W8",
-        "Reichweite": "15/30/60",
-        "FR": 1,
-        "Schuss": "5 (Kartusche)",
-        "PB": "2"
-      }
-    },
-    "Axt, Hand-": {
-      "name": "Axt, Hand-",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 1.5,
-      "kosten": 6,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Bogen, Komposit-": {
-      "name": "Bogen, Komposit-",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 1.5,
-      "kosten": 100,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "12/24/48",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Bogen, Kurz-": {
-      "name": "Bogen, Kurz-",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 1,
-      "kosten": 30,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6",
-        "Reichweite": "12/24/48",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Wurf-Chakram": {
-      "name": "Wurf-Chakram",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "4/8/16",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Dolch/Messer": {
-      "name": "Dolch/Messer",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "3/6/12",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Wurf-Dreizack": {
-      "name": "Wurf-Dreizack",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kurz-/Wurfspeer": {
-      "name": "Kurz-/Wurfspeer",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 1.5,
-      "kosten": 1,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "4/8/16",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Wurf-Speer": {
-      "name": "Wurf-Speer",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 3,
-      "kosten": 2,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Steinschlosspistole": {
-      "name": "Steinschlosspistole",
-      "kategorie": "Fernkampfwaffe",
-      "gewicht": 1.5,
-      "kosten": 150,
-      "setting": "mittelalterlich",
-      "beschreibung": "-",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W6+1",
-        "Reichweite": "5/10/20",
-        "FR": 1,
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Gegengift, Phiole": {
-      "name": "Gegengift, Phiole",
-      "kategorie": "Allgemein",
-      "gewicht": 0.25,
-      "kosten": 50,
-      "setting": "mittelalterlich",
-      "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
-      "aktiv": true
-    },
-    "Ledertunika": {
-      "name": "Ledertunika",
-      "kategorie": "Rüstung",
-      "gewicht": 5.5,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Tunika oder Wams aus Leder oder beschlagenem Leder",
-      "aktiv": true,
-      "torso": 2,
-      "arme": 2,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W6"
-    },
-    "Lederbeinlinge": {
-      "name": "Lederbeinlinge",
-      "kategorie": "Rüstung",
-      "gewicht": 4,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Beinlinge aus Leder",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 2,
-      "kopf": 0,
-      "mindeststaerke": "W6"
-    },
-    "Lederkappe": {
-      "name": "Lederkappe",
-      "kategorie": "Rüstung",
-      "gewicht": 0.5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kappe aus Leder",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 2,
-      "mindeststaerke": "W6"
-    },
-    "Kettenhemd": {
-      "name": "Kettenhemd",
-      "kategorie": "Rüstung",
-      "gewicht": 11,
-      "kosten": 100,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Hemd aus Kettenrüstung oder Schuppenrüstung",
-      "aktiv": true,
-      "torso": 3,
-      "arme": 3,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W8"
-    },
-    "Kettenbeinlinge": {
-      "name": "Kettenbeinlinge",
-      "kategorie": "Rüstung",
-      "gewicht": 2.5,
-      "kosten": 100,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Beinlinge aus Kettenrüstung",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 3,
-      "kopf": 0,
-      "mindeststaerke": "W8"
-    },
-    "Kettenhaube": {
-      "name": "Kettenhaube",
-      "kategorie": "Rüstung",
-      "gewicht": 1.5,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kettenhaube oder Helm",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 3,
-      "mindeststaerke": "W8"
-    },
-    "Plattenbrustharnisch": {
-      "name": "Plattenbrustharnisch",
-      "kategorie": "Rüstung",
-      "gewicht": 15,
-      "kosten": 500,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Brustharnisch aus Plattenrüstung",
-      "aktiv": true,
-      "torso": 4,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W10"
-    },
-    "Plattenarmschienen": {
-      "name": "Plattenarmschienen",
-      "kategorie": "Rüstung",
-      "gewicht": 5,
-      "kosten": 250,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Armschienen aus Plattenrüstung",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 4,
-      "beine": 0,
-      "kopf": 0,
-      "mindeststaerke": "W10"
-    },
-    "Plattenbeinschienen": {
-      "name": "Plattenbeinschienen",
-      "kategorie": "Rüstung",
-      "gewicht": 5,
-      "kosten": 500,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Beinschienen aus Plattenrüstung",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 4,
-      "kopf": 0,
-      "mindeststaerke": "W10"
-    },
-    "Schwerer Helm": {
-      "name": "Schwerer Helm",
-      "kategorie": "Rüstung",
-      "gewicht": 2,
-      "kosten": 250,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwerer Helm aus Metall",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 4,
-      "mindeststaerke": "W10"
-    },
-    "Schwerer Helm umschließend": {
-      "name": "Schwerer Helm umschließend",
-      "kategorie": "Rüstung",
-      "gewicht": 4,
-      "kosten": 300,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwerer umschließender Helm. –1 auf Wahrnehmungsproben, die auf Sicht basieren",
-      "aktiv": true,
-      "torso": 0,
-      "arme": 0,
-      "beine": 0,
-      "kopf": 4,
-      "mindeststaerke": "W10"
-    },
-    "Rüstungsstacheln": {
-      "name": "Rüstungsstacheln",
-      "kategorie": "Rüstungsmodifikation",
-      "gewicht": 5,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "+1 Schaden beim Zerquetschen beim Ringen",
-      "aktiv": true
-    },
-    "Panzerhandschuh beriemt": {
-      "name": "Panzerhandschuh beriemt",
-      "kategorie": "Rüstungsmodifikation",
-      "gewicht": 2.5,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "+1 auf Stärkeproben gegen Entwaffnen (Ketten und Spangen erfordern eine Aktion zum Anziehen/Ausziehen)",
-      "aktiv": true
-    },
-    "Rossharnisch Leder": {
-      "name": "Rossharnisch Leder",
-      "kategorie": "Pferderüstung",
-      "gewicht": 25,
-      "kosten": 300,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Pferderüstung aus Leder (+2 Panzerung)",
-      "aktiv": true,
-      "panzerung": 2,
-      "mindeststaerke": "W8"
-    },
-    "Rossharnisch Kette": {
-      "name": "Rossharnisch Kette",
-      "kategorie": "Pferderüstung",
-      "gewicht": 55,
-      "kosten": 500,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Pferderüstung aus Kette (+3 Panzerung)",
-      "aktiv": true,
-      "panzerung": 3,
-      "mindeststaerke": "W10"
-    },
-    "Rossharnisch Platte": {
-      "name": "Rossharnisch Platte",
-      "kategorie": "Pferderüstung",
-      "gewicht": 65,
-      "kosten": 5000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Pferderüstung aus Platte (+4 Panzerung)",
-      "aktiv": true,
-      "panzerung": 4,
-      "mindeststaerke": "W12"
-    },
-    "Leichter Schild": {
-      "name": "Leichter Schild",
-      "kategorie": "Schild",
-      "gewicht": 2,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Leichter Schild für grundlegenden Schutz",
-      "aktiv": true,
-      "parade": 1,
-      "deckung": 0,
-      "mindeststaerke": "W6"
-    },
-    "Mittelschwerer Schild": {
-      "name": "Mittelschwerer Schild",
-      "kategorie": "Schild",
-      "gewicht": 4,
-      "kosten": 9,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Mittelschwerer Schild für besseren Schutz",
-      "aktiv": true,
-      "parade": 2,
-      "deckung": -2,
-      "mindeststaerke": "W8"
-    },
-    "Schwerer Schild": {
-      "name": "Schwerer Schild",
-      "kategorie": "Schild",
-      "gewicht": 6,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwerer Schild für maximalen Schutz. –1 Bewegungsweite",
-      "aktiv": true,
-      "parade": 2,
-      "deckung": -4,
-      "mindeststaerke": "W10"
-    },
-    "Schildstacheln": {
-      "name": "Schildstacheln",
-      "kategorie": "Schildmodifikation",
-      "gewicht": 0,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "+1 Schaden bei Angriffen mit dem Schild",
-      "aktiv": true
-    },
-    "Handarmbrust": {
-      "name": "Handarmbrust",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1, eine einhändige, pistolenartige Armbrust",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Hand-Repetierarmbrust": {
-      "name": "Hand-Repetierarmbrust",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 160,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "5/10/20",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Leichte Armbrust": {
-      "name": "Leichte Armbrust",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 35,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1, handgespannt",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6",
-        "Reichweite": "10/20/40",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Leichte Repetierarmbrust": {
-      "name": "Leichte Repetierarmbrust",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 250,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6",
-        "Reichweite": "10/20/40",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Schwere Armbrust": {
-      "name": "Schwere Armbrust",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "wird mit Winde gespannt, Nachladen 2",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W8",
-        "Reichweite": "15/30/60",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Schwere Repetierarmbrust": {
-      "name": "Schwere Repetierarmbrust",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 400,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 2 einzelnen Bolzen",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "2W8",
-        "Reichweite": "15/30/60",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Handaxt": {
-      "name": "Handaxt",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 6,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Bolas": {
-      "name": "Bolas",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Bolas haben eine Härte von 8.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Blasrohr": {
-      "name": "Blasrohr",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "W4-2",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kurzbogen": {
-      "name": "Kurzbogen",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "2W6",
-        "Reichweite": "12/24/48",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Langbogen": {
-      "name": "Langbogen",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 75,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "2W6",
-        "Reichweite": "15/30/60",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Kompositbogen": {
-      "name": "Kompositbogen",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 100,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "12/24/48",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Dolch/Messer Fernkampf": {
-      "name": "Dolch/Messer",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Dreizack Fernkampf": {
-      "name": "Dreizack",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kurzspeer/Wurfspeer": {
-      "name": "Kurzspeer/Wurfspeer",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "4/8/16",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Netz (beschwert)": {
-      "name": "Netz (beschwert)",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Das Netz hat Härte 10.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Schleuder": {
-      "name": "Schleuder",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Athletik (Werfen)",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "4/8/16",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Shuriken": {
-      "name": "Shuriken",
-      "kategorie": "Waffe",
-      "gewicht": 0,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Speer Fernkampf": {
-      "name": "Speer",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Sternmesser Fernkampf": {
-      "name": "Sternmesser",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 28,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Handaxt Nahkampf": {
-      "name": "Handaxt",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 6,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitaxt": {
-      "name": "Streitaxt",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Zweihandaxt": {
-      "name": "Zweihandaxt",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 2, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W10",
-      "eigenschaften": {
-        "Schaden": "Stä+W10",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Sense": {
-      "name": "Sense",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 18,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Sichel": {
-      "name": "Sichel",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 3,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Speer Nahkampf": {
-      "name": "Speer",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Stützen, Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kurzer Speer": {
-      "name": "Kurzer Speer",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Einhändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Stachelkette": {
-      "name": "Stachelkette",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1, ignoriert Schildbonus, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Sternmesser Nahkampf": {
-      "name": "Sternmesser",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 28,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Parade +1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitkolben leicht": {
-      "name": "Streitkolben, leicht",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitkolben schwer": {
-      "name": "Streitkolben, schwer",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Totschläger": {
-      "name": "Totschläger",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Betäubungsschaden",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Bolzen (10)": {
-      "name": "Bolzen (10)",
-      "kategorie": "Munition",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Bolzen für alle Arten von Armbrüsten. Eine Kartusche mit fünf Bolzen, die 1 Pfund wiegt, kann für +10 GM für eine Repetierarmbrust erworben werden.",
-      "aktiv": true
-    },
-    "Pfeil Blasrohr (10)": {
-      "name": "Pfeil Blasrohr (10)",
-      "kategorie": "Munition",
-      "gewicht": 0,
-      "kosten": 0.5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Pfeile für ein Blasrohr",
-      "aktiv": true
-    },
-    "Pfeile (20)": {
-      "name": "Pfeile (20)",
-      "kategorie": "Munition",
-      "gewicht": 1.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Pfeile für alle Arten von Bögen",
-      "aktiv": true
-    },
-    "Schleudersteine (10)": {
-      "name": "Schleudersteine (10)",
-      "kategorie": "Munition",
-      "gewicht": 0.5,
-      "kosten": 0.1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Polierte Steine",
-      "aktiv": true
-    },
-    "Flugpfeile (20)": {
-      "name": "Flugpfeile (20)",
-      "kategorie": "Munition",
-      "gewicht": 1,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Erhöht die Reichweite des Bogens um 2, verringert aber einen Schadenswürfel um einen Typ.",
-      "aktiv": true
-    },
-    "Rauchpfeile (20)": {
-      "name": "Rauchpfeile (20)",
-      "kategorie": "Munition",
-      "gewicht": 1.5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kein Schaden. Platziert eine Kleine Explosionsschablone am Auftreffpunkt. Die Beleuchtung innerhalb der Schablone wird um eine Stufe verringert. Die Wolke hält zwei Runden an.",
-      "aktiv": true
-    },
-    "Kugeln, Feuerwaffe (30)": {
-      "name": "Kugeln, Feuerwaffe (30)",
-      "kategorie": "Munition",
-      "gewicht": 0.25,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Munition für Schusswaffen. Für Kugeln aus Spezialmaterialien siehe Pathfinder for Savage Worlds.",
-      "aktiv": true
-    },
-    "Kugeln, gerillt (1)": {
-      "name": "Kugeln, gerillt (1)",
-      "kategorie": "Munition",
-      "gewicht": 0,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Speziell gefertigte Kugel, auf die Gift aufgetragen werden kann. Nicht kompatibel mit alchemistischen Kartuschen.",
-      "aktiv": true
-    },
-    "Schrot (30)": {
-      "name": "Schrot (30)",
-      "kategorie": "Munition",
-      "gewicht": 0.25,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schrot für Streuschusswaffen. Kieselsteine oder anderer Schutt können stattdessen verwendet werden, verursachen aber –1 auf Schießenproben.",
-      "aktiv": true
-    },
-    "Alchemistische Kartusche, Drachenatem": {
-      "name": "Alchemistische Kartusche, Drachenatem",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 40,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nur für Streuschusswaffen. Kein Schießenwurf: Alle unter der Kleinen Kegelschablone legen eine Ausweichen-Probe ab. 2W6 nichtmagischer Feuerschaden. Kritischer Fehlschlag wenn beide Schadenswürfel eine 1 zeigen.",
-      "aktiv": true
-    },
-    "Alchemistische Kartusche, Fesselschuss": {
-      "name": "Alchemistische Kartusche, Fesselschuss",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 40,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nur für Streuschusswaffen. Verringert den Waffenschaden um einen Würfeltyp. Jede getroffene Kreatur muss eine Ausweichen-Probe ablegen oder wird Verstrickt.",
-      "aktiv": true
-    },
-    "Alchemistische Kartusche, Leuchtspur": {
-      "name": "Alchemistische Kartusche, Leuchtspur",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Verringert den Schaden um einen Würfeltyp. Eine getroffene Kreatur wird für eine Runde geblendet. Auch als Signalrakete verwendbar. Kann nur gegen einzelne Kreaturen eingesetzt werden.",
-      "aktiv": true
-    },
-    "Alchemistische Kartusche, Metall": {
-      "name": "Alchemistische Kartusche, Metall",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Macht Kugel und Schwarzpulver wasserdicht.",
-      "aktiv": true
-    },
-    "Alchemistische Kartusche, Salzschrot": {
-      "name": "Alchemistische Kartusche, Salzschrot",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.25,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kann in Streuschusswaffen geladen werden. Verursacht betäubenden Schaden.",
-      "aktiv": true
-    },
-    "Doppelarmbrust": {
-      "name": "Doppelarmbrust",
-      "kategorie": "Waffe",
-      "gewicht": 9,
-      "kosten": 300,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Nachladen 3 für beide Bolzen oder Nachladen 2 für einen. Auf –2 auf Schießen beide Bolzen gleichzeitig abfeuern (Schaden: 3W8).",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "2W8",
-        "Reichweite": "15/30/60",
-        "FR": "1",
-        "Schuss": "2",
-        "PB": "2"
-      }
-    },
-    "Pilum": {
-      "name": "Pilum",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Der Schaft bricht beim Aufprall ab. Mit einer Steigerung beim Angriff bleibt er im Schild des Ziels stecken; das Ziel verliert den Schildbonus bis der Spieß entfernt wird (1 Aktion).",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Dolch/Messer Nahkampf": {
-      "name": "Dolch/Messer",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Dreizack Nahkampf": {
-      "name": "Dreizack",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Stützen, Reichweite 1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitflegel": {
-      "name": "Streitflegel",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "ignoriert Schildbonus",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Streitflegel schwer": {
-      "name": "Streitflegel, schwer",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "ignoriert Schildbonus, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Glefe": {
-      "name": "Glefe",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Reichweite 1, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Guisarme": {
-      "name": "Guisarme",
-      "kategorie": "Waffe",
-      "gewicht": 4.5,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1, Reichweite 1, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Hellebarde": {
-      "name": "Hellebarde",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1, Stützen, Reichweite 1, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Katana": {
-      "name": "Katana",
-      "kategorie": "Waffe",
-      "gewicht": 1.5,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6+1",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kampfstab": {
-      "name": "Kampfstab",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 0,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Parade +1, Reichweite 1, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Keule leicht": {
-      "name": "Keule, leicht",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Keule schwer": {
-      "name": "Keule, schwer",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kriegshammer": {
-      "name": "Kriegshammer",
-      "kategorie": "Waffe",
-      "gewicht": 2.5,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Krummsäbel": {
-      "name": "Krummsäbel",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Krummschwert": {
-      "name": "Krummschwert",
-      "kategorie": "Waffe",
-      "gewicht": 4,
-      "kosten": 75,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Lanze": {
-      "name": "Lanze",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 2 bei Sturmangriff, Reichweite 2, nur im berittenen Kampf verwendbar",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "2",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Morgenstern": {
-      "name": "Morgenstern",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 8,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Peitsche": {
-      "name": "Peitsche",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Parade –1, Reichweite 2. Bei einer Steigerung beim Angriffswurf ist das Opfer Festgehalten anstelle von Bonusschaden.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "2",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Pike": {
-      "name": "Pike",
-      "kategorie": "Waffe",
-      "gewicht": 9,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1 wenn aufgesetzt, Stützen, Reichweite 2, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "2",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Ranseur": {
-      "name": "Ranseur",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1, Reichweite 1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Rapier": {
-      "name": "Rapier",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Parade +1",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Schlägel": {
-      "name": "Schlägel",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 2, Zweihändig, +2 Schaden zum Zerstören von Gegenständen",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W10",
-      "eigenschaften": {
-        "Schaden": "Stä+W10",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Bastardschwert": {
-      "name": "Bastardschwert",
-      "kategorie": "Waffe",
-      "gewicht": 3,
-      "kosten": 35,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "1"
-      }
-    },
-    "Kurzschwert": {
-      "name": "Kurzschwert",
-      "kategorie": "Waffe",
-      "gewicht": 1,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Langschwert": {
-      "name": "Langschwert",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kampfaspergillum": {
-      "name": "Kampfaspergillum",
-      "kategorie": "Waffe",
-      "gewicht": 2,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Enthält Weihwasser. Bei jedem Treffer spritzt Weihwasser: +2 Schaden gegen Kreaturen, die von Weihwasser betroffen sind. Nach drei Angriffen leer.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "Stä+W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Bill": {
-      "name": "Bill",
-      "kategorie": "Waffe",
-      "gewicht": 5.5,
-      "kosten": 11,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Stützen, Reichweite 1, Zweihändig, Parade +1 beim Verteidigen",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W8",
-      "eigenschaften": {
-        "Schaden": "Stä+W8",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Schlagring": {
-      "name": "Schlagring",
-      "kategorie": "Waffe",
-      "gewicht": 0.5,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Träger gilt als bewaffnet; freie Wiederholung beim Verbergen",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W4",
-      "eigenschaften": {
-        "Schaden": "Stä+W4",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Glefe-Guisarme": {
-      "name": "Glefe-Guisarme",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 12,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 2, Stützen, Reichweite 1, Zweihändig",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W10",
-      "eigenschaften": {
-        "Schaden": "Stä+W10",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "2"
-      }
-    },
-    "Luzerner Hammer": {
-      "name": "Luzerner Hammer",
-      "kategorie": "Waffe",
-      "gewicht": 6,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "PB 3, Reichweite 1, Zweihändig, Parade -2",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W12",
-      "eigenschaften": {
-        "Schaden": "Stä+W12",
-        "Reichweite": "1",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "3"
-      }
-    },
-    "Menschenfänger Pathfinder": {
-      "name": "Menschenfänger",
-      "kategorie": "Waffe",
-      "gewicht": 5,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Reichweite 2, Zweihändig; kein regulärer Schaden: Bei einem Treffer kann sich das Ziel nicht vom Angreifer wegbewegen, bis es eine gegensätzliche Stärkeprobe (freie Aktion) gewinnt.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "W6",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "2",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Kanone Rundgeschoss": {
-      "name": "Kanone Rundgeschoss",
-      "kategorie": "Belagerungswaffe",
-      "gewicht": 0,
-      "kosten": 0,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwere Waffe, Nachladen 8. Zwei Besatzungsmitglieder können gleichzeitig nachladen. Bei Erfolg prallt die Kugel bei geradem Würfelergebnis zu einem weiteren Opfer hinter dem ersten Ziel (innerhalb von 6\") ab.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "3W6+1",
-        "Reichweite": "50/100/200",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "4",
-        "Flächenschablone": "MFS"
-      }
-    },
-    "Balliste": {
-      "name": "Balliste",
-      "kategorie": "Belagerungswaffe",
-      "gewicht": 0,
-      "kosten": 500,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Einzelperson oder 2 Minuten für eine Mannschaft von 2.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "3W6",
-        "Reichweite": "15/30/60",
-        "FR": "Speziell",
-        "Schuss": "-",
-        "PB": "4"
-      }
-    },
-    "Belagerungsturm": {
-      "name": "Belagerungsturm",
-      "kategorie": "Belagerungsgerät",
-      "gewicht": 0,
-      "kosten": 2000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Keine Fernkampfwaffe, wird zum Erklimmen von Mauern verwendet; Schützen können aus den oberen Stockwerken feuern. Bewegungsweite 1 mit 8 Personen, verdoppelt mit 16 Personen.",
-      "aktiv": true
-    },
-    "Trebuchet": {
-      "name": "Trebuchet",
-      "kategorie": "Belagerungswaffe",
-      "gewicht": 0,
-      "kosten": 1000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "3W8",
-        "Reichweite": "30/60/120",
-        "FR": "Speziell",
-        "Schuss": "-",
-        "PB": "4",
-        "Flächenschablone": "MFS"
-      }
-    },
-    "Katapult": {
-      "name": "Katapult",
-      "kategorie": "Belagerungswaffe",
-      "gewicht": 0,
-      "kosten": 800,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "3W6",
-        "Reichweite": "24/48/96",
-        "FR": "Speziell",
-        "Schuss": "-",
-        "PB": "4",
-        "Flächenschablone": "MFS"
-      }
-    },
-    "Rammbock": {
-      "name": "Rammbock",
-      "kategorie": "Belagerungsgerät",
-      "gewicht": 1000,
-      "kosten": 1000,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Keine Fernkampfwaffe, wird zum Zertrümmern von Objekten verwendet. Mindestens 2 Personen nötig, bis zu 8 können helfen.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "3W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Alchemistenfeuer": {
-      "name": "Alchemistenfeuer",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Eine klebrige, brennbare Flüssigkeit, die beim Aufschlag in Brand gerät. Schwere Waffe. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn sie nicht in Wasser untergetaucht werden. Ziel könnte in Brand geraten.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Donnerstein": {
-      "name": "Donnerstein",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 30,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Ein verzauberter Felsen, der mit einem ohrenbetäubenden Knall explodiert. Alle in der Schablone müssen eine Konstitutionsprobe schaffen, um nicht Angeschlagen und für eine Stunde taub zu sein.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "MFS"
-      }
-    },
-    "Ewige Fackel": {
-      "name": "Ewige Fackel",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 110,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Eine 'Fackel', die dauerhaft mit Licht verzaubert ist. Verbrennt nicht und gibt keine Hitze ab.",
-      "aktiv": true
-    },
-    "Gegengift Phiole": {
-      "name": "Gegengift, Phiole",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.25,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
-      "aktiv": true
-    },
-    "Rauchstab": {
-      "name": "Rauchstab",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.05,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Ein alchemistisch behandelter Stock, der dichten Rauch (Dunkle Beleuchtung) in einer Mittleren Flächenschablone erzeugt. Er hält 1 Minute lang an und löst sich in starkem Wind innerhalb einer Runde auf.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "MFS"
-      }
-    },
-    "Säureflasche": {
-      "name": "Säureflasche",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Wird wie eine Granate geworfen. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn die Säure nicht abgewaschen wird.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Sonnenzepter": {
-      "name": "Sonnenzepter",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 2,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Ein Eisenstab mit Goldspitzen, der für sechs Stunden in einem Radius von 9 m normales Licht erzeugt. Es erhöht die Beleuchtungsstufe darüber hinaus für weitere 9\" um eine Stufe. Es gibt keine Hitze ab und zählt als Sonnenlicht.",
-      "aktiv": true,
-      "typ": "Nahkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "1W6",
-        "Reichweite": "nah",
-        "FR": "-",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Verstrickungsbeutel": {
-      "name": "Verstrickungsbeutel",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 4,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Ein Opfer mit Größe 3 oder weniger, das von diesem kleinen Beutel klebrigen Materials getroffen wird, ist für fünf Runden Abgelenkt und muss eine Athletikprobe schaffen, um nicht auch am Boden festzukleben (Festgehalten).",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "1/2/4",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-"
-      }
-    },
-    "Heiliges Wasser": {
-      "name": "Heiliges Wasser",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Heiliges Wasser kann in einer Flasche geworfen oder auf eine angrenzende Kreatur gespritzt werden. Untote und bestimmte böse Kreaturen innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Zündholz": {
-      "name": "Zündholz",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.05,
-      "kosten": 1,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Ein dünnes Stäbchen, das eine Flamme erzeugt, wenn es hart gegen eine Oberfläche geschlagen wird. Dies ermöglicht es, Fackeln und andere brennbare Substanzen in einer Aktion zu entzünden.",
-      "aktiv": true
-    },
-    "Alchemistenfreundlichkeit": {
-      "name": "Alchemistenfreundlichkeit",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kristallines Pulver ähnlich wie Salz, beliebt bei jungen Adligen. Mit Wasser gemischt ergibt es ein sprudelndes Getränk, das die Auswirkungen eines Katers innerhalb von 10 Minuten beseitigt.",
-      "aktiv": true
-    },
-    "Laugenkolben": {
-      "name": "Laugenkolben",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 15,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kolben mit kaustischer Flüssigkeit. Wirkt wie Säure gegen Schleime und säurebasierte Kreaturen (2W4 Schaden in der Kleinen Flächenschablone), ist für alle anderen harmlos.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Blutblock": {
-      "name": "Blutblock",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Klebrige, rosa Substanz zur Wundbehandlung. Eine Dosis beendet die Auswirkungen eines Reißenden Angriffs und Ausblutens. Herstellungsmodifikator: –2.",
-      "aktiv": true
-    },
-    "Blitzpulver": {
-      "name": "Blitzpulver",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 50,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Grobes graues Pulver, das bei Flamme, starker Reibung oder Aufprall fast sofort entzündet. Alle Kreaturen in der Kleinen Flächenschablone werden bis zum Ende ihres nächsten Zuges geblendet (wie der Blind-Zauber).",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Flüssiges Eis": {
-      "name": "Flüssiges Eis",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 1,
-      "kosten": 40,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Versiegeltes Glas mit blauer kristalliner Flüssigkeit (auch 'Alchemisteneis'). Nach dem Öffnen kann es 1W6 Runden lang genutzt werden, um Flüssigkeiten einzufrieren oder Objekte mit Eis zu überziehen. Kann auch als Wurfwaffe eingesetzt werden.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "2W4",
-        "Reichweite": "3/6/12",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Nushadir": {
-      "name": "Nushadir",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 10,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kleine salzige Körner in einem trockenen Behälter. Neutralisiert Säure: eine Phiole Körner oder ein Kolben Nushadirwasser macht einen Kubikfuß Säure innerhalb einer Minute berührungssicher (zu langsam, um geworfene Säure zu neutralisieren).",
-      "aktiv": true
-    },
-    "Riechsalze": {
-      "name": "Riechsalze",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.5,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Scharf duftende graue Kristalle. Ermöglichen einer schlafenden Person (magisch oder normal) eine Geistprobe zum Aufwachen. Ein Behälter hat 12 Anwendungen (nach jeder Benutzung gestöpselt), leert sich in wenigen Stunden, wenn offen gelassen. Herstellungsmodifikator: –2.",
-      "aktiv": true
-    },
-    "Rauchkügelchen": {
-      "name": "Rauchkügelchen",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0,
-      "kosten": 25,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Kleine Tonkugel mit zwei getrennten Substanzen. Beim Zerbrechen mischen sie sich und füllen eine Kleine Flächenschablone mit gelbem, harmlosem Rauch für eine Runde.",
-      "aktiv": true,
-      "typ": "Fernkampf",
-      "mindeststaerke": "-",
-      "eigenschaften": {
-        "Schaden": "-",
-        "Reichweite": "3/6/9",
-        "FR": "1",
-        "Schuss": "-",
-        "PB": "-",
-        "Flächenschablone": "KFS"
-      }
-    },
-    "Waffenblanchierer, Adamantit": {
-      "name": "Waffenblanchierer, Adamantit",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.25,
-      "kosten": 100,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Pulver, das auf einer heißen Waffe aufgeschmolzen eine temporäre Beschichtung bildet. Beim nächsten erfolgreichen Treffer löst es Umgebungsschwächen (Adamantit) aus. Eine Dosis beschichtet eine Waffe oder bis zu 10 Munitionseinheiten. Nur ein Blanchierertyp gleichzeitig auf einer Waffe. Herstellungsmodifikator: –2.",
-      "aktiv": true
-    },
-    "Waffenblanchierer, Kalteisen": {
-      "name": "Waffenblanchierer, Kalteisen",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.25,
-      "kosten": 20,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Wie Waffenblanchierer (Adamantit). Beim nächsten erfolgreichen Treffer löst es Umgebungsschwächen (Kalteisen) aus.",
-      "aktiv": true
-    },
-    "Waffenblanchierer, Silber": {
-      "name": "Waffenblanchierer, Silber",
-      "kategorie": "Alchemistischer Gegenstand",
-      "gewicht": 0.25,
-      "kosten": 5,
-      "setting": "savage_pathfinder",
-      "beschreibung": "Wie Waffenblanchierer (Adamantit). Beim nächsten erfolgreichen Treffer löst es Umgebungsschwächen (Silber) aus.",
-      "aktiv": true
-    }
-  },
-  "settingregeln": {
-    "strahlschablone": false,
-    "große_hoehen": false,
-    "verrat": false,
-    "schwierige_heilung": false,
-    "freizeit": false,
-    "riesige_feinde": false,
-    "schurkische_entschlossenheit": false,
-    "dynamischer_rueckschlag": false,
-    "entschlossenheit": false,
-    "fanatiker": false,
-    "fertigkeitsspezialisierungen": false,
-    "fieser_schaden": false,
-    "geborener_held": false,
-    "grosse_abenteuer": false,
-    "helden_sterben_nie": false,
-    "keine_machtpunkte": false,
-    "kreativer_kampf": false,
-    "mehr_fertigkeitspunkte": false,
-    "mehr_sprachen": false,
-    "narrenglueck": false,
-    "schnelle_genesung": false,
-    "schwere_entscheidungen": false,
-    "ungepanzerter_held": false,
-    "wundobergrenze": false
-  },
-  "startgeld": 300,
-  "waehrung": "GM"
+    "ausruestung": {
+        "Angelhaken": {
+            "name": "Angelhaken",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Beutel, Gürtel": {
+            "name": "Beutel, Gürtel",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Fackel": {
+            "name": "Fackel",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.01,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Licht für 1 Stunde, 4'' Radius.",
+            "aktiv": true
+        },
+        "Feuerholz (pro Tag)": {
+            "name": "Feuerholz (pro Tag)",
+            "kategorie": "Allgemein",
+            "gewicht": 10,
+            "kosten": 0.01,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Feuerstein und Stahl": {
+            "name": "Feuerstein und Stahl",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Fischernetz (2,5 Quadratmeter)": {
+            "name": "Fischernetz (2,5 Quadratmeter)",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 4,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Flasche oder Krug, Keramik (leer)": {
+            "name": "Flasche oder Krug, Keramik (leer)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.03,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Flasche, Glas (leer)": {
+            "name": "Flasche, Glas (leer)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Flaschenzug": {
+            "name": "Flaschenzug",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Handschellen": {
+            "name": "Handschellen",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Behälter, Karte oder Schriftrolle": {
+            "name": "Behälter, Karte oder Schriftrolle",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Kerze": {
+            "name": "Kerze",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.01,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Brennt eine Stunde, spendet Licht in 2'' Radius.",
+            "aktiv": true
+        },
+        "Kette": {
+            "name": "Kette",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Krähenfüße": {
+            "name": "Krähenfüße",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Ein Beutel deckt eine kleine Flächenschablone ab, zwei eine mittlere und drei eine große. Zählt als Schwieriges Gelände; jeder der sich durch das Gebiet bewegt, muss Athletik würfeln, um nicht Angeschlagen zu werden. Ein Kritischer Fehlschlag verursacht eine Wunde an den Füßen (–2 Bewegungsweite bis geheilt).",
+            "aktiv": true
+        },
+        "Kreide": {
+            "name": "Kreide",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.01,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Lampe, klein": {
+            "name": "Lampe, klein",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "3'' Radius",
+            "aktiv": true
+        },
+        "Laterne, Blend-": {
+            "name": "Laterne, Blend-",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "10'' Kegel",
+            "aktiv": true
+        },
+        "Laterne, abdeckbar": {
+            "name": "Laterne, abdeckbar",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 7,
+            "setting": "savage_pathfinder",
+            "beschreibung": "6'' Radius",
+            "aktiv": true
+        },
+        "Nähnadel": {
+            "name": "Nähnadel",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Öl (für Laterne; halber Liter)": {
+            "name": "Öl (für Laterne; halber Liter)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
+            "aktiv": true
+        },
+        "Papier": {
+            "name": "Papier",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.4,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Pergament": {
+            "name": "Pergament",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Pfeife, Keramik": {
+            "name": "Pfeife, Keramik",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Phiole, klein": {
+            "name": "Phiole, klein",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Rucksack (leer)": {
+            "name": "Rucksack (leer)",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Halbiert das effektive Gewicht des Inhalts.",
+            "aktiv": true
+        },
+        "Sack (leer)": {
+            "name": "Sack (leer)",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Sanduhr": {
+            "name": "Sanduhr",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Schaufel": {
+            "name": "Schaufel",
+            "kategorie": "Allgemein",
+            "gewicht": 4,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Schlafsack": {
+            "name": "Schlafsack",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Schleifstein": {
+            "name": "Schleifstein",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.02,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Seife": {
+            "name": "Seife",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Seil, Hanf (10''/20 Meter)": {
+            "name": "Seil, Hanf (10''/20 Meter)",
+            "kategorie": "Allgemein",
+            "gewicht": 5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
+            "aktiv": true
+        },
+        "Seil, Seide (10''/20 Meter)": {
+            "name": "Seil, Seide (10''/20 Meter)",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Segeltuch (Quadratmeter)": {
+            "name": "Segeltuch (Quadratmeter)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Siegelwachs, Stange": {
+            "name": "Siegelwachs, Stange",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Spiegel, klein, Stahl": {
+            "name": "Spiegel, klein, Stahl",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Stachel (Kletterhaken)": {
+            "name": "Stachel (Kletterhaken)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 0.05,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Stange, 4 Meter": {
+            "name": "Stange, 4 Meter",
+            "kategorie": "Allgemein",
+            "gewicht": 4,
+            "kosten": 0.25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Brechstange": {
+            "name": "Brechstange",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Tintenstift (Schreibfeder)": {
+            "name": "Tintenstift (Schreibfeder)",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Topf, Eisen": {
+            "name": "Topf, Eisen",
+            "kategorie": "Allgemein",
+            "gewicht": 2,
+            "kosten": 0.8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Trinkkrug, Keramik": {
+            "name": "Trinkkrug, Keramik",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.02,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Truhe (klein, leer)": {
+            "name": "Truhe (klein, leer)",
+            "kategorie": "Allgemein",
+            "gewicht": 6,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wasserschlauch": {
+            "name": "Wasserschlauch",
+            "kategorie": "Allgemein",
+            "gewicht": 2,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Gewicht ist mit Inhalt",
+            "aktiv": true
+        },
+        "Wolldecke": {
+            "name": "Wolldecke",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wurfhaken": {
+            "name": "Wurfhaken",
+            "kategorie": "Allgemein",
+            "gewicht": 2,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Zelt, Tuch (2 Personen)": {
+            "name": "Zelt, Tuch (2 Personen)",
+            "kategorie": "Allgemein",
+            "gewicht": 10,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Bankett (pro Person)": {
+            "name": "Bankett (pro Person)",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Bier, 4 Liter": {
+            "name": "Bier, 4 Liter",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 4,
+            "kosten": 0.2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Bier, Krug": {
+            "name": "Bier, Krug",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0.5,
+            "kosten": 0.04,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Brot, Leib": {
+            "name": "Brot, Leib",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0.25,
+            "kosten": 0.02,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Käse, Klotz": {
+            "name": "Käse, Klotz",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Reiseproviant (pro Tag)": {
+            "name": "Reiseproviant (pro Tag)",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0.5,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Mahlzeit, schlicht (pro Tag)": {
+            "name": "Mahlzeit, schlicht (pro Tag)",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Mahlzeit, gewöhnlich (pro Tag)": {
+            "name": "Mahlzeit, gewöhnlich (pro Tag)",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0,
+            "kosten": 0.3,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Mahlzeit, gut (pro Tag)": {
+            "name": "Mahlzeit, gut (pro Tag)",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Tierfutter (pro Tag)": {
+            "name": "Tierfutter (pro Tag)",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 4,
+            "kosten": 0.05,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Trockenfrüchte, Beutel": {
+            "name": "Trockenfrüchte, Beutel",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0.5,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wein, 4 Liter": {
+            "name": "Wein, 4 Liter",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 4,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wein, Becher": {
+            "name": "Wein, Becher",
+            "kategorie": "Essen & Trinken",
+            "gewicht": 0.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Adeligenkleindung": {
+            "name": "Adeligenkleindung",
+            "kategorie": "Kleidung",
+            "gewicht": 5,
+            "kosten": 75,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Händlerkleidung": {
+            "name": "Händlerkleidung",
+            "kategorie": "Kleidung",
+            "gewicht": 2,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Handwerkerkleidung": {
+            "name": "Handwerkerkleidung",
+            "kategorie": "Kleidung",
+            "gewicht": 2,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Kaltwetterkleidung": {
+            "name": "Kaltwetterkleidung",
+            "kategorie": "Kleidung",
+            "gewicht": 3.5,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schützt vor Kälte",
+            "aktiv": true
+        },
+        "Königliche Kleidung": {
+            "name": "Königliche Kleidung",
+            "kategorie": "Kleidung",
+            "gewicht": 7.5,
+            "kosten": 100,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Reisekleidung": {
+            "name": "Reisekleidung",
+            "kategorie": "Kleidung",
+            "gewicht": 2.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Esel oder Maultier": {
+            "name": "Esel oder Maultier",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Hund, Wachhund": {
+            "name": "Hund, Wachhund",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Pferd, leicht": {
+            "name": "Pferd, leicht",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0,
+            "kosten": 75,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Siehe Seite 248",
+            "aktiv": true
+        },
+        "Pferd, schwer": {
+            "name": "Pferd, schwer",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0,
+            "kosten": 300,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Siehe Seite 248",
+            "aktiv": true
+        },
+        "Pony, leicht": {
+            "name": "Pony, leicht",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Siehe Seite 248",
+            "aktiv": true
+        },
+        "Pony, schwer": {
+            "name": "Pony, schwer",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0,
+            "kosten": 45,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Siehe Seite 248",
+            "aktiv": true
+        },
+        "Sattel, Kriegssattel": {
+            "name": "Sattel, Kriegssattel",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 15,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Freie Wiederholung bei Reitenproben, um im Sattel zu bleiben",
+            "aktiv": true
+        },
+        "Sattel, Reitsattel": {
+            "name": "Sattel, Reitsattel",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 12.5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Satteltaschen, leer": {
+            "name": "Satteltaschen, leer",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 4,
+            "kosten": 4,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Zaumzeug und Zügel": {
+            "name": "Zaumzeug und Zügel",
+            "kategorie": "Tiere & Ausrüstung",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Herberge, schlicht (pro Tag)": {
+            "name": "Herberge, schlicht (pro Tag)",
+            "kategorie": "Unterkunft",
+            "gewicht": 0,
+            "kosten": 0.2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Herberge, gewöhnlich (pro Tag)": {
+            "name": "Herberge, gewöhnlich (pro Tag)",
+            "kategorie": "Unterkunft",
+            "gewicht": 0,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Herberge, gut (pro Tag)": {
+            "name": "Herberge, gut (pro Tag)",
+            "kategorie": "Unterkunft",
+            "gewicht": 0,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Stall (pro Tag)": {
+            "name": "Stall (pro Tag)",
+            "kategorie": "Unterkunft",
+            "gewicht": 0,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Abenteurerausrüstung": {
+            "name": "Abenteurerausrüstung",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 2.5,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Blendlaterne, Feuerstein und Stahl, Hanfseil, Kerze, kleiner Spiegel, Kreide, Mahlzeiten für 1 Woche, Rucksack, Öl, Schaufel, Schlafsack, Schleifstein, Seife, Wasserschlauch, Wurfhaken, Zusatzkleidung, 3 x Fackeln",
+            "aktiv": true
+        },
+        "Diebeswerkzeug": {
+            "name": "Diebeswerkzeug",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.25,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Dietriche und Nadeln, Handschuhe, Ölflaschen, Schmiere, Seidenseil, –2 auf Diebeskunst ohne.",
+            "aktiv": true
+        },
+        "Fernrohr": {
+            "name": "Fernrohr",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.5,
+            "kosten": 1000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Wahrnehmung +2 auf Entfernung",
+            "aktiv": true
+        },
+        "Hammer": {
+            "name": "Hammer",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.25,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Werkzeug eines Handwerkers": {
+            "name": "Werkzeug eines Handwerkers",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 1.25,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Heilertasche": {
+            "name": "Heilertasche",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.25,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Rudimentäre medizinische Ausrüstung, inklusive Salben und Verbänden, –1 auf Heilen ohne.",
+            "aktiv": true
+        },
+        "Heiliges Symbol, Holz": {
+            "name": "Heiliges Symbol, Holz",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Heiliges Symbol, Silber": {
+            "name": "Heiliges Symbol, Silber",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.5,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Kaufmannswaage": {
+            "name": "Kaufmannswaage",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.25,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Kletterausrüstung": {
+            "name": "Kletterausrüstung",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 2.5,
+            "kosten": 80,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Hammer, Kletterhaken, Seil, Steigeisen und andere Ausrüstung zum Klettern. Diese Ausrüstung erlaubt es dem Anwender, bis zu 2 Punkte Abzüge beim Klettern zu ignorieren.",
+            "aktiv": true
+        },
+        "Musikinstrument": {
+            "name": "Musikinstrument",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.75,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Spitzhacke": {
+            "name": "Spitzhacke",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 1.25,
+            "kosten": 3,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Vergrößerungsglas": {
+            "name": "Vergrößerungsglas",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0,
+            "kosten": 100,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Verkleidungsausrüstung": {
+            "name": "Verkleidungsausrüstung",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 2,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schminke, Prothesen und falsches Haar. Gewährt eine freie Wiederholung bei Darbietungsproben bei Verwendung einer Verkleidung.",
+            "aktiv": true
+        },
+        "Vorschlaghammer": {
+            "name": "Vorschlaghammer",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 2.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Zauberbuch, Magier (leer)": {
+            "name": "Zauberbuch, Magier (leer)",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.75,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Zauberkomponentenbeutel": {
+            "name": "Zauberkomponentenbeutel",
+            "kategorie": "Werkzeuge & Ausrüstungssets",
+            "gewicht": 0.5,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Alchemistentasche": {
+            "name": "Alchemistentasche",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 25,
+            "setting": "fantasy",
+            "beschreibung": "Tragbares Labor mit Werkzeugen und Kräutern.",
+            "aktiv": true
+        },
+        "Artefakterschaffertasche": {
+            "name": "Artefakterschaffertasche",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 100,
+            "setting": "fantasy",
+            "beschreibung": "Werkzeuge zum Verzaubern von magischen Gegenständen.",
+            "aktiv": true
+        },
+        "Bandolier": {
+            "name": "Bandolier",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 0.5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Behälter für Karte oder Schriftrolle": {
+            "name": "Behälter für Karte oder Schriftrolle",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Buch": {
+            "name": "Buch",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 50,
+            "setting": "fantasy",
+            "beschreibung": "Ermöglicht Rechercheproben.",
+            "aktiv": true
+        },
+        "Diebeswerkzeuge": {
+            "name": "Diebeswerkzeuge",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 30,
+            "setting": "fantasy",
+            "beschreibung": "-2 auf Diebeskunst ohne Werkzeuge.",
+            "aktiv": true
+        },
+        "Fallenherstellungsset": {
+            "name": "Fallenherstellungsset",
+            "kategorie": "Allgemein",
+            "gewicht": 5,
+            "kosten": 150,
+            "setting": "fantasy",
+            "beschreibung": "-2 auf Reparieren ohne Set.",
+            "aktiv": true
+        },
+        "Fass": {
+            "name": "Fass",
+            "kategorie": "Allgemein",
+            "gewicht": 15,
+            "kosten": 2,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Feder": {
+            "name": "Feder",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Feldflasche (Metall)": {
+            "name": "Feldflasche (Metall)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Fernglas": {
+            "name": "Fernglas",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1000,
+            "setting": "fantasy",
+            "beschreibung": "Wahrnehmung +2, um entfernte Objekte zu erkennen.",
+            "aktiv": true
+        },
+        "Flasche": {
+            "name": "Flasche",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Flickzeug": {
+            "name": "Flickzeug",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Glocke": {
+            "name": "Glocke",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Gürteltasche": {
+            "name": "Gürteltasche",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Karren": {
+            "name": "Karren",
+            "kategorie": "Allgemein",
+            "gewicht": 40,
+            "kosten": 15,
+            "setting": "fantasy",
+            "beschreibung": "150 kg Ladevermögen.",
+            "aktiv": true
+        },
+        "Kette (10 Meter)": {
+            "name": "Kette (10 Meter)",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 30,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Kiste": {
+            "name": "Kiste",
+            "kategorie": "Allgemein",
+            "gewicht": 5,
+            "kosten": 5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Laterne": {
+            "name": "Laterne",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 12,
+            "setting": "fantasy",
+            "beschreibung": "Licht für 3 Stunden, 4'' Radius.",
+            "aktiv": true
+        },
+        "Öl (0,5 l)": {
+            "name": "Öl (0,5 l)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "Brennstoff, kann als Wurfwaffe verwendet werden.",
+            "aktiv": true
+        },
+        "Pergament (pro Blatt)": {
+            "name": "Pergament (pro Blatt)",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Ruderboot": {
+            "name": "Ruderboot",
+            "kategorie": "Allgemein",
+            "gewicht": 50,
+            "kosten": 50,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Sack, klein": {
+            "name": "Sack, klein",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Seil, Hanf (20 Meter)": {
+            "name": "Seil, Hanf (20 Meter)",
+            "kategorie": "Allgemein",
+            "gewicht": 5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "Trägt 150 kg, bricht bei Überbelastung.",
+            "aktiv": true
+        },
+        "Stab (3,5 m)": {
+            "name": "Stab (3,5 m)",
+            "kategorie": "Allgemein",
+            "gewicht": 4,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Tagebuch, leer": {
+            "name": "Tagebuch, leer",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Tinte (Fläschchen)": {
+            "name": "Tinte (Fläschchen)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Krug, Keramik": {
+            "name": "Krug, Keramik",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Heiliges Symbol, Gold": {
+            "name": "Heiliges Symbol, Gold",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 100,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Schubkarre": {
+            "name": "Schubkarre",
+            "kategorie": "Allgemein",
+            "gewicht": 10,
+            "kosten": 10,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Schwertscheide": {
+            "name": "Schwertscheide",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 8,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Siegelwachs, Stab": {
+            "name": "Siegelwachs, Stab",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Kreide (Schachtel mit 12 Stück)": {
+            "name": "Kreide (Schachtel mit 12 Stück)",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Leinwand (m2)": {
+            "name": "Leinwand (m2)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Reitbedarf": {
+            "name": "Reitbedarf",
+            "kategorie": "Allgemein",
+            "gewicht": 12.5,
+            "kosten": 15,
+            "setting": "fantasy",
+            "beschreibung": "Sattel, Zaumzeug und Zügel. -2 auf Reiten ohne Ausrüstung.",
+            "aktiv": true
+        },
+        "Schaufel, klein": {
+            "name": "Schaufel, klein",
+            "kategorie": "Allgemein",
+            "gewicht": 2,
+            "kosten": 2,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Steigeisen/Kletterhaken (10)": {
+            "name": "Steigeisen/Kletterhaken (10)",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Bier, Becher": {
+            "name": "Bier, Becher",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Futter, Tier (1 Tag)": {
+            "name": "Futter, Tier (1 Tag)",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 2,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Grundrationen (1 Tag)": {
+            "name": "Grundrationen (1 Tag)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Mahlzeit, billig": {
+            "name": "Mahlzeit, billig",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Mahlzeit, durchschnittlich": {
+            "name": "Mahlzeit, durchschnittlich",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 0.5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Mahlzeit, gut": {
+            "name": "Mahlzeit, gut",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Rationen, edel (1 Tag)": {
+            "name": "Rationen, edel (1 Tag)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wasser, 1 Liter (1 Tag)": {
+            "name": "Wasser, 1 Liter (1 Tag)",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 0.25,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wein, Flasche": {
+            "name": "Wein, Flasche",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Wein, Glas": {
+            "name": "Wein, Glas",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 0.5,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Feine Kleidung": {
+            "name": "Feine Kleidung",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 100,
+            "setting": "fantasy",
+            "beschreibung": "+1 auf Überreden in Statussituationen.",
+            "aktiv": true
+        },
+        "Formelle Kleidung": {
+            "name": "Formelle Kleidung",
+            "kategorie": "Allgemein",
+            "gewicht": 2.5,
+            "kosten": 75,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Gewöhnliche Kleidung": {
+            "name": "Gewöhnliche Kleidung",
+            "kategorie": "Allgemein",
+            "gewicht": 1,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Stiefel, schwer": {
+            "name": "Stiefel, schwer",
+            "kategorie": "Allgemein",
+            "gewicht": 2,
+            "kosten": 2,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Umhang, leicht (mit Kapuze)": {
+            "name": "Umhang, leicht (mit Kapuze)",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 2,
+            "setting": "fantasy",
+            "beschreibung": "",
+            "aktiv": true
+        },
+        "Winterkleidung": {
+            "name": "Winterkleidung",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 8,
+            "setting": "fantasy",
+            "beschreibung": "Schützt vor Kälte (siehe SWAE, S. 118).",
+            "aktiv": true
+        },
+        "Abenteurerpaket": {
+            "name": "Abenteurerpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 11.5,
+            "kosten": 45,
+            "setting": "fantasy",
+            "beschreibung": "Rucksack, Schlafsack, Kerze, Kreide, gewöhnliche Kleidung, Feuerstein und Stahl, Wurfhaken, Laterne, Spiegel, Seil, Öl, Schaufel, Seife, 3 Fackeln, Wasserschlauch, Schleifstein, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Alchemistenpaket": {
+            "name": "Alchemistenpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 15.5,
+            "kosten": 50,
+            "setting": "fantasy",
+            "beschreibung": "Alchemistentasche, Rucksack, Feuerstein und Stahl, Schlafsack, Spiegel, Gürteltasche, Öl, Seil, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Diebespaket": {
+            "name": "Diebespaket",
+            "kategorie": "Allgemein",
+            "gewicht": 9.5,
+            "kosten": 65,
+            "setting": "fantasy",
+            "beschreibung": "Diebeswerkzeug, Rucksack, Spiegel, Feuerstein und Stahl, Gürteltasche, Wurfhaken, Seil, Krähenfüße, Sack (klein), Öl, Laterne, Wasserschlauch, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Gewölbeforscherpaket": {
+            "name": "Gewölbeforscherpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 15.5,
+            "kosten": 50,
+            "setting": "fantasy",
+            "beschreibung": "Seil, Wurfhaken, Rucksack, Feuerstein und Stahl, Hammer, Schlafsack, Brechstange, Laterne, Öl, Steigeisen, Schaufel, Wasserschläuche, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Klerikerpaket": {
+            "name": "Klerikerpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 6,
+            "kosten": 100,
+            "setting": "fantasy",
+            "beschreibung": "Heiliges Symbol, Schlafsack, Feuerstein und Stahl, Kerze, Heilertasche, Laterne, Öl, Pergament, Tinte, Feder, Rucksack, Wasserschlauch, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Magierpaket": {
+            "name": "Magierpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 8,
+            "kosten": 80,
+            "setting": "fantasy",
+            "beschreibung": "Zauberbuch, Rucksack, Schlafsack, Lampe, Feuerstein und Stahl, Tinte, Feder, Öl, Umhang, Buch, Wasserschlauch, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Söldnerpaket": {
+            "name": "Söldnerpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 12,
+            "kosten": 45,
+            "setting": "fantasy",
+            "beschreibung": "Schlafsack, Rucksack, Krähenfüße, Laterne, 1,5 l Öl, Bier (5 l), Feuerstein und Stahl, Krug, Seil, Handschellen, Wasserschlauch, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Unterhalterpaket": {
+            "name": "Unterhalterpaket",
+            "kategorie": "Allgemein",
+            "gewicht": 8,
+            "kosten": 120,
+            "setting": "fantasy",
+            "beschreibung": "Musikinstrument, Rucksack, Schlafsack, Spiegel, Tagebuch, Tinte und Federkiel, Feuerstein und Stahl, Mantel (leicht, mit Kapuze), formelle Kleidung, Verpflegung für 1 Woche, Flickzeug, Flasche Wein.",
+            "aktiv": true
+        },
+        "Wildnispaket": {
+            "name": "Wildnispaket",
+            "kategorie": "Allgemein",
+            "gewicht": 12,
+            "kosten": 36,
+            "setting": "fantasy",
+            "beschreibung": "Zelt (2 Personen), Rucksack, Seil, Schlafsack, Winterkleidung, Stiefel (schwer), Feuerstein und Stahl, Schaufel (klein), Umhang mit Kapuze, Wasserschlauch, Verpflegung für 1 Woche.",
+            "aktiv": true
+        },
+        "Blasrohrpfeile (20)": {
+            "name": "Blasrohrpfeile (20)",
+            "kategorie": "Allgemein",
+            "gewicht": 0,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "Nur für den Gebrauch mit dem Blasrohr. Enthält 20 Pfeile.",
+            "aktiv": true
+        },
+        "Brandpfeile (20)": {
+            "name": "Brandpfeile/-bolzen (20)",
+            "kategorie": "Allgemein",
+            "gewicht": 1.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "Halbe normale Reichweite, +1W6 Schaden, kann brennbare Gegenstände entzünden. Pro Stück.",
+            "aktiv": true
+        },
+        "Schießpulver (10)": {
+            "name": "Schießpulver (10)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "Für Schwarzpulverwaffen. Enthält 10 Schuss.",
+            "aktiv": true
+        },
+        "Schleudersteine (20)": {
+            "name": "Schleudersteine (20)",
+            "kategorie": "Allgemein",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "fantasy",
+            "beschreibung": "Polierte Steine für Schleudern. Enthält 20 Steine.",
+            "aktiv": true
+        },
+        "Beinlinge": {
+            "name": "Beinlinge",
+            "kategorie": "Rüstung",
+            "gewicht": 2.5,
+            "kosten": 5,
+            "setting": "mittelalterlich",
+            "beschreibung": "Leichte Stoffbeinlinge",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 1,
+            "kopf": 0,
+            "mindeststaerke": "W4"
+        },
+        "Robe mit Kapuze": {
+            "name": "Robe mit Kapuze",
+            "kategorie": "Rüstung",
+            "gewicht": 4,
+            "kosten": 10,
+            "setting": "mittelalterlich",
+            "beschreibung": "Robe mit Kapuze schützt Torso, Arme und Kopf",
+            "aktiv": true,
+            "torso": 1,
+            "arme": 1,
+            "beine": 0,
+            "kopf": 1,
+            "mindeststaerke": "W4"
+        },
+        "Tunika": {
+            "name": "Tunika",
+            "kategorie": "Rüstung",
+            "gewicht": 2.5,
+            "kosten": 10,
+            "setting": "mittelalterlich",
+            "beschreibung": "Leichte Stofftunika schützt Torso und Arme",
+            "aktiv": true,
+            "torso": 1,
+            "arme": 1,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W4"
+        },
+        "Umhang mit Kapuze": {
+            "name": "Umhang mit Kapuze",
+            "kategorie": "Rüstung",
+            "gewicht": 2.5,
+            "kosten": 5,
+            "setting": "mittelalterlich",
+            "beschreibung": "Leichter Umhang schützt Torso und Kopf",
+            "aktiv": true,
+            "torso": 1,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 1,
+            "mindeststaerke": "W4"
+        },
+        "Bronzearmschienen": {
+            "name": "Bronzearmschienen",
+            "kategorie": "Rüstung",
+            "gewicht": 2.5,
+            "kosten": 100,
+            "setting": "mittelalterlich",
+            "beschreibung": "Mittlere Armschienen aus Bronze",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 3,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W8"
+        },
+        "Bronzebeinschienen": {
+            "name": "Bronzebeinschienen",
+            "kategorie": "Rüstung",
+            "gewicht": 3,
+            "kosten": 200,
+            "setting": "mittelalterlich",
+            "beschreibung": "Mittlere Beinschienen aus Bronze",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 3,
+            "kopf": 0,
+            "mindeststaerke": "W8"
+        },
+        "Bronzebrustpanzer": {
+            "name": "Bronzebrustpanzer",
+            "kategorie": "Rüstung",
+            "gewicht": 6.5,
+            "kosten": 200,
+            "setting": "mittelalterlich",
+            "beschreibung": "Mittlerer Brustpanzer aus Bronze",
+            "aktiv": true,
+            "torso": 3,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W8"
+        },
+        "Schwerer geschlossener Helm": {
+            "name": "Schwerer geschlossener Helm",
+            "kategorie": "Rüstung",
+            "gewicht": 4,
+            "kosten": 300,
+            "setting": "mittelalterlich",
+            "beschreibung": "Schwerer Helm mit geschlossenem Visier",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 4,
+            "mindeststaerke": "W10"
+        },
+        "Kettenhose": {
+            "name": "Kettenhose",
+            "kategorie": "Rüstung",
+            "gewicht": 10,
+            "kosten": 100,
+            "setting": "mittelalterlich",
+            "beschreibung": "Mittlere Kettenhose schützt die Beine",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 3,
+            "kopf": 0,
+            "mindeststaerke": "W8"
+        },
+        "Bronzehelm": {
+            "name": "Bronzehelm",
+            "kategorie": "Rüstung",
+            "gewicht": 3,
+            "kosten": 120,
+            "setting": "mittelalterlich",
+            "beschreibung": "Mittlerer Helm aus Bronze",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 3,
+            "mindeststaerke": "W8"
+        },
+        "Beinlinge aus natürlicher Rüstung": {
+            "name": "Beinlinge aus natürlicher Rüstung",
+            "kategorie": "Rüstung",
+            "gewicht": 3.5,
+            "kosten": 20,
+            "setting": "mittelalterlich",
+            "beschreibung": "Beinlinge aus dicker natürlicher Rüstung",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 2,
+            "kopf": 0,
+            "mindeststaerke": "W6"
+        },
+        "Hemd aus natürlicher Rüstung": {
+            "name": "Hemd aus natürlicher Rüstung",
+            "kategorie": "Rüstung",
+            "gewicht": 5,
+            "kosten": 20,
+            "setting": "mittelalterlich",
+            "beschreibung": "Hemd aus natürlicher Rüstung schützt Torso und Arme",
+            "aktiv": true,
+            "torso": 2,
+            "arme": 2,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W6"
+        },
+        "Kleiner Schild": {
+            "name": "Kleiner Schild",
+            "kategorie": "Schild",
+            "gewicht": 2,
+            "kosten": 5,
+            "setting": "mittelalterlich",
+            "beschreibung": "Kleiner Schild für grundlegenden Schutz.",
+            "aktiv": true,
+            "parade": 1,
+            "deckung": 0,
+            "mindeststaerke": "W6"
+        },
+        "Mittlerer Schild": {
+            "name": "Mittlerer Schild",
+            "kategorie": "Schild",
+            "gewicht": 4,
+            "kosten": 9,
+            "setting": "mittelalterlich",
+            "beschreibung": "Mittlerer Schild für besseren Schutz.",
+            "aktiv": true,
+            "parade": 2,
+            "deckung": -2,
+            "mindeststaerke": "W8"
+        },
+        "Großer Schild": {
+            "name": "Großer Schild",
+            "kategorie": "Schild",
+            "gewicht": 6,
+            "kosten": 20,
+            "setting": "mittelalterlich",
+            "beschreibung": "Großer Schild für maximalen Schutz. Verringert die Bewegungsweite um 1.",
+            "aktiv": true,
+            "parade": 2,
+            "deckung": -4,
+            "mindeststaerke": "W10"
+        },
+        "Chakram": {
+            "name": "Chakram",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "mittelalterlich",
+            "beschreibung": "Parade +1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Dolch": {
+            "name": "Dolch",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "mittelalterlich",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Dreizack": {
+            "name": "Dreizack",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "mittelalterlich",
+            "beschreibung": "Reichweite 1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Haken-Schwert": {
+            "name": "Haken-Schwert",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 20,
+            "setting": "mittelalterlich",
+            "beschreibung": "+1 zum Entwaffnen.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Zweihandschwert": {
+            "name": "Zweihandschwert",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 50,
+            "setting": "mittelalterlich",
+            "beschreibung": "PB 2, Zweihändig.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W10",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": 2
+            }
+        },
+        "Spalthammer": {
+            "name": "Spalthammer",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 12,
+            "setting": "mittelalterlich",
+            "beschreibung": "PB 2, Zweihändig, +2 Schaden gegen Gegenstände.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W10",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": 2
+            }
+        },
+        "Stab": {
+            "name": "Stab",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 0,
+            "setting": "mittelalterlich",
+            "beschreibung": "Parade +1, Reichweite 1, Zweihändig.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Entermesser": {
+            "name": "Entermesser",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Keule, leicht": {
+            "name": "Keule, leicht",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 1,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Keule, schwer": {
+            "name": "Keule, schwer",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 2,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Menschenfänger": {
+            "name": "Menschenfänger",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 15,
+            "setting": "mittelalterlich",
+            "beschreibung": "Reichweite 2, Zweihändig, kein Bonusschaden bei einer Steigerung, aber das Opfer ist Gebunden",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "2",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Meteorhammer": {
+            "name": "Meteorhammer",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 12,
+            "setting": "mittelalterlich",
+            "beschreibung": "Reichweite 2, ignoriert Schildbonus, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "2",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Speer": {
+            "name": "Speer",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 2,
+            "setting": "mittelalterlich",
+            "beschreibung": "Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Speer, Kurz-": {
+            "name": "Speer, Kurz-",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 1,
+            "setting": "mittelalterlich",
+            "beschreibung": "Einhändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitflegel, Zweihand": {
+            "name": "Streitflegel, Zweihand",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 15,
+            "setting": "mittelalterlich",
+            "beschreibung": "Ignoriert Schildbonus, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitkolben, leicht": {
+            "name": "Streitkolben, leicht",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 5,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitkolben, schwer": {
+            "name": "Streitkolben, schwer",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 12,
+            "setting": "mittelalterlich",
+            "beschreibung": "PB 1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "-",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Handrepetierarmbrust": {
+            "name": "Handrepetierarmbrust",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 160,
+            "setting": "mittelalterlich",
+            "beschreibung": "Kartusche mit 5 Bolzen oder 1 Bolzen. Nachladen 1. Rückstoßabzug.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "5/10/20",
+                "FR": 2,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Donnerbüchse": {
+            "name": "Donnerbüchse",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 300,
+            "setting": "schwarzpulver",
+            "beschreibung": "Regeln wie Schrotflinte (SWAE S. 106). Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "1-3W6",
+                "Reichweite": "10/20/40",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Muskete": {
+            "name": "Muskete",
+            "kategorie": "Waffe",
+            "gewicht": 7.5,
+            "kosten": 300,
+            "setting": "schwarzpulver",
+            "beschreibung": "Schwere, lange Feuerwaffe. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W8",
+                "Reichweite": "10/20/40",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Blunderbuss": {
+            "name": "Blunderbuss",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 2000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Streuschuss. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Bucklergewehr": {
+            "name": "Bucklergewehr",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 750,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Muss zum Nachladen abgenommen werden. Immer Nebenhandabzug beim Schießen, Parade +1. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "2",
+                "PB": "2"
+            }
+        },
+        "Culverin": {
+            "name": "Culverin",
+            "kategorie": "Waffe",
+            "gewicht": 20,
+            "kosten": 4000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schießen ohne Unterstützung: –2. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "3W6",
+                "Reichweite": "10/20/40",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Doppelhakengewehr": {
+            "name": "Doppelhakengewehr",
+            "kategorie": "Waffe",
+            "gewicht": 9,
+            "kosten": 4000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schießen ohne Halterung: –2 und der Schütze wird zu Boden geworfen. Nachladen 3.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "3W8",
+                "Reichweite": "12/24/48",
+                "FR": "1",
+                "Schuss": "2",
+                "PB": "-"
+            }
+        },
+        "Muskete Pathfinder": {
+            "name": "Muskete",
+            "kategorie": "Waffe",
+            "gewicht": 4.5,
+            "kosten": 1500,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W10",
+                "Reichweite": "10/20/40",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "2"
+            }
+        },
+        "Muskete, Axt-/Kriegshammer-": {
+            "name": "Muskete, Axt-/Kriegshammer-",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 1600,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Als Nahkampfwaffe: entsprechende Waffenwerte. Bei Fehlfunktion: –1 auf Kämpfenproben bis zur Reparatur. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "8/16/32",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Muskete, doppelläufig": {
+            "name": "Muskete, doppelläufig",
+            "kategorie": "Waffe",
+            "gewicht": 5.5,
+            "kosten": 2500,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Doppelläufig. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W8+1",
+                "Reichweite": "10/20/40",
+                "FR": "1",
+                "Schuss": "2",
+                "PB": "2"
+            }
+        },
+        "Pfefferbüchse": {
+            "name": "Pfefferbüchse",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 3000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "6",
+                "PB": "1"
+            }
+        },
+        "Pistole": {
+            "name": "Pistole",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 1000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Pistole, Mantel-": {
+            "name": "Pistole, Mantel-",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 750,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W4+1",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Pistole, doppelläufig": {
+            "name": "Pistole, doppelläufig",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 1750,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Doppelläufig. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "2",
+                "PB": "1"
+            }
+        },
+        "Pistole, Drachen-": {
+            "name": "Pistole, Drachen-",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 1000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Streuschuss. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Stockdegenpistole": {
+            "name": "Stockdegenpistole",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 775,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Wahrnehmungsprobe erforderlich, um zu erkennen, dass es sich um mehr als einen Gehstock handelt. Nachladen 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W4+1",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Revolver": {
+            "name": "Revolver",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 4000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "6",
+                "PB": "1"
+            }
+        },
+        "Gewehr": {
+            "name": "Gewehr",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 5000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W8+1",
+                "Reichweite": "20/40/80",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Gewehr, Pfefferbüchse": {
+            "name": "Gewehr, Pfefferbüchse",
+            "kategorie": "Waffe",
+            "gewicht": 7.5,
+            "kosten": 7000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W8+1",
+                "Reichweite": "20/40/80",
+                "FR": "1",
+                "Schuss": "4",
+                "PB": "1"
+            }
+        },
+        "Schrotflinte": {
+            "name": "Schrotflinte",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 5000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Streuschuss. Nachladen 1.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "1",
+                "PB": "1"
+            }
+        },
+        "Schrotflinte, doppelläufig": {
+            "name": "Schrotflinte, doppelläufig",
+            "kategorie": "Waffe",
+            "gewicht": 7.5,
+            "kosten": 7000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Doppelläufig, Streuschuss. Nachladen 1.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "2",
+                "PB": "1"
+            }
+        },
+        "Armbrust, Leichte Repetier-": {
+            "name": "Armbrust, Leichte Repetier-",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 4,
+            "kosten": 250,
+            "setting": "mittelalterlich",
+            "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen. Verursacht einen Abzug für Rückstoß.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6",
+                "Reichweite": "10/20/40",
+                "FR": 1,
+                "Schuss": "5 (Kartusche)",
+                "PB": "2"
+            }
+        },
+        "Armbrust, Schwere Repetier-": {
+            "name": "Armbrust, Schwere Repetier-",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 6,
+            "kosten": 400,
+            "setting": "mittelalterlich",
+            "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "2W8",
+                "Reichweite": "15/30/60",
+                "FR": 1,
+                "Schuss": "5 (Kartusche)",
+                "PB": "2"
+            }
+        },
+        "Axt, Hand-": {
+            "name": "Axt, Hand-",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 1.5,
+            "kosten": 6,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Bogen, Komposit-": {
+            "name": "Bogen, Komposit-",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 1.5,
+            "kosten": 100,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "12/24/48",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Bogen, Kurz-": {
+            "name": "Bogen, Kurz-",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 1,
+            "kosten": 30,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6",
+                "Reichweite": "12/24/48",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Wurf-Chakram": {
+            "name": "Wurf-Chakram",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "4/8/16",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Dolch/Messer": {
+            "name": "Dolch/Messer",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "3/6/12",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Wurf-Dreizack": {
+            "name": "Wurf-Dreizack",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kurz-/Wurfspeer": {
+            "name": "Kurz-/Wurfspeer",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 1.5,
+            "kosten": 1,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "4/8/16",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Wurf-Speer": {
+            "name": "Wurf-Speer",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 3,
+            "kosten": 2,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Steinschlosspistole": {
+            "name": "Steinschlosspistole",
+            "kategorie": "Fernkampfwaffe",
+            "gewicht": 1.5,
+            "kosten": 150,
+            "setting": "mittelalterlich",
+            "beschreibung": "-",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W6+1",
+                "Reichweite": "5/10/20",
+                "FR": 1,
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Gegengift, Phiole": {
+            "name": "Gegengift, Phiole",
+            "kategorie": "Allgemein",
+            "gewicht": 0.25,
+            "kosten": 50,
+            "setting": "mittelalterlich",
+            "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
+            "aktiv": true
+        },
+        "Ledertunika": {
+            "name": "Ledertunika",
+            "kategorie": "Rüstung",
+            "gewicht": 5.5,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Tunika oder Wams aus Leder oder beschlagenem Leder",
+            "aktiv": true,
+            "torso": 2,
+            "arme": 2,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W6"
+        },
+        "Lederbeinlinge": {
+            "name": "Lederbeinlinge",
+            "kategorie": "Rüstung",
+            "gewicht": 4,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Beinlinge aus Leder",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 2,
+            "kopf": 0,
+            "mindeststaerke": "W6"
+        },
+        "Lederkappe": {
+            "name": "Lederkappe",
+            "kategorie": "Rüstung",
+            "gewicht": 0.5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kappe aus Leder",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 2,
+            "mindeststaerke": "W6"
+        },
+        "Kettenhemd": {
+            "name": "Kettenhemd",
+            "kategorie": "Rüstung",
+            "gewicht": 11,
+            "kosten": 100,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Hemd aus Kettenrüstung oder Schuppenrüstung",
+            "aktiv": true,
+            "torso": 3,
+            "arme": 3,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W8"
+        },
+        "Kettenbeinlinge": {
+            "name": "Kettenbeinlinge",
+            "kategorie": "Rüstung",
+            "gewicht": 2.5,
+            "kosten": 100,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Beinlinge aus Kettenrüstung",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 3,
+            "kopf": 0,
+            "mindeststaerke": "W8"
+        },
+        "Kettenhaube": {
+            "name": "Kettenhaube",
+            "kategorie": "Rüstung",
+            "gewicht": 1.5,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kettenhaube oder Helm",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 3,
+            "mindeststaerke": "W8"
+        },
+        "Plattenbrustharnisch": {
+            "name": "Plattenbrustharnisch",
+            "kategorie": "Rüstung",
+            "gewicht": 15,
+            "kosten": 500,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Brustharnisch aus Plattenrüstung",
+            "aktiv": true,
+            "torso": 4,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W10"
+        },
+        "Plattenarmschienen": {
+            "name": "Plattenarmschienen",
+            "kategorie": "Rüstung",
+            "gewicht": 5,
+            "kosten": 250,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Armschienen aus Plattenrüstung",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 4,
+            "beine": 0,
+            "kopf": 0,
+            "mindeststaerke": "W10"
+        },
+        "Plattenbeinschienen": {
+            "name": "Plattenbeinschienen",
+            "kategorie": "Rüstung",
+            "gewicht": 5,
+            "kosten": 500,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Beinschienen aus Plattenrüstung",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 4,
+            "kopf": 0,
+            "mindeststaerke": "W10"
+        },
+        "Schwerer Helm": {
+            "name": "Schwerer Helm",
+            "kategorie": "Rüstung",
+            "gewicht": 2,
+            "kosten": 250,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwerer Helm aus Metall",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 4,
+            "mindeststaerke": "W10"
+        },
+        "Schwerer Helm umschließend": {
+            "name": "Schwerer Helm umschließend",
+            "kategorie": "Rüstung",
+            "gewicht": 4,
+            "kosten": 300,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwerer umschließender Helm. –1 auf Wahrnehmungsproben, die auf Sicht basieren",
+            "aktiv": true,
+            "torso": 0,
+            "arme": 0,
+            "beine": 0,
+            "kopf": 4,
+            "mindeststaerke": "W10"
+        },
+        "Rüstungsstacheln": {
+            "name": "Rüstungsstacheln",
+            "kategorie": "Rüstungsmodifikation",
+            "gewicht": 5,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "+1 Schaden beim Zerquetschen beim Ringen",
+            "aktiv": true
+        },
+        "Panzerhandschuh beriemt": {
+            "name": "Panzerhandschuh beriemt",
+            "kategorie": "Rüstungsmodifikation",
+            "gewicht": 2.5,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "+1 auf Stärkeproben gegen Entwaffnen (Ketten und Spangen erfordern eine Aktion zum Anziehen/Ausziehen)",
+            "aktiv": true
+        },
+        "Rossharnisch Leder": {
+            "name": "Rossharnisch Leder",
+            "kategorie": "Pferderüstung",
+            "gewicht": 25,
+            "kosten": 300,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Pferderüstung aus Leder (+2 Panzerung)",
+            "aktiv": true,
+            "panzerung": 2,
+            "mindeststaerke": "W8"
+        },
+        "Rossharnisch Kette": {
+            "name": "Rossharnisch Kette",
+            "kategorie": "Pferderüstung",
+            "gewicht": 55,
+            "kosten": 500,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Pferderüstung aus Kette (+3 Panzerung)",
+            "aktiv": true,
+            "panzerung": 3,
+            "mindeststaerke": "W10"
+        },
+        "Rossharnisch Platte": {
+            "name": "Rossharnisch Platte",
+            "kategorie": "Pferderüstung",
+            "gewicht": 65,
+            "kosten": 5000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Pferderüstung aus Platte (+4 Panzerung)",
+            "aktiv": true,
+            "panzerung": 4,
+            "mindeststaerke": "W12"
+        },
+        "Leichter Schild": {
+            "name": "Leichter Schild",
+            "kategorie": "Schild",
+            "gewicht": 2,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Leichter Schild für grundlegenden Schutz",
+            "aktiv": true,
+            "parade": 1,
+            "deckung": 0,
+            "mindeststaerke": "W6"
+        },
+        "Mittelschwerer Schild": {
+            "name": "Mittelschwerer Schild",
+            "kategorie": "Schild",
+            "gewicht": 4,
+            "kosten": 9,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Mittelschwerer Schild für besseren Schutz",
+            "aktiv": true,
+            "parade": 2,
+            "deckung": -2,
+            "mindeststaerke": "W8"
+        },
+        "Schwerer Schild": {
+            "name": "Schwerer Schild",
+            "kategorie": "Schild",
+            "gewicht": 6,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwerer Schild für maximalen Schutz. –1 Bewegungsweite",
+            "aktiv": true,
+            "parade": 2,
+            "deckung": -4,
+            "mindeststaerke": "W10"
+        },
+        "Schildstacheln": {
+            "name": "Schildstacheln",
+            "kategorie": "Schildmodifikation",
+            "gewicht": 0,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "+1 Schaden bei Angriffen mit dem Schild",
+            "aktiv": true
+        },
+        "Handarmbrust": {
+            "name": "Handarmbrust",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1, eine einhändige, pistolenartige Armbrust",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hand-Repetierarmbrust": {
+            "name": "Hand-Repetierarmbrust",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 160,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "5/10/20",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Leichte Armbrust": {
+            "name": "Leichte Armbrust",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 35,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1, handgespannt",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6",
+                "Reichweite": "10/20/40",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Leichte Repetierarmbrust": {
+            "name": "Leichte Repetierarmbrust",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 250,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 1 für eine Kartusche mit 5 Bolzen oder 1 einzelnen Bolzen",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6",
+                "Reichweite": "10/20/40",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Schwere Armbrust": {
+            "name": "Schwere Armbrust",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "wird mit Winde gespannt, Nachladen 2",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W8",
+                "Reichweite": "15/30/60",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Schwere Repetierarmbrust": {
+            "name": "Schwere Repetierarmbrust",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 400,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 2 für eine Kartusche mit 5 Bolzen oder 2 einzelnen Bolzen",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "2W8",
+                "Reichweite": "15/30/60",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Handaxt": {
+            "name": "Handaxt",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 6,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Bolas": {
+            "name": "Bolas",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Bolas haben eine Härte von 8.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Blasrohr": {
+            "name": "Blasrohr",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "W4-2",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kurzbogen": {
+            "name": "Kurzbogen",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "2W6",
+                "Reichweite": "12/24/48",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Langbogen": {
+            "name": "Langbogen",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 75,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "2W6",
+                "Reichweite": "15/30/60",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Kompositbogen": {
+            "name": "Kompositbogen",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 100,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "12/24/48",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Dolch/Messer Fernkampf": {
+            "name": "Dolch/Messer",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Dreizack Fernkampf": {
+            "name": "Dreizack",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kurzspeer/Wurfspeer": {
+            "name": "Kurzspeer/Wurfspeer",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "4/8/16",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Netz (beschwert)": {
+            "name": "Netz (beschwert)",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Bei einem erfolgreichen Treffer ist das Ziel Festgehalten. Das Netz hat Härte 10.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Schleuder": {
+            "name": "Schleuder",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Athletik (Werfen)",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "4/8/16",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Shuriken": {
+            "name": "Shuriken",
+            "kategorie": "Waffe",
+            "gewicht": 0,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Speer Fernkampf": {
+            "name": "Speer",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Sternmesser Fernkampf": {
+            "name": "Sternmesser",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 28,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Handaxt Nahkampf": {
+            "name": "Handaxt",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 6,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitaxt": {
+            "name": "Streitaxt",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Zweihandaxt": {
+            "name": "Zweihandaxt",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 2, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W10",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Sense": {
+            "name": "Sense",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 18,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Sichel": {
+            "name": "Sichel",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 3,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Speer Nahkampf": {
+            "name": "Speer",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Stützen, Reichweite 1, Parade +1, wenn mit zwei Händen verwendet",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kurzer Speer": {
+            "name": "Kurzer Speer",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Einhändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Stachelkette": {
+            "name": "Stachelkette",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1, ignoriert Schildbonus, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Sternmesser Nahkampf": {
+            "name": "Sternmesser",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 28,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Parade +1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitkolben leicht": {
+            "name": "Streitkolben, leicht",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitkolben schwer": {
+            "name": "Streitkolben, schwer",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Totschläger": {
+            "name": "Totschläger",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Betäubungsschaden",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Bolzen (10)": {
+            "name": "Bolzen (10)",
+            "kategorie": "Munition",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Bolzen für alle Arten von Armbrüsten. Eine Kartusche mit fünf Bolzen, die 1 Pfund wiegt, kann für +10 GM für eine Repetierarmbrust erworben werden.",
+            "aktiv": true
+        },
+        "Pfeil Blasrohr (10)": {
+            "name": "Pfeil Blasrohr (10)",
+            "kategorie": "Munition",
+            "gewicht": 0,
+            "kosten": 0.5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Pfeile für ein Blasrohr",
+            "aktiv": true
+        },
+        "Pfeile (20)": {
+            "name": "Pfeile (20)",
+            "kategorie": "Munition",
+            "gewicht": 1.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Pfeile für alle Arten von Bögen",
+            "aktiv": true
+        },
+        "Schleudersteine (10)": {
+            "name": "Schleudersteine (10)",
+            "kategorie": "Munition",
+            "gewicht": 0.5,
+            "kosten": 0.1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Polierte Steine",
+            "aktiv": true
+        },
+        "Flugpfeile (20)": {
+            "name": "Flugpfeile (20)",
+            "kategorie": "Munition",
+            "gewicht": 1,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Erhöht die Reichweite des Bogens um 2, verringert aber einen Schadenswürfel um einen Typ.",
+            "aktiv": true
+        },
+        "Rauchpfeile (20)": {
+            "name": "Rauchpfeile (20)",
+            "kategorie": "Munition",
+            "gewicht": 1.5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kein Schaden. Platziert eine Kleine Explosionsschablone am Auftreffpunkt. Die Beleuchtung innerhalb der Schablone wird um eine Stufe verringert. Die Wolke hält zwei Runden an.",
+            "aktiv": true
+        },
+        "Kugeln, Feuerwaffe (30)": {
+            "name": "Kugeln, Feuerwaffe (30)",
+            "kategorie": "Munition",
+            "gewicht": 0.25,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Munition für Schusswaffen. Für Kugeln aus Spezialmaterialien siehe Pathfinder for Savage Worlds.",
+            "aktiv": true
+        },
+        "Kugeln, gerillt (1)": {
+            "name": "Kugeln, gerillt (1)",
+            "kategorie": "Munition",
+            "gewicht": 0,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Speziell gefertigte Kugel, auf die Gift aufgetragen werden kann. Nicht kompatibel mit alchemistischen Kartuschen.",
+            "aktiv": true
+        },
+        "Schrot (30)": {
+            "name": "Schrot (30)",
+            "kategorie": "Munition",
+            "gewicht": 0.25,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schrot für Streuschusswaffen. Kieselsteine oder anderer Schutt können stattdessen verwendet werden, verursachen aber –1 auf Schießenproben.",
+            "aktiv": true
+        },
+        "Alchemistische Kartusche, Drachenatem": {
+            "name": "Alchemistische Kartusche, Drachenatem",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 40,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nur für Streuschusswaffen. Kein Schießenwurf: Alle unter der Kleinen Kegelschablone legen eine Ausweichen-Probe ab. 2W6 nichtmagischer Feuerschaden. Kritischer Fehlschlag wenn beide Schadenswürfel eine 1 zeigen.",
+            "aktiv": true
+        },
+        "Alchemistische Kartusche, Fesselschuss": {
+            "name": "Alchemistische Kartusche, Fesselschuss",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 40,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nur für Streuschusswaffen. Verringert den Waffenschaden um einen Würfeltyp. Jede getroffene Kreatur muss eine Ausweichen-Probe ablegen oder wird Verstrickt.",
+            "aktiv": true
+        },
+        "Alchemistische Kartusche, Leuchtspur": {
+            "name": "Alchemistische Kartusche, Leuchtspur",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Verringert den Schaden um einen Würfeltyp. Eine getroffene Kreatur wird für eine Runde geblendet. Auch als Signalrakete verwendbar. Kann nur gegen einzelne Kreaturen eingesetzt werden.",
+            "aktiv": true
+        },
+        "Alchemistische Kartusche, Metall": {
+            "name": "Alchemistische Kartusche, Metall",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Macht Kugel und Schwarzpulver wasserdicht.",
+            "aktiv": true
+        },
+        "Alchemistische Kartusche, Salzschrot": {
+            "name": "Alchemistische Kartusche, Salzschrot",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.25,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kann in Streuschusswaffen geladen werden. Verursacht betäubenden Schaden.",
+            "aktiv": true
+        },
+        "Doppelarmbrust": {
+            "name": "Doppelarmbrust",
+            "kategorie": "Waffe",
+            "gewicht": 9,
+            "kosten": 300,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Nachladen 3 für beide Bolzen oder Nachladen 2 für einen. Auf –2 auf Schießen beide Bolzen gleichzeitig abfeuern (Schaden: 3W8).",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "2W8",
+                "Reichweite": "15/30/60",
+                "FR": "1",
+                "Schuss": "2",
+                "PB": "2"
+            }
+        },
+        "Pilum": {
+            "name": "Pilum",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Der Schaft bricht beim Aufprall ab. Mit einer Steigerung beim Angriff bleibt er im Schild des Ziels stecken; das Ziel verliert den Schildbonus bis der Spieß entfernt wird (1 Aktion).",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Dolch/Messer Nahkampf": {
+            "name": "Dolch/Messer",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Dreizack Nahkampf": {
+            "name": "Dreizack",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Stützen, Reichweite 1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitflegel": {
+            "name": "Streitflegel",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "ignoriert Schildbonus",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Streitflegel schwer": {
+            "name": "Streitflegel, schwer",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "ignoriert Schildbonus, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Glefe": {
+            "name": "Glefe",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Reichweite 1, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Guisarme": {
+            "name": "Guisarme",
+            "kategorie": "Waffe",
+            "gewicht": 4.5,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1, Reichweite 1, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Hellebarde": {
+            "name": "Hellebarde",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1, Stützen, Reichweite 1, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Katana": {
+            "name": "Katana",
+            "kategorie": "Waffe",
+            "gewicht": 1.5,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6+1",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kampfstab": {
+            "name": "Kampfstab",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 0,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Parade +1, Reichweite 1, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Keule leicht": {
+            "name": "Keule, leicht",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Keule schwer": {
+            "name": "Keule, schwer",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kriegshammer": {
+            "name": "Kriegshammer",
+            "kategorie": "Waffe",
+            "gewicht": 2.5,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Krummsäbel": {
+            "name": "Krummsäbel",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Krummschwert": {
+            "name": "Krummschwert",
+            "kategorie": "Waffe",
+            "gewicht": 4,
+            "kosten": 75,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Lanze": {
+            "name": "Lanze",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 2 bei Sturmangriff, Reichweite 2, nur im berittenen Kampf verwendbar",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "2",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Morgenstern": {
+            "name": "Morgenstern",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 8,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Peitsche": {
+            "name": "Peitsche",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Parade –1, Reichweite 2. Bei einer Steigerung beim Angriffswurf ist das Opfer Festgehalten anstelle von Bonusschaden.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "2",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Pike": {
+            "name": "Pike",
+            "kategorie": "Waffe",
+            "gewicht": 9,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1 wenn aufgesetzt, Stützen, Reichweite 2, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "2",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Ranseur": {
+            "name": "Ranseur",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1, Reichweite 1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Rapier": {
+            "name": "Rapier",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Parade +1",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Schlägel": {
+            "name": "Schlägel",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 2, Zweihändig, +2 Schaden zum Zerstören von Gegenständen",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W10",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Bastardschwert": {
+            "name": "Bastardschwert",
+            "kategorie": "Waffe",
+            "gewicht": 3,
+            "kosten": 35,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 1, kann zweihändig verwendet werden (für +1 Schaden)",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "1"
+            }
+        },
+        "Kurzschwert": {
+            "name": "Kurzschwert",
+            "kategorie": "Waffe",
+            "gewicht": 1,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Langschwert": {
+            "name": "Langschwert",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kampfaspergillum": {
+            "name": "Kampfaspergillum",
+            "kategorie": "Waffe",
+            "gewicht": 2,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Enthält Weihwasser. Bei jedem Treffer spritzt Weihwasser: +2 Schaden gegen Kreaturen, die von Weihwasser betroffen sind. Nach drei Angriffen leer.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Bill": {
+            "name": "Bill",
+            "kategorie": "Waffe",
+            "gewicht": 5.5,
+            "kosten": 11,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Stützen, Reichweite 1, Zweihändig, Parade +1 beim Verteidigen",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W8",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Schlagring": {
+            "name": "Schlagring",
+            "kategorie": "Waffe",
+            "gewicht": 0.5,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Träger gilt als bewaffnet; freie Wiederholung beim Verbergen",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W4",
+            "eigenschaften": {
+                "Schaden": "Stä+W4",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Glefe-Guisarme": {
+            "name": "Glefe-Guisarme",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 12,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 2, Stützen, Reichweite 1, Zweihändig",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W10",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Luzerner Hammer": {
+            "name": "Luzerner Hammer",
+            "kategorie": "Waffe",
+            "gewicht": 6,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "PB 3, Reichweite 1, Zweihändig, Parade -2",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W12",
+            "eigenschaften": {
+                "Schaden": "Stä+W12",
+                "Reichweite": "1",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "3"
+            }
+        },
+        "Menschenfänger Pathfinder": {
+            "name": "Menschenfänger",
+            "kategorie": "Waffe",
+            "gewicht": 5,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Reichweite 2, Zweihändig; kein regulärer Schaden: Bei einem Treffer kann sich das Ziel nicht vom Angreifer wegbewegen, bis es eine gegensätzliche Stärkeprobe (freie Aktion) gewinnt.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "W6",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "2",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Kanone Rundgeschoss": {
+            "name": "Kanone Rundgeschoss",
+            "kategorie": "Belagerungswaffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwere Waffe, Nachladen 8. Zwei Besatzungsmitglieder können gleichzeitig nachladen. Bei Erfolg prallt die Kugel bei geradem Würfelergebnis zu einem weiteren Opfer hinter dem ersten Ziel (innerhalb von 6\") ab.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "3W6+1",
+                "Reichweite": "50/100/200",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "4",
+                "Flächenschablone": "MFS"
+            }
+        },
+        "Balliste": {
+            "name": "Balliste",
+            "kategorie": "Belagerungswaffe",
+            "gewicht": 0,
+            "kosten": 500,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Einzelperson oder 2 Minuten für eine Mannschaft von 2.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "3W6",
+                "Reichweite": "15/30/60",
+                "FR": "Speziell",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Belagerungsturm": {
+            "name": "Belagerungsturm",
+            "kategorie": "Belagerungsgerät",
+            "gewicht": 0,
+            "kosten": 2000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Keine Fernkampfwaffe, wird zum Erklimmen von Mauern verwendet; Schützen können aus den oberen Stockwerken feuern. Bewegungsweite 1 mit 8 Personen, verdoppelt mit 16 Personen.",
+            "aktiv": true
+        },
+        "Trebuchet": {
+            "name": "Trebuchet",
+            "kategorie": "Belagerungswaffe",
+            "gewicht": 0,
+            "kosten": 1000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "3W8",
+                "Reichweite": "30/60/120",
+                "FR": "Speziell",
+                "Schuss": "-",
+                "PB": "4",
+                "Flächenschablone": "MFS"
+            }
+        },
+        "Katapult": {
+            "name": "Katapult",
+            "kategorie": "Belagerungswaffe",
+            "gewicht": 0,
+            "kosten": 800,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Schwere Waffe, Nachladezeit ist 5 Minuten für eine Mannschaft von 4.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "3W6",
+                "Reichweite": "24/48/96",
+                "FR": "Speziell",
+                "Schuss": "-",
+                "PB": "4",
+                "Flächenschablone": "MFS"
+            }
+        },
+        "Rammbock": {
+            "name": "Rammbock",
+            "kategorie": "Belagerungsgerät",
+            "gewicht": 1000,
+            "kosten": 1000,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Keine Fernkampfwaffe, wird zum Zertrümmern von Objekten verwendet. Mindestens 2 Personen nötig, bis zu 8 können helfen.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "3W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Alchemistenfeuer": {
+            "name": "Alchemistenfeuer",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Eine klebrige, brennbare Flüssigkeit, die beim Aufschlag in Brand gerät. Schwere Waffe. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn sie nicht in Wasser untergetaucht werden. Ziel könnte in Brand geraten.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Donnerstein": {
+            "name": "Donnerstein",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 30,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Ein verzauberter Felsen, der mit einem ohrenbetäubenden Knall explodiert. Alle in der Schablone müssen eine Konstitutionsprobe schaffen, um nicht Angeschlagen und für eine Stunde taub zu sein.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "MFS"
+            }
+        },
+        "Ewige Fackel": {
+            "name": "Ewige Fackel",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 110,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Eine 'Fackel', die dauerhaft mit Licht verzaubert ist. Verbrennt nicht und gibt keine Hitze ab.",
+            "aktiv": true
+        },
+        "Gegengift Phiole": {
+            "name": "Gegengift, Phiole",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.25,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Gewährt für eine Stunde einen Bonus von +4 zum Widerstand gegen Gifte.",
+            "aktiv": true
+        },
+        "Rauchstab": {
+            "name": "Rauchstab",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.05,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Ein alchemistisch behandelter Stock, der dichten Rauch (Dunkle Beleuchtung) in einer Mittleren Flächenschablone erzeugt. Er hält 1 Minute lang an und löst sich in starkem Wind innerhalb einer Runde auf.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "MFS"
+            }
+        },
+        "Säureflasche": {
+            "name": "Säureflasche",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Wird wie eine Granate geworfen. Charaktere innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges, wenn die Säure nicht abgewaschen wird.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Sonnenzepter": {
+            "name": "Sonnenzepter",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 2,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Ein Eisenstab mit Goldspitzen, der für sechs Stunden in einem Radius von 9 m normales Licht erzeugt. Es erhöht die Beleuchtungsstufe darüber hinaus für weitere 9\" um eine Stufe. Es gibt keine Hitze ab und zählt als Sonnenlicht.",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "1W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Verstrickungsbeutel": {
+            "name": "Verstrickungsbeutel",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 4,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Ein Opfer mit Größe 3 oder weniger, das von diesem kleinen Beutel klebrigen Materials getroffen wird, ist für fünf Runden Abgelenkt und muss eine Athletikprobe schaffen, um nicht auch am Boden festzukleben (Festgehalten).",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "1/2/4",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Heiliges Wasser": {
+            "name": "Heiliges Wasser",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Heiliges Wasser kann in einer Flasche geworfen oder auf eine angrenzende Kreatur gespritzt werden. Untote und bestimmte böse Kreaturen innerhalb der Schablone erleiden 2W4 Schaden sowie 2W4–2 Schaden zu Beginn ihres nächsten Zuges.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Zündholz": {
+            "name": "Zündholz",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.05,
+            "kosten": 1,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Ein dünnes Stäbchen, das eine Flamme erzeugt, wenn es hart gegen eine Oberfläche geschlagen wird. Dies ermöglicht es, Fackeln und andere brennbare Substanzen in einer Aktion zu entzünden.",
+            "aktiv": true
+        },
+        "Alchemistenfreundlichkeit": {
+            "name": "Alchemistenfreundlichkeit",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kristallines Pulver ähnlich wie Salz, beliebt bei jungen Adligen. Mit Wasser gemischt ergibt es ein sprudelndes Getränk, das die Auswirkungen eines Katers innerhalb von 10 Minuten beseitigt.",
+            "aktiv": true
+        },
+        "Laugenkolben": {
+            "name": "Laugenkolben",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 15,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kolben mit kaustischer Flüssigkeit. Wirkt wie Säure gegen Schleime und säurebasierte Kreaturen (2W4 Schaden in der Kleinen Flächenschablone), ist für alle anderen harmlos.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Blutblock": {
+            "name": "Blutblock",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Klebrige, rosa Substanz zur Wundbehandlung. Eine Dosis beendet die Auswirkungen eines Reißenden Angriffs und Ausblutens. Herstellungsmodifikator: –2.",
+            "aktiv": true
+        },
+        "Blitzpulver": {
+            "name": "Blitzpulver",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 50,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Grobes graues Pulver, das bei Flamme, starker Reibung oder Aufprall fast sofort entzündet. Alle Kreaturen in der Kleinen Flächenschablone werden bis zum Ende ihres nächsten Zuges geblendet (wie der Blind-Zauber).",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Flüssiges Eis": {
+            "name": "Flüssiges Eis",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 1,
+            "kosten": 40,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Versiegeltes Glas mit blauer kristalliner Flüssigkeit (auch 'Alchemisteneis'). Nach dem Öffnen kann es 1W6 Runden lang genutzt werden, um Flüssigkeiten einzufrieren oder Objekte mit Eis zu überziehen. Kann auch als Wurfwaffe eingesetzt werden.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "2W4",
+                "Reichweite": "3/6/12",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Nushadir": {
+            "name": "Nushadir",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 10,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kleine salzige Körner in einem trockenen Behälter. Neutralisiert Säure: eine Phiole Körner oder ein Kolben Nushadirwasser macht einen Kubikfuß Säure innerhalb einer Minute berührungssicher (zu langsam, um geworfene Säure zu neutralisieren).",
+            "aktiv": true
+        },
+        "Riechsalze": {
+            "name": "Riechsalze",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.5,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Scharf duftende graue Kristalle. Ermöglichen einer schlafenden Person (magisch oder normal) eine Geistprobe zum Aufwachen. Ein Behälter hat 12 Anwendungen (nach jeder Benutzung gestöpselt), leert sich in wenigen Stunden, wenn offen gelassen. Herstellungsmodifikator: –2.",
+            "aktiv": true
+        },
+        "Rauchkügelchen": {
+            "name": "Rauchkügelchen",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0,
+            "kosten": 25,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Kleine Tonkugel mit zwei getrennten Substanzen. Beim Zerbrechen mischen sie sich und füllen eine Kleine Flächenschablone mit gelbem, harmlosem Rauch für eine Runde.",
+            "aktiv": true,
+            "typ": "Fernkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "-",
+                "Reichweite": "3/6/9",
+                "FR": "1",
+                "Schuss": "-",
+                "PB": "-",
+                "Flächenschablone": "KFS"
+            }
+        },
+        "Waffenblanchierer, Adamantit": {
+            "name": "Waffenblanchierer, Adamantit",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.25,
+            "kosten": 100,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Pulver, das auf einer heißen Waffe aufgeschmolzen eine temporäre Beschichtung bildet. Beim nächsten erfolgreichen Treffer löst es Umgebungsschwächen (Adamantit) aus. Eine Dosis beschichtet eine Waffe oder bis zu 10 Munitionseinheiten. Nur ein Blanchierertyp gleichzeitig auf einer Waffe. Herstellungsmodifikator: –2.",
+            "aktiv": true
+        },
+        "Waffenblanchierer, Kalteisen": {
+            "name": "Waffenblanchierer, Kalteisen",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.25,
+            "kosten": 20,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Wie Waffenblanchierer (Adamantit). Beim nächsten erfolgreichen Treffer löst es Umgebungsschwächen (Kalteisen) aus.",
+            "aktiv": true
+        },
+        "Waffenblanchierer, Silber": {
+            "name": "Waffenblanchierer, Silber",
+            "kategorie": "Alchemistischer Gegenstand",
+            "gewicht": 0.25,
+            "kosten": 5,
+            "setting": "savage_pathfinder",
+            "beschreibung": "Wie Waffenblanchierer (Adamantit). Beim nächsten erfolgreichen Treffer löst es Umgebungsschwächen (Silber) aus.",
+            "aktiv": true
+        }
+    },
+    "settingregeln": {
+        "strahlschablone": false,
+        "große_hoehen": false,
+        "verrat": false,
+        "schwierige_heilung": false,
+        "freizeit": false,
+        "riesige_feinde": false,
+        "schurkische_entschlossenheit": false,
+        "dynamischer_rueckschlag": false,
+        "entschlossenheit": false,
+        "fanatiker": false,
+        "fertigkeitsspezialisierungen": false,
+        "fieser_schaden": false,
+        "geborener_held": false,
+        "grosse_abenteuer": false,
+        "helden_sterben_nie": false,
+        "keine_machtpunkte": false,
+        "kreativer_kampf": false,
+        "mehr_fertigkeitspunkte": false,
+        "mehr_sprachen": false,
+        "narrenglueck": false,
+        "schnelle_genesung": false,
+        "schwere_entscheidungen": false,
+        "ungepanzerter_held": false,
+        "wundobergrenze": false
+    },
+    "startgeld": 300,
+    "waehrung": "GM"
 }

--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -58,7 +58,7 @@
             "custom": false,
             "effects": {
                 "attribute_bonuses": {},
-                "robustheit_bonus": 2,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 2,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -70,7 +70,8 @@
                     "wuchtig": true,
                     "offensichtlich": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 2
             }
         },
         "Draken": {
@@ -132,7 +133,7 @@
                 "attribute_bonuses": {
                     "Stärke": 4
                 },
-                "robustheit_bonus": 3,
+                "robustheit_bonus": 2,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -144,7 +145,8 @@
                     "dumm": true,
                     "wuchtig": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 1
             }
         },
         "Floraner": {
@@ -424,7 +426,7 @@
                 "attribute_bonuses": {
                     "Willenskraft": 2
                 },
-                "robustheit_bonus": -3,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -436,7 +438,8 @@
                     "winzling_sehr_klein": true,
                     "max_staerke_w6": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -3
             }
         },
         "Roboter": {
@@ -599,7 +602,7 @@
                 "attribute_bonuses": {
                     "Stärke": 2
                 },
-                "robustheit_bonus": 2,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": 0,
                 "fertigkeits_startboni": {},
                 "auto_talente": [],
@@ -607,7 +610,8 @@
                     "wuchtig": true,
                     "anfaellig_hitze": true
                 },
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": 2
             }
         }
     },

--- a/settings/Superkräfte Kompendium.json
+++ b/settings/Superkräfte Kompendium.json
@@ -286,14 +286,15 @@
                 "attribute_bonuses": {
                     "Willenskraft": 2
                 },
-                "robustheit_bonus": -1,
+                "robustheit_bonus": 0,
                 "bewegungsweite_bonus": -1,
                 "fertigkeits_startboni": {},
                 "auto_talente": [
                     "Glück"
                 ],
                 "spezielle_effekte": {},
-                "wahlmoeglichkeiten": {}
+                "wahlmoeglichkeiten": {},
+                "groesse_modifikator": -1
             }
         },
         "Mensch": {
@@ -3085,8 +3086,7 @@
             "name": "Profi",
             "kategorie": "Legendär",
             "rang": "L",
-            "voraussetzungen": [
-            ],
+            "voraussetzungen": [],
             "beschreibung": "Die Eigenschaft des Charakters und die Obergrenze erhöhen sich um einen Schritt.",
             "neue_maechte": 0,
             "machtpunkte": 0,

--- a/test units/test_groesse.py
+++ b/test units/test_groesse.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Test-Unit für die neue abgeleitete Größe und ihre Auswirkung auf Robustheit.
+
+Prüft:
+  - groesse-Property existiert und Default 0
+  - Volk-Größe wird korrekt aus effects.groesse_modifikator gelesen
+  - Talent "Kräftig" → Größe +1 (statt direktem Robustheit-Bonus)
+  - Handicap "Klein" leicht → Größe -1 (statt direktem Robustheit-Bonus)
+  - Robustheit summiert Größe + sonstige Robustheit-Boni
+  - Migrierte Setting-Daten (Halbling, Halbriese, Goblin, Flickenmonster) korrekt
+"""
+
+import unittest
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+class MockWuerfel:
+    def __init__(self, value=4, modifier=0):
+        self.value = value
+        self.modifier = modifier
+
+
+class MockAttribut:
+    def __init__(self, name, wert=4, modifier=0):
+        self.name = name
+        self.wert = wert
+        self.modifier = modifier
+        self.wuerfel = MockWuerfel(value=wert, modifier=modifier)
+
+
+class MockFertigkeit:
+    def __init__(self, wert=4):
+        self.wert = wert
+
+
+class MockHandicap:
+    def __init__(self, name, stufe="leicht"):
+        self.name = name
+        self.stufe = stufe
+        self.ausgewaehlt = True
+
+
+class MockVolk:
+    def __init__(self, name, groesse_mod=0, robustheit_bonus=0, bewegung_bonus=0):
+        self.name = name
+        self.effects = {
+            'groesse_modifikator': groesse_mod,
+            'robustheit_bonus': robustheit_bonus,
+            'bewegungsweite_bonus': bewegung_bonus,
+            'spezielle_effekte': {},
+            'auto_talente': [],
+        }
+
+    def get_groesse_modifikator(self):
+        return self.effects.get('groesse_modifikator', 0)
+
+    def get_robustheit_bonus(self):
+        return self.effects.get('robustheit_bonus', 0)
+
+    def get_bewegungsweite_bonus(self):
+        return self.effects.get('bewegungsweite_bonus', 0)
+
+
+class MockCharakter:
+    """Minimaler Mock, der die Felder bereitstellt, die berechne_abgeleitete_werte braucht."""
+
+    def __init__(self, konstitution=4):
+        self.attribute = {'Konstitution': MockAttribut('Konstitution', konstitution)}
+        self.fertigkeiten = {}
+        self.handicaps = {}
+        self.talente = {}
+        self.voelker = {}
+        self.voelker_selected = {}
+        self.selected_handicaps = []
+        self.selected_talente = []
+        self.selected_waffen = []
+        self.selected_ruestungen = []
+        self.selected_schilde = []
+        self.selected_allgemeine_ausruestung = []
+        self.cyberware_installationen = {}
+        self.ausruestung = {}
+        self.active_setting_name = "SWAE"
+        self.machtpunkte = 0
+        self.erschoepfung = 0
+        self.wunden = 0
+        self.bennys = 3
+        self.entschlossenheit = 0
+        self.vermoegen = 500
+        self.waehrungseinheit = "Gold"
+        self.gesamtgewicht = 0
+        self.maximale_traglast = 40
+        # Abgeleitete Werte (werden vom Test geschrieben)
+        self.bewegungsweite = 6
+        self.parade = 2
+        self.robustheit = 0
+        self.robustheit_basis = 0
+        self.robustheit_mit_ruestung = ""
+        self.groesse = 0
+
+
+class TestGroesseBerechnung(unittest.TestCase):
+    """Direkter Test der Größe-Berechnung in berechne_abgeleitete_werte."""
+
+    def setUp(self):
+        from functions.abgeleitete_werte import berechne_abgeleitete_werte
+        self.berechne = berechne_abgeleitete_werte
+
+    def test_mensch_default_groesse_0(self):
+        """Mensch ohne Volk: Größe = 0, Robustheit = (KON//2) + 2."""
+        char = MockCharakter(konstitution=6)
+        self.berechne(char)
+        self.assertEqual(char.groesse, 0)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2)  # = 5
+
+    def test_halbling_groesse_minus_1(self):
+        """Volk mit groesse_modifikator=-1: Größe = -1, Robustheit -1."""
+        char = MockCharakter(konstitution=6)
+        char.voelker = {'Halbling': MockVolk('Halbling', groesse_mod=-1)}
+        char.voelker_selected = {'Halbling': True}
+        self.berechne(char)
+        self.assertEqual(char.groesse, -1)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2 - 1)  # = 4
+
+    def test_halbriese_groesse_plus_3(self):
+        """Volk mit groesse_modifikator=+3: Größe = +3, Robustheit +3."""
+        char = MockCharakter(konstitution=8)
+        char.voelker = {'Halbriese': MockVolk('Halbriese', groesse_mod=3)}
+        char.voelker_selected = {'Halbriese': True}
+        self.berechne(char)
+        self.assertEqual(char.groesse, 3)
+        self.assertEqual(char.robustheit_basis, (8 // 2) + 2 + 3)  # = 9
+
+    def test_kraeftig_talent_erhoeht_groesse(self):
+        """Talent 'Kräftig' erhöht Größe um 1 (nicht mehr direkt robustheit)."""
+        char = MockCharakter(konstitution=6)
+        char.selected_talente = ['Kräftig']
+        self.berechne(char)
+        self.assertEqual(char.groesse, 1)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2 + 1)  # = 6
+
+    def test_klein_handicap_verringert_groesse(self):
+        """Handicap 'Klein' leicht: Größe -1 (nicht mehr direkt robustheit)."""
+        char = MockCharakter(konstitution=6)
+        char.handicaps = {'Klein': MockHandicap('Klein', 'leicht')}
+        char.selected_handicaps = ['Klein']
+        self.berechne(char)
+        self.assertEqual(char.groesse, -1)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2 - 1)  # = 4
+
+    def test_fettleibig_handicap_robustheit_kein_groesse(self):
+        """Handicap 'Fettleibig' leicht: Robustheit +1, aber Größe = 0 (Körperfett)."""
+        char = MockCharakter(konstitution=6)
+        char.handicaps = {'Fettleibig': MockHandicap('Fettleibig', 'leicht')}
+        char.selected_handicaps = ['Fettleibig']
+        self.berechne(char)
+        self.assertEqual(char.groesse, 0)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2 + 1)  # = 6
+
+    def test_raufbold_talent_robustheit_kein_groesse(self):
+        """Talent 'Raufbold': Robustheit +1, aber Größe = 0."""
+        char = MockCharakter(konstitution=6)
+        char.selected_talente = ['Raufbold']
+        self.berechne(char)
+        self.assertEqual(char.groesse, 0)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2 + 1)  # = 6
+
+    def test_halbling_mit_kraeftig_neutralisiert(self):
+        """Halbling (-1 Größe) + Kräftig (+1 Größe) = 0; Robustheit unverändert."""
+        char = MockCharakter(konstitution=6)
+        char.voelker = {'Halbling': MockVolk('Halbling', groesse_mod=-1)}
+        char.voelker_selected = {'Halbling': True}
+        char.selected_talente = ['Kräftig']
+        self.berechne(char)
+        self.assertEqual(char.groesse, 0)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2)  # = 5
+
+    def test_split_volk_groesse_und_robustheit(self):
+        """Volk mit groesse=+1 UND robustheit_bonus=+1 (z.B. Flickenmonster):
+        Größe und Rest-Robustheit werden separat addiert (insgesamt +2 auf Robustheit)."""
+        char = MockCharakter(konstitution=6)
+        char.voelker = {'Flickenmonster': MockVolk('Flickenmonster',
+                                                    groesse_mod=1,
+                                                    robustheit_bonus=1)}
+        char.voelker_selected = {'Flickenmonster': True}
+        self.berechne(char)
+        self.assertEqual(char.groesse, 1)
+        self.assertEqual(char.robustheit_basis, (6 // 2) + 2 + 1 + 1)  # = 7
+
+
+class TestSettingsMigration(unittest.TestCase):
+    """Verifiziert, dass die Settings-JSONs nach Migration konsistent sind."""
+
+    def _load_volk(self, setting_datei, volk_name):
+        import json
+        pfad = project_root / 'settings' / setting_datei
+        with pfad.open('r', encoding='utf-8') as f:
+            daten = json.load(f)
+        return daten['voelker'].get(volk_name)
+
+    def test_swae_halbling(self):
+        volk = self._load_volk('SWAE.json', 'Halbling')
+        self.assertEqual(volk['effects']['groesse_modifikator'], -1)
+        self.assertEqual(volk['effects']['robustheit_bonus'], 0)
+
+    def test_fk_halbriese(self):
+        volk = self._load_volk('Fantasy Kompendium.json', 'Halbriese')
+        self.assertEqual(volk['effects']['groesse_modifikator'], 3)
+        self.assertEqual(volk['effects']['robustheit_bonus'], 0)
+
+    def test_fk_goblin(self):
+        volk = self._load_volk('Fantasy Kompendium.json', 'Goblin')
+        self.assertEqual(volk['effects']['groesse_modifikator'], -1)
+        self.assertEqual(volk['effects']['robustheit_bonus'], 0)
+
+    def test_horror_flickenmonster_split(self):
+        """Flickenmonster: Größe +1 (aus Text) plus Untoten-Robustheit +1."""
+        volk = self._load_volk('Horror Kompendium.json', 'Flickenmonster')
+        self.assertEqual(volk['effects']['groesse_modifikator'], 1)
+        self.assertEqual(volk['effects']['robustheit_bonus'], 1)
+
+
+class TestVolkParser(unittest.TestCase):
+    """Prüft, dass _parse_einzeleffekt 'Größe ±X' nach groesse_modifikator routet."""
+
+    def test_groesse_minus_1_in_handicap_text(self):
+        from models.volk import Volk
+        volk = Volk(name="TestVolk", handicaps=["Größe -1 (Reduzierte Robustheit um 1)"])
+        volk._parse_effects_from_text()
+        self.assertEqual(volk.effects.get('groesse_modifikator', 0), -1)
+        self.assertEqual(volk.effects.get('robustheit_bonus', 0), 0,
+                         "robustheit_bonus darf NICHT mehr gesetzt werden, wenn Größe schon erkannt wurde")
+
+    def test_groesse_plus_3_in_besonderheiten(self):
+        from models.volk import Volk
+        volk = Volk(name="TestVolk", besonderheiten=["Größe +3 (+3 Robustheit durch überragende Größe)"])
+        volk._parse_effects_from_text()
+        self.assertEqual(volk.effects.get('groesse_modifikator', 0), 3)
+        self.assertEqual(volk.effects.get('robustheit_bonus', 0), 0)
+
+    def test_orkische_wildheit_bleibt_robustheit(self):
+        from models.volk import Volk
+        volk = Volk(name="TestVolk", besonderheiten=["Orkische Wildheit (+1 Robustheit)"])
+        volk._parse_effects_from_text()
+        self.assertEqual(volk.effects.get('groesse_modifikator', 0), 0)
+        self.assertEqual(volk.effects.get('robustheit_bonus', 0), 1,
+                         "Robustheit-Boni ohne 'Größe'-Wort bleiben in robustheit_bonus")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/utils/html_utils.py
+++ b/utils/html_utils.py
@@ -294,9 +294,11 @@ def _erzeuge_volk_sektion(charakter):
 
 def _erzeuge_abgeleitete_werte_sektion(charakter):
     """Erzeugt die abgeleiteten Werte Sektion"""
+    groesse_anzeige = f"{charakter.groesse:+d}" if charakter.groesse != 0 else "0"
     abgeleitete_werte = {
         'Bewegungsweite': charakter.bewegungsweite,
         'Parade': charakter.parade,
+        'Größe': groesse_anzeige,
         'Robustheit': charakter.robustheit_mit_ruestung,
         'Machtpunkte': charakter.machtpunkte,
         'Wunden': charakter.wunden,

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -274,9 +274,11 @@ def generiere_pdf(charakter, output_pdf, printer_friendly=False, show_steigerung
 
     abgeleitete_header = Paragraph("Abgeleitete Werte", style_heading)
     abgeleitete_data = [["Beschreibung", "Wert"]]
+    groesse_anzeige = f"{charakter.groesse:+d}" if charakter.groesse != 0 else "0"
     abgeleitete_werte = {
         'Bewegungsweite': charakter.bewegungsweite,
         'Parade': charakter.parade,
+        'Größe': groesse_anzeige,
         'Robustheit': charakter.robustheit_mit_ruestung,
         'Machtpunkte': charakter.machtpunkte,
         'Wunden': charakter.wunden,

--- a/views/charakterbogen_view.py
+++ b/views/charakterbogen_view.py
@@ -785,9 +785,11 @@ class CharakterbogenWidget(MDBoxLayout):
         abgeleitete_werte_grid.clear_widgets()
         
         # Liste der anzuzeigenden abgeleiteten Werte
+        groesse_anzeige = f"{self.charakter.groesse:+d}" if self.charakter.groesse != 0 else "0"
         werte = [
             ("Bewegungsweite", str(self.charakter.bewegungsweite)),
             ("Parade", str(self.charakter.parade)),
+            ("Größe", groesse_anzeige),
             ("Robustheit", self.charakter.robustheit_mit_ruestung),
             ("Machtpunkte", str(self.charakter.machtpunkte)),
             ("Wunden", str(self.charakter.wunden)),


### PR DESCRIPTION
Größe (Mensch=0) ist jetzt eine eigene Property neben Robustheit und wird
im Charakterbogen, PDF, HTML und Statblock angezeigt. Sie wird 1:1 auf
Robustheit addiert, ist aber datenmäßig getrennt vom robustheit_bonus.

- models/charakter_properties.py: groesse NumericProperty
- models/volk.py: effects.groesse_modifikator + Getter; _parse_einzeleffekt
  routet "Größe ±N" jetzt nach groesse_modifikator
- functions/abgeleitete_werte.py: Größe getrennt berechnen, Talent "Kräftig"
  und Handicap "Klein leicht" sind jetzt Größe-Effekte (statt Robustheit);
  Doppelung zwischen Volk-Größe und Robustheit-Bonus wird per Logger.warning
  signalisiert
- config/volkseigenarten_config.json + functions/volkseigenarten_funktionen.py:
  groesse_punkt aggregiert in groesse_modifikator (kein doppelter
  robustheit_bonus mehr)
- scripts/migrate_groesse_modifikator.py: einmaliges Migrationsskript für
  alle settings/*.json (25 Volk-Einträge migriert), zusätzlich Bereinigung
  redundanter auto_handicaps "Klein" bei 5 bereits klein-codierten Völkern
- test units/test_groesse.py: 16 neue Tests (Berechnung, Setting-Daten, Parser)

Anzeige in:
- views/charakterbogen_view.py
- utils/pdf_utils.py
- utils/html_utils.py
- functions/statblock_generator.py

https://claude.ai/code/session_01T7cSCJfbkZEQ2rkp6QVXgw