### PR TITLE
Android 16 (API 36) als Target: targetSdk-Bump + Predictive-Back-Opt-out

### DIFF
--- a/build_fixes.py
+++ b/build_fixes.py
@@ -6,6 +6,10 @@ Zusätzlich: 16 KB Page Size Alignment für Android (Google Play Pflicht ab 31.0
 für Updates / 01.11.2025 für neue Apps; gilt nur für 64-Bit Libraries).
 Patches: pythonforandroid/archs.py common_ldflags und SDL2-Bootstrap Application.mk.
 
+Zusätzlich: Predictive-Back-Opt-out für targetSdk 36 (Android 16) —
+android:enableOnBackInvokedCallback="false" im <application>-Tag, damit
+SDL2/Kivy weiterhin KEYCODE_BACK erhalten (Zurück-Taste schließt Popups).
+
 Wird automatisch von build_android.py / build_all.py aufgerufen, BEVOR buildozer startet.
 Kann auch manuell ausgeführt werden: python build_fixes.py
 """
@@ -202,6 +206,99 @@ def fix_android_manifest_fileprovider():
 
         except Exception as e:
             print(f"P4A Hook: Error fixing manifest {manifest_file}: {e}")
+
+    return fixed_any
+
+
+def _find_manifest_files():
+    """Sammelt alle AndroidManifest-Kandidaten: gerenderte Manifeste in den
+    Build-/Dist-Verzeichnissen UND die p4a-Templates (AndroidManifest.tmpl.xml),
+    aus denen p4a das Manifest bei jedem Build neu rendert.
+
+    Templates mitzupatchen ist wichtig: Patches nur am gerenderten Manifest
+    gehen bei einem Re-Render verloren.
+    """
+    manifest_files = []
+
+    # 1) p4a-Bootstrap-Templates (venv + buildozer-extrahierte Kopie)
+    for p4a_dir in _find_all_pythonforandroid_dirs():
+        for tmpl in [
+            p4a_dir / "bootstraps" / "sdl2" / "build" / "templates" / "AndroidManifest.tmpl.xml",
+            p4a_dir / "bootstraps" / "common" / "build" / "templates" / "AndroidManifest.tmpl.xml",
+        ]:
+            if tmpl.exists():
+                manifest_files.append(tmpl)
+
+    platform_dir = Path(".buildozer/android/platform")
+    if platform_dir.exists():
+        # 2) Templates, die bereits in die Dists kopiert wurden
+        manifest_files += list(platform_dir.glob("build-*/dists/*/templates/AndroidManifest.tmpl.xml"))
+        # 3) Gerenderte Manifeste (verschiedene p4a-Versionen, verschiedene Pfade)
+        manifest_files += list(platform_dir.glob("build-*/dists/*/src/main/AndroidManifest.xml"))
+        manifest_files += list(platform_dir.glob("build-*/dists/*/AndroidManifest.xml"))
+
+    # Duplikate (Symlinks/mehrfache Globs) entfernen
+    seen = set()
+    unique = []
+    for f in manifest_files:
+        resolved = f.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(f)
+    return unique
+
+
+def fix_android_manifest_predictive_back():
+    """Injiziert android:enableOnBackInvokedCallback="false" in das
+    <application>-Tag des AndroidManifest.xml (und der p4a-Templates).
+
+    Hintergrund: Ab targetSdk 36 (Android 16) ist "Predictive Back"
+    standardmäßig aktiviert. Das System liefert dann KEIN KEYCODE_BACK
+    mehr an die Activity — SDL2/Kivy sehen die Zurück-Taste/-Geste nicht
+    mehr (kein ESC-Event, Popups mit auto_dismiss schließen nicht, die
+    App wird stattdessen sofort minimiert). Da SDL2 keinen
+    OnBackInvokedCallback registriert, ist der Manifest-Opt-out der
+    einzige Weg, das bisherige Back-Verhalten zu erhalten.
+
+    Idempotent: Attribut wird nur eingefügt, wenn es noch fehlt.
+    """
+    print("P4A Hook: Checking AndroidManifest for predictive-back opt-out...")
+
+    manifest_files = _find_manifest_files()
+    if not manifest_files:
+        print("P4A Hook: No AndroidManifest files found, skipping predictive-back fix")
+        return False
+
+    fixed_any = False
+    for manifest_file in manifest_files:
+        try:
+            with open(manifest_file, 'r') as f:
+                content = f.read()
+
+            if 'enableOnBackInvokedCallback' in content:
+                print(f"P4A Hook: predictive-back opt-out already present in {manifest_file}")
+                continue
+
+            new_content, count = re.subn(
+                r'<application\b',
+                '<application android:enableOnBackInvokedCallback="false"',
+                content,
+                count=1,
+            )
+            if count == 0:
+                print(f"P4A Hook: <application> tag not found in {manifest_file}")
+                continue
+
+            with open(manifest_file, 'w') as f:
+                f.write(new_content)
+            print(f"P4A Hook: predictive-back opt-out added to {manifest_file}")
+            fixed_any = True
+
+        except Exception as e:
+            print(f"P4A Hook: Error fixing manifest {manifest_file}: {e}")
+
+    if not fixed_any:
+        print("P4A Hook: All manifests already have the predictive-back opt-out")
 
     return fixed_any
 
@@ -615,6 +712,7 @@ def before_apk_build(toolchain):
     fix_kivy_python3_compatibility()
     fix_pyjnius_python3_compatibility()
     fix_android_manifest_fileprovider()
+    fix_android_manifest_predictive_back()
     fix_p4a_ldflags_for_16kb_alignment()
     fix_sdl2_bootstrap_16kb_alignment()
     fix_sqlite3_recipe_16kb_alignment()
@@ -635,6 +733,10 @@ if __name__ == "__main__":
     if manifest_fixed:
         print("P4A Hook: FileProvider in AndroidManifest.xml eingefügt")
 
+    back_fixed = fix_android_manifest_predictive_back()
+    if back_fixed:
+        print("P4A Hook: Predictive-Back-Opt-out in AndroidManifest.xml eingefügt")
+
     archs_fixed = fix_p4a_ldflags_for_16kb_alignment()
     if archs_fixed:
         print("P4A Hook: archs.py mit 16 KB LDFLAGS gepatcht")
@@ -647,7 +749,7 @@ if __name__ == "__main__":
     if sqlite3_fixed:
         print("P4A Hook: sqlite3 Android.mk mit 16 KB LOCAL_LDFLAGS gepatcht")
 
-    if any([kivy_fixed, pyjnius_fixed, manifest_fixed, archs_fixed, sdl2_fixed, sqlite3_fixed]):
+    if any([kivy_fixed, pyjnius_fixed, manifest_fixed, back_fixed, archs_fixed, sdl2_fixed, sqlite3_fixed]):
         print("P4A Hook: Build fixes completed successfully")
     else:
         print("P4A Hook: No fixes were needed")

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -106,7 +106,15 @@ android.permissions = android.permission.INTERNET, android.permission.WRITE_EXTE
 #android.features = android.hardware.usb.host
 
 # (int) Target Android API, should be as high as possible.
-android.api = 35
+# Android 16 (API 36). ACHTUNG:
+#   - SDK Platform 36 + Build-Tools müssen lokal installiert sein
+#     (android.skip_update = True verhindert den Auto-Download!)
+#   - Ab targetSdk 36 ist "Predictive Back" standardmäßig aktiv, wodurch
+#     SDL2/Kivy KEIN KEYCODE_BACK mehr erhalten würde (Zurück-Taste/-Geste
+#     würde die App minimieren statt Popups zu schließen). Der Opt-out
+#     (android:enableOnBackInvokedCallback="false") wird über den
+#     build_fixes.py Hook ins Manifest injiziert — siehe p4a.hook unten.
+android.api = 36
 
 # (int) Minimum API your APK / AAB will support.
 android.minapi = 21
@@ -359,6 +367,9 @@ p4a.branch = master
 # build_fixes.py macht u.a.:
 #   - Cython-3.x-Patches für Kivy & PyJNIus (long → int)
 #   - FileProvider-Manifest-Korrektur
+#   - Predictive-Back-Opt-out (enableOnBackInvokedCallback="false") im
+#     Manifest — PFLICHT ab targetSdk 36, sonst erhält Kivy kein
+#     KEYCODE_BACK mehr (Zurück-Taste schließt keine Popups mehr)
 #   - 16-KB-Page-Size-Alignment via archs.py common_ldflags
 #     und SDL2-Bootstrap APP_LDFLAGS (nur arm64-v8a / x86_64)
 p4a.hook = ./build_fixes.py

--- a/docs/ANDROID_WORKAROUNDS.md
+++ b/docs/ANDROID_WORKAROUNDS.md
@@ -298,6 +298,28 @@ main_layout = MDBoxLayout(orientation="vertical", size_hint_y=None, height=main_
 - Integrated search field with filtered list
 - Used for race/species selection and other searchable lists
 
+## Android 16 / targetSdk 36 (`buildozer.spec` + `build_fixes.py`)
+
+Die App zielt auf **Android 16 (API 36)** (`android.api = 36` in `buildozer.spec`). Zwei Verhaltensänderungen von targetSdk 36 sind relevant — beide sind abgedeckt, die Absicherungen dürfen NICHT entfernt werden:
+
+### Predictive Back (KRITISCH)
+**Problem:** Ab targetSdk 36 aktiviert Android "Predictive Back" standardmäßig. Das System liefert dann **kein `KEYCODE_BACK` mehr an die Activity**. SDL2 registriert keinen `OnBackInvokedCallback` — Kivy bekommt also kein ESC-Event mehr: Popups/Overlays mit `auto_dismiss` schließen nicht mehr per Zurück-Taste/-Geste, stattdessen wird die App sofort minimiert.
+
+**Solution:** `build_fixes.py` → `fix_android_manifest_predictive_back()` injiziert `android:enableOnBackInvokedCallback="false"` in das `<application>`-Tag — sowohl in die gerenderten Manifeste als auch in die p4a-Templates (`AndroidManifest.tmpl.xml`), damit der Patch ein Re-Rendern überlebt. Der Fix ist idempotent und läuft automatisch über den `p4a.hook`.
+
+**Regel:** Dieser Opt-out muss bestehen bleiben, solange die App auf SDL2-Back-Key-Events angewiesen ist (d.h. solange kein eigener `OnBackInvokedCallback` implementiert wird).
+
+### Edge-to-Edge
+Seit targetSdk 35 erzwingt Android Edge-to-Edge-Darstellung; ab targetSdk 36 ist der Manifest-Opt-out (`windowOptOutEdgeToEdgeEnforcement`) abgeschaltet. Die App verwendet diesen Opt-out **nicht** — sie behandelt die Insets selbst:
+- `main.py` ermittelt Statusbar-/Notch-Höhe (`_android_top_padding`) und Navigationsleisten-Höhe (`_android_bottom_padding`) via jnius
+- Overlays/Views verwenden Top-Spacer für Statusbar/Notch (siehe `views/app_navigation_mixin.py`, `views/*_overlay.py`)
+
+Dieses Insets-Handling darf bei UI-Änderungen nicht entfernt werden — ohne die Spacer liegt der Inhalt unter der Statusbar.
+
+### Build-Voraussetzungen für API 36
+- SDK Platform 36 + passende Build-Tools müssen lokal installiert sein (`android.skip_update = True` verhindert den Auto-Download durch buildozer)
+- Die 16-KB-Page-Size-Fixes in `build_fixes.py` bleiben nötig (Google-Play-Pflicht, unabhängig vom API-Level)
+
 ## Archetypen-Synchronisation & jtar-Mojibake (`utils/archetypen_sync.py`)
 **Problem 1:** Die mitgelieferten Archetypen (`chars/Archetypen/`) liegen nach der APK-Installation im App-Verzeichnis (`files/app/`), das bei jedem Update gelöscht und neu entpackt wird. Sie müssen ins persistente Verzeichnis (`files/chars/Archetypen/`) kopiert werden. Wählt man dabei den **ersten existierenden** Quellpfad, kann ein veraltetes oder falsches Verzeichnis das echte Bundle verdecken — die Kopie läuft dann scheinbar erfolgreich, aber ohne neue Dateien.
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -21,3 +21,9 @@ python build_windows_wine.py
 - `savage_worlds_generator_linux.spec` (Linux)
 - `savage_worlds_generator_wine.spec` (Wine)
 - `buildozer.spec` (Android)
+
+## Android: API-Level & Voraussetzungen
+
+- **targetSdk / `android.api` = 36** (Android 16), `android.minapi = 21`
+- SDK Platform 36 + Build-Tools müssen im lokalen SDK (`android.sdk_path`) installiert sein — `android.skip_update = True` verhindert den Auto-Download durch buildozer
+- `build_fixes.py` (p4a.hook) injiziert u.a. den **Predictive-Back-Opt-out** (`android:enableOnBackInvokedCallback="false"`) ins Manifest — ohne ihn erhält Kivy ab targetSdk 36 kein `KEYCODE_BACK` mehr. Details: [ANDROID_WORKAROUNDS.md](ANDROID_WORKAROUNDS.md)


### PR DESCRIPTION
- buildozer.spec: android.api 35 → 36
- build_fixes.py: neuer Manifest-Patch fix_android_manifest_predictive_back()
  injiziert android:enableOnBackInvokedCallback="false" in <application>
  (gerenderte Manifeste UND p4a-Templates, idempotent). Ohne den Opt-out
  liefert Android ab targetSdk 36 kein KEYCODE_BACK mehr an SDL2/Kivy —
  die Zurück-Taste würde Popups nicht mehr schließen, sondern die App
  minimieren.
- Doku: neuer Abschnitt "Android 16 / targetSdk 36" in
  docs/ANDROID_WORKAROUNDS.md (Predictive Back, Edge-to-Edge-Insets,
  Build-Voraussetzungen), Hinweis in docs/BUILD.md

Bestehende Workarounds (16-KB-Alignment, FileProvider, Cython-Fixes,
Statusbar-/Navbar-Insets in main.py) bleiben unverändert und greifen
auch mit API 36.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KT1JEXv1Sg4Ns21rTsAtPP