### PR TITLE
Raufbold/Schläger steigern natürliche Waffen

### DIFF
--- a/config/natuerliche_waffen_config.json
+++ b/config/natuerliche_waffen_config.json
@@ -1,5 +1,5 @@
 {
-    "_kommentar": "Natürliche/waffenlose Waffen aus Abstammung und Talenten. gruppen: Anzeigename je Waffengruppe (ergibt mit Würfel und PB den Namen des Ausrüstungs-Eintrags, z. B. 'Klauen (Stä+W6, PB 2)'). wuerfel_kette: Reihenfolge für 'steigert'. volkseigenarten: spezielle_effekte-Schlüssel -> Gruppe. talente: pro gewählter Kopie angewendet, in dieser Reihenfolge. grundwuerfel = nur setzen, wenn die Gruppe noch keinen Würfel hat; setzt = mindestens dieser Würfel; steigert = um n Würfeltypen erhöhen (nur wenn schon ein Würfel da ist); pb = Panzerbrechend mindestens auf diesen Wert; wiederholung = gilt ab der zweiten gewählten Kopie.",
+    "_kommentar": "Natürliche/waffenlose Waffen aus Abstammung und Talenten. gruppen: Anzeigename je Waffengruppe (ergibt mit Würfel und PB den Namen des Ausrüstungs-Eintrags, z. B. 'Klauen (Stä+W6, PB 2)'). wuerfel_kette: Reihenfolge für 'steigert'. volkseigenarten: spezielle_effekte-Schlüssel -> Gruppe. talente: pro gewählter Kopie angewendet, in dieser Reihenfolge. grundwuerfel = nur setzen, wenn die Gruppe noch keinen Würfel hat; setzt = mindestens dieser Würfel; steigert = um n Würfeltypen erhöhen (nur wenn schon ein Würfel da ist); steigert_alle = steigert jede Gruppe, die bereits einen Würfel hat (Raufbold/Schläger: 'oder erhöhe Würfeltyp bei Kombination mit Kampfkünstler, Klauen o. ä.'), und greift erst auf gruppe/grundwuerfel zurück, wenn der Charakter gar keine natürliche Waffe hat; pb = Panzerbrechend mindestens auf diesen Wert; wiederholung = gilt ab der zweiten gewählten Kopie.",
     "gruppen": {
         "unbewaffnet": "Waffenloser Schlag",
         "klauen": "Klauen",
@@ -25,7 +25,8 @@
         "Raufbold": {
             "gruppe": "unbewaffnet",
             "grundwuerfel": "W4",
-            "steigert": 1
+            "steigert": 1,
+            "steigert_alle": true
         },
         "Waffenloser Schlag": {
             "gruppe": "unbewaffnet",
@@ -37,7 +38,8 @@
         },
         "Schläger": {
             "gruppe": "unbewaffnet",
-            "steigert": 1
+            "steigert": 1,
+            "steigert_alle": true
         },
         "Klauen": {
             "gruppe": "klauen",

--- a/functions/natuerliche_waffen.py
+++ b/functions/natuerliche_waffen.py
@@ -4,8 +4,9 @@ Natürliche Waffen (Klauen, Biss, Hörner, waffenlose Schläge).
 Der Bestand wird nicht fortgeschrieben, sondern bei jeder Änderung neu aus
 Abstammung + gewählten Talenten abgeleitet und mit dem Inventar abgeglichen
 (synchronisiere). Das ist nötig, weil Talente vorhandene Waffen verbessern
-(Kampfkünstler W4 -> Kampfkunstmeister W6 -> Schläger W8) und ein Snapshot je
-Talent diese Ketten nicht sauber zurücknehmen könnte.
+(Kampfkünstler W4 -> Kampfkunstmeister W6 -> Schläger W8, Raufbold steigert
+Klauen der Abstammung) und ein Snapshot je Talent diese Ketten nicht sauber
+zurücknehmen könnte.
 
 Quellen, in dieser Reihenfolge:
 
@@ -190,6 +191,24 @@ def _reihenfolge(eintrag):
     return (1 if regel.get('steigert') else 0, 0 if regel.get('grundwuerfel') else 1, index)
 
 
+def _steigere_alle(zustand, regel, kette):
+    """
+    Steigert jede Gruppe, die schon einen Würfel hat (Raufbold, Schläger).
+
+    Raufbold macht die Fäuste zur natürlichen Waffe (Stä+W4) — wer aber bereits
+    eine hat (Klauen der Abstammung, Kampfkünstler, ...), steigert stattdessen
+    deren Würfeltyp; Schläger steigert danach dasselbe noch einmal. Gibt False
+    zurück, wenn nichts zu steigern war, damit die Regel auf ihren
+    grundwuerfel zurückfallen kann.
+    """
+    eintraege = [e for e in zustand.values() if e["wuerfel"]]
+    if not eintraege:
+        return False
+    for eintrag in eintraege:
+        eintrag["wuerfel"] = _steigere(eintrag["wuerfel"], regel.get('steigert') or 0, kette)
+    return True
+
+
 def _aus_talenten(charakter, zustand, kette):
     """Natürliche Waffen aus den gewählten Talenten in den Zustand eintragen."""
     gewaehlt = getattr(charakter, 'selected_talente', None) or []
@@ -202,6 +221,8 @@ def _aus_talenten(charakter, zustand, kette):
         wiederholung = regel.get('wiederholung') or {}
         for kopie in range(anzahl):
             aktiv = {**regel, **wiederholung} if kopie else regel
+            if aktiv.get('steigert_alle') and _steigere_alle(zustand, aktiv, kette):
+                continue
             eintrag = zustand.setdefault(gruppe, {"wuerfel": None, "pb": 0})
             if aktiv.get('setzt'):
                 eintrag["wuerfel"] = _maximum(eintrag["wuerfel"], aktiv['setzt'], kette)

--- a/settings/50 Fathoms.json
+++ b/settings/50 Fathoms.json
@@ -5294,6 +5294,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Alchemistentasche": {
             "name": "Alchemistentasche",
             "kategorie": "Allgemein",

--- a/settings/Deadlands.json
+++ b/settings/Deadlands.json
@@ -5040,6 +5040,291 @@
         "PB": "-"
       }
     },
+    "Biss (Stä+W8)": {
+      "name": "Biss (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W8, PB 2)": {
+      "name": "Biss (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss (Stä+W10)": {
+      "name": "Biss (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W10, PB 2)": {
+      "name": "Biss (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W6, PB 2)": {
+      "name": "Biss/Klauen (Stä+W6, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W8, PB 2)": {
+      "name": "Biss/Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10)": {
+      "name": "Biss/Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 2)": {
+      "name": "Biss/Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 4)": {
+      "name": "Biss/Klauen (Stä+W10, PB 4)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "4"
+      }
+    },
+    "Hörner (Stä+W8)": {
+      "name": "Hörner (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Hörner (Stä+W10)": {
+      "name": "Hörner (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8)": {
+      "name": "Klauen (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8, PB 2)": {
+      "name": "Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Klauen (Stä+W10)": {
+      "name": "Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W10, PB 2)": {
+      "name": "Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
     "Schickes Kleid": {
       "name": "Schickes Kleid",
       "kategorie": "Allgemein",

--- a/settings/Fantasy Kompendium.json
+++ b/settings/Fantasy Kompendium.json
@@ -6655,6 +6655,291 @@
         "PB": "-"
       }
     },
+    "Biss (Stä+W8)": {
+      "name": "Biss (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W8, PB 2)": {
+      "name": "Biss (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss (Stä+W10)": {
+      "name": "Biss (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W10, PB 2)": {
+      "name": "Biss (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W6, PB 2)": {
+      "name": "Biss/Klauen (Stä+W6, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W8, PB 2)": {
+      "name": "Biss/Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10)": {
+      "name": "Biss/Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 2)": {
+      "name": "Biss/Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 4)": {
+      "name": "Biss/Klauen (Stä+W10, PB 4)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "4"
+      }
+    },
+    "Hörner (Stä+W8)": {
+      "name": "Hörner (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Hörner (Stä+W10)": {
+      "name": "Hörner (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8)": {
+      "name": "Klauen (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8, PB 2)": {
+      "name": "Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Klauen (Stä+W10)": {
+      "name": "Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W10, PB 2)": {
+      "name": "Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
     "Alchemistentasche": {
       "name": "Alchemistentasche",
       "kategorie": "Allgemein",

--- a/settings/HeXXen 1773.json
+++ b/settings/HeXXen 1773.json
@@ -4222,6 +4222,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Abenteurerpaket": {
             "name": "Abenteurerpaket",
             "kategorie": "Allgemein",

--- a/settings/Hellfrost.json
+++ b/settings/Hellfrost.json
@@ -6795,6 +6795,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Alchemistentasche": {
             "name": "Alchemistentasche",
             "kategorie": "Allgemein",

--- a/settings/Horror Kompendium.json
+++ b/settings/Horror Kompendium.json
@@ -5951,6 +5951,291 @@
         "PB": "-"
       }
     },
+    "Biss (Stä+W8)": {
+      "name": "Biss (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W8, PB 2)": {
+      "name": "Biss (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss (Stä+W10)": {
+      "name": "Biss (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W10, PB 2)": {
+      "name": "Biss (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W6, PB 2)": {
+      "name": "Biss/Klauen (Stä+W6, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W8, PB 2)": {
+      "name": "Biss/Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10)": {
+      "name": "Biss/Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 2)": {
+      "name": "Biss/Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 4)": {
+      "name": "Biss/Klauen (Stä+W10, PB 4)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "4"
+      }
+    },
+    "Hörner (Stä+W8)": {
+      "name": "Hörner (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Hörner (Stä+W10)": {
+      "name": "Hörner (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8)": {
+      "name": "Klauen (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8, PB 2)": {
+      "name": "Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Klauen (Stä+W10)": {
+      "name": "Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W10, PB 2)": {
+      "name": "Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
     "Silberkugeln (10)": {
       "name": "Silberkugeln (10)",
       "kategorie": "Munition",

--- a/settings/Rippers.json
+++ b/settings/Rippers.json
@@ -4996,6 +4996,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Silberkugeln (10)": {
             "name": "Silberkugeln (10)",
             "kategorie": "Munition",

--- a/settings/SWAE.json
+++ b/settings/SWAE.json
@@ -4131,6 +4131,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Abenteurerpaket": {
             "name": "Abenteurerpaket",
             "kategorie": "Allgemein",

--- a/settings/Savage Aventurien.json
+++ b/settings/Savage Aventurien.json
@@ -11128,6 +11128,291 @@
         "PB": "-"
       }
     },
+    "Biss (Stä+W8)": {
+      "name": "Biss (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W8, PB 2)": {
+      "name": "Biss (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss (Stä+W10)": {
+      "name": "Biss (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W10, PB 2)": {
+      "name": "Biss (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W6, PB 2)": {
+      "name": "Biss/Klauen (Stä+W6, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W8, PB 2)": {
+      "name": "Biss/Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10)": {
+      "name": "Biss/Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 2)": {
+      "name": "Biss/Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 4)": {
+      "name": "Biss/Klauen (Stä+W10, PB 4)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "4"
+      }
+    },
+    "Hörner (Stä+W8)": {
+      "name": "Hörner (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Hörner (Stä+W10)": {
+      "name": "Hörner (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8)": {
+      "name": "Klauen (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8, PB 2)": {
+      "name": "Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Klauen (Stä+W10)": {
+      "name": "Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W10, PB 2)": {
+      "name": "Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
     "Angelhaken": {
       "name": "Angelhaken",
       "kategorie": "Allgemein",

--- a/settings/Savage Pathfinder.json
+++ b/settings/Savage Pathfinder.json
@@ -9695,6 +9695,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Angelhaken": {
             "name": "Angelhaken",
             "kategorie": "Allgemein",

--- a/settings/SciFi Kompendium.json
+++ b/settings/SciFi Kompendium.json
@@ -5723,6 +5723,291 @@
         "PB": "-"
       }
     },
+    "Biss (Stä+W8)": {
+      "name": "Biss (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W8, PB 2)": {
+      "name": "Biss (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss (Stä+W10)": {
+      "name": "Biss (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss (Stä+W10, PB 2)": {
+      "name": "Biss (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W6, PB 2)": {
+      "name": "Biss/Klauen (Stä+W6, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W6",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W8, PB 2)": {
+      "name": "Biss/Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10)": {
+      "name": "Biss/Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 2)": {
+      "name": "Biss/Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Biss/Klauen (Stä+W10, PB 4)": {
+      "name": "Biss/Klauen (Stä+W10, PB 4)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "4"
+      }
+    },
+    "Hörner (Stä+W8)": {
+      "name": "Hörner (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Hörner (Stä+W10)": {
+      "name": "Hörner (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8)": {
+      "name": "Klauen (Stä+W8)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W8, PB 2)": {
+      "name": "Klauen (Stä+W8, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W8",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
+    "Klauen (Stä+W10)": {
+      "name": "Klauen (Stä+W10)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "-"
+      }
+    },
+    "Klauen (Stä+W10, PB 2)": {
+      "name": "Klauen (Stä+W10, PB 2)",
+      "kategorie": "Waffe",
+      "unterkategorie": "Natürliche Waffe",
+      "gewicht": 0,
+      "kosten": 0,
+      "setting": "",
+      "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+      "aktiv": true,
+      "typ": "Nahkampf",
+      "mindeststaerke": "-",
+      "eigenschaften": {
+        "Schaden": "Stä+W10",
+        "Reichweite": "nah",
+        "FR": "-",
+        "Schuss": "-",
+        "PB": "2"
+      }
+    },
     "3D-Drucker": {
       "name": "3D-Drucker",
       "kategorie": "Ausrüstung",

--- a/settings/Sundered Skies.json
+++ b/settings/Sundered Skies.json
@@ -6412,6 +6412,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Bronzene Brustplatte": {
             "name": "Bronzene Brustplatte",
             "kategorie": "Rüstung",

--- a/settings/Superkräfte Kompendium.json
+++ b/settings/Superkräfte Kompendium.json
@@ -5076,6 +5076,291 @@
                 "PB": "-"
             }
         },
+        "Biss (Stä+W8)": {
+            "name": "Biss (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W8, PB 2)": {
+            "name": "Biss (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss (Stä+W10)": {
+            "name": "Biss (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss (Stä+W10, PB 2)": {
+            "name": "Biss (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W6, PB 2)": {
+            "name": "Biss/Klauen (Stä+W6, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W6",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W8, PB 2)": {
+            "name": "Biss/Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10)": {
+            "name": "Biss/Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 2)": {
+            "name": "Biss/Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Biss/Klauen (Stä+W10, PB 4)": {
+            "name": "Biss/Klauen (Stä+W10, PB 4)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Biss- oder Klauenangriff, dessen Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "4"
+            }
+        },
+        "Hörner (Stä+W8)": {
+            "name": "Hörner (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Hörner (Stä+W10)": {
+            "name": "Hörner (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Hörner, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8)": {
+            "name": "Klauen (Stä+W8)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W8, PB 2)": {
+            "name": "Klauen (Stä+W8, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W8",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
+        "Klauen (Stä+W10)": {
+            "name": "Klauen (Stä+W10)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "-"
+            }
+        },
+        "Klauen (Stä+W10, PB 2)": {
+            "name": "Klauen (Stä+W10, PB 2)",
+            "kategorie": "Waffe",
+            "unterkategorie": "Natürliche Waffe",
+            "gewicht": 0,
+            "kosten": 0,
+            "setting": "",
+            "beschreibung": "Klauen, deren Würfeltyp durch Talente gesteigert wurde (z. B. Raufbold, Schläger).",
+            "aktiv": true,
+            "typ": "Nahkampf",
+            "mindeststaerke": "-",
+            "eigenschaften": {
+                "Schaden": "Stä+W10",
+                "Reichweite": "nah",
+                "FR": "-",
+                "Schuss": "-",
+                "PB": "2"
+            }
+        },
         "Axt, Handbeil": {
             "name": "Axt, Handbeil",
             "kategorie": "Waffe",

--- a/test units/test_natuerliche_waffen.py
+++ b/test units/test_natuerliche_waffen.py
@@ -120,6 +120,36 @@ class TestAbleitungAusTalenten(unittest.TestCase):
         charakter = FakeCharakter(volk, talente=['Wilde Klauen'])
         self.assertEqual(abgeleitete_waffen(charakter), ["Klauen (Stä+W6, PB 2)"])
 
+    def test_raufbold_steigert_waffen_der_abstammung(self):
+        """Wer schon natürliche Waffen hat, steigert sie statt der Fäuste"""
+        volk = FakeVolk(
+            effects={'spezielle_effekte': {'klauen': True, 'biss': True}},
+            besonderheiten=["Klauen (Stä+W4 Schaden, PB 2)", "Biss (Stä+W4 Schaden)"],
+        )
+        charakter = FakeCharakter(volk, talente=['Raufbold'])
+        self.assertEqual(abgeleitete_waffen(charakter),
+                         ["Klauen (Stä+W6, PB 2)", "Biss (Stä+W6)"])
+
+        charakter.selected_talente.append('Schläger')
+        self.assertEqual(abgeleitete_waffen(charakter),
+                         ["Klauen (Stä+W8, PB 2)", "Biss (Stä+W8)"])
+
+    def test_raufbold_ohne_natuerliche_waffen_gibt_faeuste(self):
+        """Ohne vorhandene Waffe bleibt es beim Grundwürfel für die Fäuste"""
+        self.assertEqual(abgeleitete_waffen(FakeCharakter(talente=['Raufbold'])),
+                         ["Waffenloser Schlag (Stä+W4)"])
+        self.assertEqual(abgeleitete_waffen(FakeCharakter(talente=['Raufbold', 'Schläger'])),
+                         ["Waffenloser Schlag (Stä+W6)"])
+        self.assertEqual(abgeleitete_waffen(FakeCharakter(talente=['Schläger'])), [])
+
+    def test_raufbold_steigert_auch_die_faeuste_des_kampfkuenstlers(self):
+        """Kampfkünstler verleiht die Fäuste, danach steigert Raufbold beides"""
+        volk = FakeVolk(effects={'spezielle_effekte': {'biss': True}},
+                        besonderheiten=["Biss (Stä+W4 Schaden)"])
+        charakter = FakeCharakter(volk, talente=['Kampfkünstler', 'Raufbold'])
+        self.assertEqual(abgeleitete_waffen(charakter),
+                         ["Biss (Stä+W6)", "Waffenloser Schlag (Stä+W6)"])
+
 
 class TestSynchronisation(unittest.TestCase):
 


### PR DESCRIPTION
Raufbold macht die Fäuste nur dann zur natürlichen Waffe (Stä+W4), wenn
der Charakter noch keine hat — sonst steigert das Talent laut Regeltext
("oder erhöhe Würfeltyp bei Kombination mit Kampfkünstler, Klauen oder
ähnlichen Fähigkeiten") den Würfeltyp der vorhandenen natürlichen Waffen;
Schläger steigert danach noch einmal.

Dafür kennt natuerliche_waffen_config.json die neue Regel-Eigenschaft
"steigert_alle". Die Ausrüstungskataloge aller Settings bekommen die
Einträge, die durch das Steigern jetzt erreichbar sind (Klauen, Biss,
Biss/Klauen und Hörner bis Stä+W10) — ohne sie hätte die Synchronisation
die gesteigerte Waffe verworfen.

Übernimmt savage-worlds-web#33 für die Kivy-Variante.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017qxF67DrM7Zcr69bu5Pr8N