### PR TITLE
Add archetype synchronization with Mojibake repair for Android

### DIFF
--- a/docs/ANDROID_WORKAROUNDS.md
+++ b/docs/ANDROID_WORKAROUNDS.md
@@ -297,3 +297,14 @@ main_layout = MDBoxLayout(orientation="vertical", size_hint_y=None, height=main_
 - Slide-up/down animation
 - Integrated search field with filtered list
 - Used for race/species selection and other searchable lists
+
+## Archetypen-Synchronisation & jtar-Mojibake (`utils/archetypen_sync.py`)
+**Problem 1:** Die mitgelieferten Archetypen (`chars/Archetypen/`) liegen nach der APK-Installation im App-Verzeichnis (`files/app/`), das bei jedem Update gelöscht und neu entpackt wird. Sie müssen ins persistente Verzeichnis (`files/chars/Archetypen/`) kopiert werden. Wählt man dabei den **ersten existierenden** Quellpfad, kann ein veraltetes oder falsches Verzeichnis das echte Bundle verdecken — die Kopie läuft dann scheinbar erfolgreich, aber ohne neue Dateien.
+
+**Problem 2:** Der Java-Tar-Extractor von python-for-android (jtar) parst Header-Namen, indem er **signierte Bytes direkt zu chars castet**. UTF-8-Bytes ≥ 0x80 werden sign-extended (0xC3 → U+FFC3). Dateinamen mit Umlauten landen dadurch als Mojibake auf dem Gerät: `Kopfgeldjäger` → `Kopfgeldjￃﾤger` (verifiziert mit jtar 2.3 + OpenJDK).
+
+**Solution:** `utils/archetypen_sync.py` (aufgerufen aus `main.py` in `on_start`):
+- `finde_beste_quelle()` wählt unter allen Kandidaten-Pfaden (inkl. `ANDROID_ARGUMENT`-Umgebungsvariable, dem kanonischen p4a-App-Pfad) das Verzeichnis mit den **meisten** Archetypen-JSONs und überspringt das Zielverzeichnis selbst.
+- `sync_archetypen()` kopiert fehlende/geänderte Dateien (Größenvergleich statt mtime, da die APK-Extraktion keine brauchbaren Timestamps setzt) und repariert dabei Mojibake-Namen (`repariere_mojibake_name()`); alte Mojibake-Varianten im Ziel werden entfernt.
+- Das Ergebnis wird per Snackbar gemeldet (`X neue Archetypen installiert`), ein Fehlschlag (kein Bundle gefunden) als Warnung — so ist der Zustand auf dem Gerät ohne Logzugriff diagnostizierbar.
+- Der FileManager bietet auf Android Schnellzugriffe „Meine Charaktere" und „Archetypen" direkt auf das persistente Verzeichnis.

--- a/main.py
+++ b/main.py
@@ -398,16 +398,21 @@ class SW_Charakter_GeneratorApp(MDApp):
             # Neues Verzeichnis erstellen falls nötig
             new_chars_dir.mkdir(parents=True, exist_ok=True)
 
-            # Alte Charaktere migrieren (nur wenn alte Dateien existieren)
-            if old_chars_dir.exists() and old_chars_dir != new_chars_dir:
-                migrated = 0
-                for json_file in old_chars_dir.glob('*.json'):
-                    target = new_chars_dir / json_file.name
-                    if not target.exists():
-                        shutil.copy2(str(json_file), str(target))
-                        migrated += 1
-                if migrated > 0:
-                    Logger.info(f"Migration: {migrated} Charakter(e) ins persistente Verzeichnis kopiert")
+            # Alte Charaktere migrieren (nur wenn alte Dateien existieren).
+            # Eigener try-Block, damit ein Fehler hier die Archetypen-Kopie
+            # nicht verhindert.
+            try:
+                if old_chars_dir.exists() and old_chars_dir != new_chars_dir:
+                    migrated = 0
+                    for json_file in old_chars_dir.glob('*.json'):
+                        target = new_chars_dir / json_file.name
+                        if not target.exists():
+                            shutil.copy2(str(json_file), str(target))
+                            migrated += 1
+                    if migrated > 0:
+                        Logger.info(f"Migration: {migrated} Charakter(e) ins persistente Verzeichnis kopiert")
+            except Exception as e:
+                Logger.warning(f"Charakter-Migration fehlgeschlagen: {e}")
 
             # Archetypen aus gebündeltem App-Verzeichnis ins persistente Verzeichnis kopieren
             self._copy_archetypen_on_android(old_chars_dir, new_chars_dir)
@@ -418,17 +423,28 @@ class SW_Charakter_GeneratorApp(MDApp):
     def _copy_archetypen_on_android(self, bundled_chars_dir: Path, user_chars_dir: Path):
         """Kopiert mitgelieferte Archetypen ins persistente Benutzer-Verzeichnis auf Android.
 
-        Vergleicht Dateigröße statt mtime, da APK-Extraktion oft ältere Timestamps
-        setzt als bereits vorhandene User-Dateien.
+        Als Quelle wird unter allen Kandidaten das Verzeichnis mit den
+        meisten Archetypen-JSONs gewählt — nicht das erste existierende.
+        Das verhindert, dass ein veraltetes oder leeres Verzeichnis das
+        echte Bundle verdeckt. Der kanonische p4a-App-Pfad kommt zusätzlich
+        aus der Umgebungsvariable ANDROID_ARGUMENT (von p4a/start.c gesetzt).
         """
         try:
-            import shutil
+            from utils.archetypen_sync import (
+                finde_beste_quelle, sync_archetypen, zaehle_archetypen,
+            )
 
             # Hol den Root der App (wo die Ressourcen entpackt werden)
             app_root = get_application_root()
-            
-            # Prüfe mehrere mögliche Quellpfade für Archetypen
-            possible_sources = [
+
+            # Mögliche Quellpfade für Archetypen sammeln
+            kandidaten = []
+            for env_var in ('ANDROID_ARGUMENT', 'ANDROID_APP_PATH'):
+                env_dir = os.environ.get(env_var)
+                if env_dir:
+                    kandidaten.append(Path(env_dir) / 'chars' / 'Archetypen')
+                    kandidaten.append(Path(env_dir) / 'Archetypen')
+            kandidaten += [
                 bundled_chars_dir / 'Archetypen',  # chars/Archetypen (normal)
                 bundled_chars_dir.parent / 'Archetypen',  # /Archetypen (neben chars)
                 app_root / 'Archetypen',  # Direkt im App-Root (buildozer)
@@ -436,49 +452,65 @@ class SW_Charakter_GeneratorApp(MDApp):
                 Path(get_resource_path('chars/Archetypen')),  # via get_resource_path
                 Path(get_resource_path('Archetypen')),  # direkt im resources
             ]
+            # Duplikate entfernen, Reihenfolge erhalten
+            kandidaten = list(dict.fromkeys(kandidaten))
 
-            bundled_archetypen = None
-            for src in possible_sources:
-                Logger.debug(f"Archetypen: Prüfe {src}")
-                if src.exists():
-                    bundled_archetypen = src
-                    Logger.info(f"Archetypen: Gefunden in {src}")
-                    break
+            user_archetypen = Path(user_chars_dir) / 'Archetypen'
 
-            if not bundled_archetypen:
-                Logger.warning(f"Archetypen: Kein gebündeltes Verzeichnis gefunden in {len(possible_sources)} möglichen Pfaden:")
-                for src in possible_sources:
-                    Logger.warning(f"Archetypen:   - {src}: {src.exists()}")
+            for kandidat in kandidaten:
+                Logger.info(f"Archetypen: Kandidat {kandidat}: {zaehle_archetypen(kandidat)} JSON(s)")
+
+            quelle, quell_anzahl = finde_beste_quelle(kandidaten, user_archetypen)
+
+            if not quelle:
+                vorhanden = zaehle_archetypen(user_archetypen)
+                Logger.warning(
+                    f"Archetypen: Kein gebündeltes Verzeichnis mit Archetypen gefunden "
+                    f"({len(kandidaten)} Kandidaten geprüft, {vorhanden} bereits im Ziel)"
+                )
+                # Nutzer sichtbar warnen, wenn offensichtlich Archetypen fehlen
+                if vorhanden < 50:
+                    self._zeige_archetypen_feedback(
+                        f"Gebündelte Archetypen nicht gefunden — nur {vorhanden} verfügbar. "
+                        f"Bitte als Fehler melden.",
+                        erfolg=False,
+                    )
                 return
 
-            user_archetypen = user_chars_dir / 'Archetypen'
-            user_archetypen.mkdir(parents=True, exist_ok=True)
+            statistik = sync_archetypen(quelle, user_archetypen)
+            gesamt = zaehle_archetypen(user_archetypen)
+            Logger.info(
+                f"Archetypen: Quelle {quelle} ({quell_anzahl} JSONs) → "
+                f"{statistik['kopiert']} kopiert, {statistik['repariert']} Namen repariert, "
+                f"{statistik['vorhanden']} unverändert, {statistik['fehler']} Fehler, "
+                f"{gesamt} insgesamt im Ziel"
+            )
 
-            # Zähle Quelldateien
-            source_files = list(bundled_archetypen.rglob('*'))
-            source_count = sum(1 for f in source_files if f.is_file())
-            Logger.info(f"Archetypen: Quelle hat {source_count} Datei(en)")
-
-            copied = 0
-            for item in bundled_archetypen.rglob('*'):
-                if item.is_file():
-                    rel_path = item.relative_to(bundled_archetypen)
-                    target = user_archetypen / rel_path
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    # Kopieren wenn Zieldatei fehlt oder abweichende Größe hat (Update)
-                    if not target.exists() or item.stat().st_size != target.stat().st_size:
-                        shutil.copy2(str(item), str(target))
-                        copied += 1
-                        Logger.debug(f"Archetypen: Kopiert {item.name}")
-
-            if copied > 0:
-                Logger.info(f"Archetypen: {copied} Datei(en) ins persistente Verzeichnis kopiert")
-            else:
-                # Auch loggen wenn nichts kopiert wurde, weil bereits vorhanden
-                existing_count = sum(1 for f in user_archetypen.rglob('*') if f.is_file())
-                Logger.info(f"Archetypen: Bereits {existing_count} Datei(en) im Zielverzeichnis vorhanden")
+            if statistik['kopiert'] > 0:
+                self._zeige_archetypen_feedback(
+                    f"{statistik['kopiert']} neue Archetypen installiert ({gesamt} insgesamt)"
+                )
         except Exception as e:
             Logger.error(f"Archetypen-Kopie fehlgeschlagen: {e}", exc_info=True)
+
+    def _zeige_archetypen_feedback(self, nachricht: str, erfolg: bool = True):
+        """Zeigt das Ergebnis der Archetypen-Synchronisation als Snackbar.
+
+        Verzögert, damit die UI beim App-Start bereits aufgebaut ist.
+        """
+        def _show(dt):
+            try:
+                from services.service_container import service_container
+                dialog_service = service_container.get_dialog_service()
+                if dialog_service:
+                    if erfolg:
+                        dialog_service.show_success_dialog(nachricht)
+                    else:
+                        dialog_service.show_warning_dialog(nachricht)
+            except Exception as e:
+                Logger.warning(f"Archetypen-Feedback konnte nicht angezeigt werden: {e}")
+
+        Clock.schedule_once(_show, 3.0)
 
     def _migrate_settings_on_android(self):
         """Migriert benutzerdefinierte Settings vom alten App-Verzeichnis ins persistente Verzeichnis auf Android."""

--- a/test units/test_archetypen_sync.py
+++ b/test units/test_archetypen_sync.py
@@ -1,0 +1,202 @@
+# tests/test_archetypen_sync.py
+"""
+Unit Tests für die Archetypen-Synchronisation (utils/archetypen_sync.py).
+Testet Mojibake-Reparatur, Quellen-Auswahl und Datei-Synchronisation.
+"""
+
+import unittest
+import sys
+import os
+import tempfile
+import shutil
+from pathlib import Path
+
+# Projekt-Root zum Path hinzufügen
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.archetypen_sync import (
+    repariere_mojibake_name,
+    zaehle_archetypen,
+    finde_beste_quelle,
+    sync_archetypen,
+)
+
+
+class TestRepariereMojibakeName(unittest.TestCase):
+    """Tests für die Reparatur von Latin-1/UTF-8-Mojibake in Dateinamen."""
+
+    def test_mojibake_umlaut_wird_repariert(self):
+        """'Ã¤' (jtar-Mojibake für 'ä') wird zurückkonvertiert."""
+        self.assertEqual(
+            repariere_mojibake_name('Archetyp_Deadlands_KopfgeldjÃ¤ger_A.json'),
+            'Archetyp_Deadlands_Kopfgeldjäger_A.json',
+        )
+
+    def test_mojibake_oe_und_ue(self):
+        """Auch 'Ã¶' und 'Ã¼' werden repariert."""
+        self.assertEqual(repariere_mojibake_name('SalonschÃ¶nheit.json'), 'Salonschönheit.json')
+        self.assertEqual(repariere_mojibake_name('VerrÃ¼ckte.json'), 'Verrückte.json')
+
+    def test_ascii_name_unveraendert(self):
+        """Reine ASCII-Namen bleiben unverändert."""
+        self.assertEqual(
+            repariere_mojibake_name('Archetyp_SWAE_Soldat_A.json'),
+            'Archetyp_SWAE_Soldat_A.json',
+        )
+
+    def test_echter_umlaut_unveraendert(self):
+        """Korrekte Umlaute lösen UnicodeDecodeError aus und bleiben erhalten."""
+        self.assertEqual(
+            repariere_mojibake_name('Kopfgeldjäger.json'),
+            'Kopfgeldjäger.json',
+        )
+
+    def test_surrogate_unveraendert(self):
+        """Surrogate-Escapes (nicht dekodierbare Bytes) bleiben unverändert."""
+        name = 'Kopfgeldj\udcc3\udca4ger.json'
+        self.assertEqual(repariere_mojibake_name(name), name)
+
+    def test_java_signed_byte_mojibake_wird_repariert(self):
+        """jtar castet signierte Bytes zu chars: 0xC3 → U+FFC3 (real auf Android)."""
+        name = 'Archetyp_Savage_Pathfinder_Mￃﾶnch_Sajan_A.json'
+        self.assertEqual(
+            repariere_mojibake_name(name),
+            'Archetyp_Savage_Pathfinder_Mönch_Sajan_A.json',
+        )
+
+    def test_java_signed_byte_mojibake_ungueltig_bleibt(self):
+        """Nicht als UTF-8 dekodierbare Byte-Folgen bleiben unverändert."""
+        name = 'Datei_ￃX.json'  # 0xC3 ohne Folgebyte ist kein gültiges UTF-8
+        self.assertEqual(repariere_mojibake_name(name), name)
+
+
+class TestZaehleArchetypen(unittest.TestCase):
+    """Tests für das Zählen von Archetypen-JSONs."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_zaehlt_json_rekursiv(self):
+        (self.tmp / 'a.json').write_text('{}')
+        (self.tmp / 'sub').mkdir()
+        (self.tmp / 'sub' / 'b.json').write_text('{}')
+        (self.tmp / 'c.txt').write_text('x')
+        self.assertEqual(zaehle_archetypen(self.tmp), 2)
+
+    def test_nicht_existierendes_verzeichnis(self):
+        self.assertEqual(zaehle_archetypen(self.tmp / 'gibtsnicht'), 0)
+
+    def test_datei_statt_verzeichnis(self):
+        f = self.tmp / 'datei.json'
+        f.write_text('{}')
+        self.assertEqual(zaehle_archetypen(f), 0)
+
+
+class TestFindeBesteQuelle(unittest.TestCase):
+    """Tests für die Auswahl der besten Archetypen-Quelle."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.ziel = self.tmp / 'user' / 'Archetypen'
+        self.ziel.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _mache_quelle(self, name, anzahl):
+        quelle = self.tmp / name
+        quelle.mkdir(parents=True)
+        for i in range(anzahl):
+            (quelle / f'archetyp_{i}.json').write_text('{}')
+        return quelle
+
+    def test_quelle_mit_meisten_jsons_gewinnt(self):
+        """Nicht der erste existierende Kandidat, sondern der vollste gewinnt."""
+        alt = self._mache_quelle('alt', 12)
+        bundle = self._mache_quelle('bundle', 214)
+        quelle, anzahl = finde_beste_quelle([alt, bundle], self.ziel)
+        self.assertEqual(quelle, bundle)
+        self.assertEqual(anzahl, 214)
+
+    def test_ziel_selbst_wird_uebersprungen(self):
+        """Das Zielverzeichnis darf nie als Quelle gewählt werden."""
+        for i in range(12):
+            (self.ziel / f'alt_{i}.json').write_text('{}')
+        quelle, anzahl = finde_beste_quelle([self.ziel], self.ziel)
+        self.assertIsNone(quelle)
+        self.assertEqual(anzahl, 0)
+
+    def test_keine_kandidaten(self):
+        quelle, anzahl = finde_beste_quelle(
+            [self.tmp / 'gibtsnicht1', self.tmp / 'gibtsnicht2'], self.ziel
+        )
+        self.assertIsNone(quelle)
+        self.assertEqual(anzahl, 0)
+
+
+class TestSyncArchetypen(unittest.TestCase):
+    """Tests für die eigentliche Datei-Synchronisation."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.quelle = self.tmp / 'bundle'
+        self.quelle.mkdir()
+        self.ziel = self.tmp / 'user' / 'Archetypen'
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_fehlende_dateien_werden_kopiert(self):
+        (self.quelle / 'a.json').write_text('{"a": 1}')
+        (self.quelle / 'b.json').write_text('{"b": 2}')
+        statistik = sync_archetypen(self.quelle, self.ziel)
+        self.assertEqual(statistik['kopiert'], 2)
+        self.assertTrue((self.ziel / 'a.json').exists())
+        self.assertTrue((self.ziel / 'b.json').exists())
+
+    def test_gleiche_groesse_wird_uebersprungen(self):
+        (self.quelle / 'a.json').write_text('{"a": 1}')
+        sync_archetypen(self.quelle, self.ziel)
+        statistik = sync_archetypen(self.quelle, self.ziel)
+        self.assertEqual(statistik['kopiert'], 0)
+        self.assertEqual(statistik['vorhanden'], 1)
+
+    def test_geaenderte_groesse_wird_aktualisiert(self):
+        (self.quelle / 'a.json').write_text('{"a": 1}')
+        sync_archetypen(self.quelle, self.ziel)
+        (self.quelle / 'a.json').write_text('{"a": 1, "neu": true}')
+        statistik = sync_archetypen(self.quelle, self.ziel)
+        self.assertEqual(statistik['kopiert'], 1)
+        self.assertEqual((self.ziel / 'a.json').read_text(), '{"a": 1, "neu": true}')
+
+    def test_mojibake_name_wird_repariert(self):
+        """Eine Mojibake-Datei aus der APK-Extraktion landet mit korrektem Namen im Ziel."""
+        (self.quelle / 'KopfgeldjÃ¤ger.json').write_text('{}')
+        statistik = sync_archetypen(self.quelle, self.ziel)
+        self.assertEqual(statistik['repariert'], 1)
+        self.assertTrue((self.ziel / 'Kopfgeldjäger.json').exists())
+        self.assertFalse((self.ziel / 'KopfgeldjÃ¤ger.json').exists())
+
+    def test_alte_mojibake_variante_im_ziel_wird_entfernt(self):
+        """Wurde früher die Mojibake-Variante kopiert, wird sie aufgeräumt."""
+        self.ziel.mkdir(parents=True)
+        (self.ziel / 'KopfgeldjÃ¤ger.json').write_text('{}')
+        (self.quelle / 'KopfgeldjÃ¤ger.json').write_text('{}')
+        sync_archetypen(self.quelle, self.ziel)
+        self.assertTrue((self.ziel / 'Kopfgeldjäger.json').exists())
+        self.assertFalse((self.ziel / 'KopfgeldjÃ¤ger.json').exists())
+
+    def test_unterverzeichnisse(self):
+        sub = self.quelle / 'Setting'
+        sub.mkdir()
+        (sub / 'a.json').write_text('{}')
+        statistik = sync_archetypen(self.quelle, self.ziel)
+        self.assertEqual(statistik['kopiert'], 1)
+        self.assertTrue((self.ziel / 'Setting' / 'a.json').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/archetypen_sync.py
+++ b/utils/archetypen_sync.py
@@ -1,0 +1,125 @@
+# utils/archetypen_sync.py
+"""
+Synchronisation der mitgelieferten Archetypen ins persistente
+Benutzer-Verzeichnis (Android).
+
+Reine Datei-Logik ohne Kivy-Abhängigkeiten, damit sie in Unit-Tests
+ohne App-Kontext geprüft werden kann. Logging und Plattform-Erkennung
+verbleiben beim Aufrufer (main.py).
+"""
+
+import shutil
+from pathlib import Path
+
+
+def repariere_mojibake_name(name: str) -> str:
+    """Repariert Mojibake in Dateinamen aus der APK-Extraktion.
+
+    Der Java-Tar-Extractor von python-for-android (jtar) castet beim Parsen
+    der Header signierte Bytes direkt zu chars. UTF-8-Bytes ≥ 0x80 werden
+    dadurch sign-extended: 0xC3 → U+FFC3. 'Kopfgeldjäger' landet so als
+    'Kopfgeldjￃﾤger' auf dem Gerät (verifiziert mit jtar 2.3 + OpenJDK).
+
+    Zusätzlich wird klassisches Latin-1-Mojibake ('Ã¤' → 'ä') repariert.
+    Rückkonvertierung nur, wenn die rekonstruierten Bytes gültiges UTF-8
+    ergeben — reine ASCII-Namen und echte Umlaut-Namen bleiben unverändert.
+    """
+    # Muster 1: Java-signed-byte-Mojibake (U+FF80–U+FFFF)
+    if any(0xFF80 <= ord(c) <= 0xFFFF for c in name):
+        try:
+            raw = bytes(
+                (ord(c) - 0xFF00) if 0xFF80 <= ord(c) <= 0xFFFF else ord(c)
+                for c in name
+            )
+            return raw.decode('utf-8')
+        except (ValueError, UnicodeDecodeError):
+            return name
+
+    # Muster 2: Latin-1-Mojibake ('Ã¤')
+    try:
+        return name.encode('latin-1').decode('utf-8')
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return name
+
+
+def zaehle_archetypen(verzeichnis: Path) -> int:
+    """Zählt JSON-Dateien (rekursiv) in einem Verzeichnis. 0 bei Fehlern."""
+    try:
+        verzeichnis = Path(verzeichnis)
+        if not verzeichnis.is_dir():
+            return 0
+        return sum(1 for f in verzeichnis.rglob('*.json') if f.is_file())
+    except OSError:
+        return 0
+
+
+def finde_beste_quelle(kandidaten, ziel: Path):
+    """Wählt aus den Kandidaten das Verzeichnis mit den meisten Archetypen-JSONs.
+
+    Das Zielverzeichnis selbst wird übersprungen, damit nie "von sich
+    selbst" kopiert wird (z.B. wenn ein Kandidaten-Pfad versehentlich auf
+    das persistente Verzeichnis zeigt).
+
+    Returns:
+        tuple: (Pfad oder None, Anzahl JSONs in der Quelle)
+    """
+    try:
+        ziel_resolved = Path(ziel).resolve()
+    except OSError:
+        ziel_resolved = Path(ziel)
+
+    beste = None
+    beste_anzahl = 0
+    for kandidat in kandidaten:
+        pfad = Path(kandidat)
+        try:
+            if pfad.resolve() == ziel_resolved:
+                continue
+        except OSError:
+            continue
+        anzahl = zaehle_archetypen(pfad)
+        if anzahl > beste_anzahl:
+            beste = pfad
+            beste_anzahl = anzahl
+    return beste, beste_anzahl
+
+
+def sync_archetypen(quelle: Path, ziel: Path) -> dict:
+    """Kopiert fehlende oder geänderte Archetypen von quelle nach ziel.
+
+    - Vergleich über Dateigröße statt mtime, da die APK-Extraktion keine
+      brauchbaren Timestamps setzt.
+    - Mojibake-Namen aus der APK-Extraktion werden beim Kopieren repariert;
+      eine eventuell früher kopierte Mojibake-Variante im Ziel wird entfernt.
+
+    Returns:
+        dict: Statistik mit 'kopiert', 'repariert', 'vorhanden', 'fehler'
+    """
+    statistik = {'kopiert': 0, 'repariert': 0, 'vorhanden': 0, 'fehler': 0}
+    quelle = Path(quelle)
+    ziel = Path(ziel)
+    ziel.mkdir(parents=True, exist_ok=True)
+
+    for item in quelle.rglob('*'):
+        if not item.is_file():
+            continue
+        rel_path = item.relative_to(quelle)
+        ziel_name = repariere_mojibake_name(item.name)
+        target = ziel / rel_path.parent / ziel_name
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if ziel_name != item.name:
+                statistik['repariert'] += 1
+                # Alte Mojibake-Variante im Ziel aufräumen
+                alte_variante = ziel / rel_path.parent / item.name
+                if alte_variante.exists():
+                    alte_variante.unlink()
+            if not target.exists() or item.stat().st_size != target.stat().st_size:
+                shutil.copy2(str(item), str(target))
+                statistik['kopiert'] += 1
+            else:
+                statistik['vorhanden'] += 1
+        except OSError:
+            statistik['fehler'] += 1
+
+    return statistik

--- a/utils/custom_filemanager.py
+++ b/utils/custom_filemanager.py
@@ -83,6 +83,19 @@ class CustomFileManager(MDFileManager):
         """
         paths = []
 
+        # Persistentes Charakter-Verzeichnis und Archetypen zuoberst —
+        # die häufigsten Ziele beim Laden/Speichern von Charakteren
+        try:
+            from utils.path_utils import get_chars_path
+            chars_dir = get_chars_path()
+            if os.path.isdir(chars_dir):
+                paths.append((chars_dir, "Meine Charaktere", "account-group"))
+            archetypen_dir = os.path.join(chars_dir, "Archetypen")
+            if os.path.isdir(archetypen_dir):
+                paths.append((archetypen_dir, "Archetypen", "sword-cross"))
+        except Exception as e:
+            Logger.warning(f"CustomFileManager: Charakter-Schnellzugriffe nicht verfügbar: {e}")
+
         # Interner Speicher (primärer Zugriffspunkt für Nutzer)
         internal = "/storage/emulated/0"
         if os.path.exists(internal) and os.access(internal, os.R_OK):

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -39,13 +39,21 @@ def _resolve_base_path() -> Path:
     """Zentrale Pfad-Erkennung für alle Laufzeitumgebungen.
 
     Reihenfolge:
-    1. PyInstaller one-file (_MEIPASS) – eindeutig
-    2. PyInstaller one-dir (_internal/ neben der EXE) – eindeutig
-    3. PyInstaller one-dir (EXE-Verzeichnis enthält main.py) – eindeutig
-    4. __file__-basiert – funktioniert immer, auch auf Android/p4a wo
-       sys.frozen=True gesetzt ist, sys.executable aber auf den Python-Interpreter
-       in _python_bundle/bin/ zeigt und NICHT auf das App-Verzeichnis.
+    1. Android/p4a: ANDROID_ARGUMENT/ANDROID_APP_PATH – wird von p4a (start.c)
+       direkt auf das entpackte App-Verzeichnis gesetzt und ist damit die
+       verlässlichste Quelle auf Android
+    2. PyInstaller one-file (_MEIPASS) – eindeutig
+    3. PyInstaller one-dir (_internal/ neben der EXE) – eindeutig
+    4. PyInstaller one-dir (EXE-Verzeichnis enthält main.py) – eindeutig
+    5. __file__-basiert – funktioniert auf allen übrigen Plattformen
     """
+    # Android/p4a: kanonischer App-Pfad aus der Umgebung (nur dort gesetzt)
+    android_app_path = os.environ.get('ANDROID_ARGUMENT') or os.environ.get('ANDROID_APP_PATH')
+    if android_app_path:
+        p = Path(android_app_path)
+        if p.is_dir():
+            return p
+
     if getattr(sys, 'frozen', False):
         # PyInstaller one-file
         if hasattr(sys, '_MEIPASS'):


### PR DESCRIPTION
## Summary

Implements robust synchronization of bundled archetypes to the persistent user directory on Android, with automatic repair of filename corruption (Mojibake) caused by the jtar tar extractor used by python-for-android.

## Key Changes

- **New module `utils/archetypen_sync.py`**: Core synchronization logic independent of Kivy, enabling unit testing without app context
  - `repariere_mojibake_name()`: Repairs two Mojibake patterns from jtar (Java signed-byte casting and Latin-1 encoding errors)
  - `zaehle_archetypen()`: Recursively counts JSON files in a directory
  - `finde_beste_quelle()`: Selects the source directory with the most archetypes (not just the first existing one), preventing stale/empty directories from masking the real bundle
  - `sync_archetypen()`: Copies missing/changed files by size comparison (not mtime, since APK extraction has unreliable timestamps), repairs names during copy, and cleans up old Mojibake variants

- **Refactored `main.py` `_copy_archetypen_on_android()`**: 
  - Now uses the new sync module functions
  - Checks multiple candidate paths (including `ANDROID_ARGUMENT` and `ANDROID_APP_PATH` environment variables set by p4a)
  - Provides detailed logging of source selection and copy statistics
  - Shows user feedback via snackbar when archetypes are installed or missing
  - Wrapped character migration in separate try-block so archetype sync isn't blocked by migration failures

- **Added `_zeige_archetypen_feedback()` helper**: Displays archetype sync results as non-blocking snackbars after a 3-second delay (allowing UI to initialize)

- **Updated `utils/path_utils.py`**: Prioritizes `ANDROID_ARGUMENT`/`ANDROID_APP_PATH` environment variables for Android app root detection (more reliable than sys.frozen checks)

- **Enhanced `utils/custom_filemanager.py`**: Adds persistent character directory and archetypes as top-level shortcuts in the file manager for easier access

- **Updated `docs/ANDROID_WORKAROUNDS.md`**: Documents the jtar Mojibake problem and solution

## Testing

- **Comprehensive unit test suite** (`test units/test_archetypen_sync.py`): 202 lines covering
  - Mojibake repair (Java signed-byte, Latin-1, ASCII, valid UTF-8, surrogate escapes)
  - Archetype counting (recursive, non-existent dirs, files vs directories)
  - Source selection (most JSONs wins, target self-exclusion, no candidates)
  - File synchronization (copy missing, skip unchanged, update changed, repair names, cleanup old variants, subdirectories)

## Implementation Details

- **Size-based comparison**: Avoids reliance on mtime which is unreliable after APK extraction
- **Best-source selection**: Iterates all candidates to find the fullest, not the first existing — prevents silent failures when a stale directory exists
- **Atomic name repair**: Mojibake names are repaired during copy; old variants are cleaned up in the same operation
- **Error resilience**: Sync continues on per-file errors; statistics track failures separately
- **No Kivy dependency in sync module**: Enables unit testing and potential reuse in other contexts

https://claude.ai/code/session_01HnPBCFULxueTEDRTHjheMC