### PR TITLE
Lösch-Dialoge: Auswahl über SearchBottomSheet statt MDDialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Die häufigsten Fallen auf Android — **vollständige Begründung und Code-Beis
 - **`MDDialog` IMMER mit `size_hint=(0.85, None)`** — nicht `(1, 1)`, sonst Vollbild-Popup auf Android.
 - **`MDDialogContentContainer` benötigt feste Höhe** (`size_hint_y=None`, berechnete `height`).
 - **`TextFieldScrollView` statt `MDScrollView`** wenn `MDTextField` enthalten ist.
-- **`SearchBottomSheet` statt `MDDialog`** für Such-/Filterlisten.
+- **`SearchBottomSheet` statt `MDDialog`** für Such-/Filterlisten — auch für Mehrfachauswahl (`multi_select=True`, z.B. Phase 1 der Lösch-Dialoge). In einem `MDDialog` scrollen solche Listen auf Android nicht.
 
 ## Technology Stack
 

--- a/docs/ANDROID_WORKAROUNDS.md
+++ b/docs/ANDROID_WORKAROUNDS.md
@@ -283,23 +283,33 @@ else:
 **Problem:** Die "Löschen"-Dialoge in Einstellungen (Volk, Talent, Macht, etc.) haben Checkboxen im ElementOverlay, die auf Android Touch-Bounce-Probleme haben. Das funktioniert schlechter als die Setting-Auswahl in "Neuer Charakter".
 
 **Two-Phase Pattern (IMPLEMENTIERT — STANDARD für Delete-Dialoge):**
-1. **Phase 1:** ElementOverlay öffnen mit Checkboxen (mit Debounce)
-2. **Phase 2:** Wenn der Benutzer auf "Löschen" klickt, ein SEPARATES Bestätigungs-Popup öffnen
+1. **Phase 1:** `SearchBottomSheet(multi_select=True)` öffnen — Suchfeld + Checkboxen mit Per-Item-Debounce
+2. **Phase 2:** Nach dem Bestätigen ein SEPARATES Bestätigungs-Popup (`MDDialog`) öffnen
    - Keine Checkboxen im Bestätigungs-Popup
    - Das Bestätigungs-Popup zeigt die ausgewählten Elemente als Text-Liste
    - Einheitlicher Methodenname: `_show_delete_confirmation_popup(selected_items)`
+   - Erst per `Clock.schedule_once(..., 0.1)` öffnen — das Sheet schließt gerade mit Animation
 
-**Setting-Auswahl Pattern als Referenz:**
-Die Setting-Auswahl bei "Neuer Charakter" in `charakter_verwaltung_widget.py` ist das Vorbild:
-- MDListItem mit on_release auf dem Item (nicht auf der Checkbox)
-- Checkbox nur zur visuellen Anzeige, nicht für Event-Handling
-- Beim Klick auf das Item wird die Selection-Logik ausgeführt
+**Phase 1 gehört NICHT in einen MDDialog (Fix 2026-08):** Die Auswahlliste lag früher als
+`MDScrollView` in einem `MDDialog`. Auf Android war die Liste dadurch **nicht scrollbar**
+(der Dialog fängt die Touch-Events ab, dasselbe Problem, das zur Entstehung von
+`SearchBottomSheet` geführt hat), und der breite Scrollbalken lag über den Checkboxen.
+Phase 1 läuft deshalb über `SearchBottomSheet` (ModalView) — dort sind Scrollverhalten,
+Balken-Padding (`padding=[0, 0, dp(32), 0]`) und Debounce bereits gelöst.
 
 **Vorlage:**
 ```python
-def _show_delete_options_popup(self):
-    """Phase 1: Optionen-Popup mit Checkboxen (ElementOverlay mit Debounce)"""
-    pass
+def show_delete_dialog(self):
+    """Phase 1: Auswahl-Sheet mit Suche + Checkboxen"""
+    from views.ui_components import SearchBottomSheet
+    self._delete_popup = SearchBottomSheet(
+        title=f"{self.element_name} löschen",
+        items=sorted(elemente),
+        multi_select=True,
+        on_confirm=self._on_delete_action_clicked,   # bekommt die Namensliste
+        search_hint=f"{self.element_name} suchen...",
+    )
+    self._delete_popup.open()
 
 def _show_delete_confirmation_popup(self, selected_items):
     """Phase 2: Bestätigungs-Popup OHNE Checkboxen"""
@@ -307,6 +317,11 @@ def _show_delete_confirmation_popup(self, selected_items):
     # Ausgewählte Items als Text anzeigen
     pass
 ```
+
+**Scroll-Geometrie im Bestätigungs-Popup:** Die Deckelung (`min(48dp * n, 200dp)`) gehört an
+den `MDScrollView` (`size_hint=(1, None), height=...`), **nicht** an die `MDList` — deren Höhe
+muss über `minimum_height` mitwachsen. Früher war es umgekehrt: ab ~5 gewählten Einträgen
+waren die restlichen weder sichtbar noch erreichbar.
 
 **Wo dieses Two-Phase Pattern bereits implementiert ist (9 Popups):**
 - `views/talent_popup.py` — Talent löschen
@@ -355,6 +370,16 @@ scroll = MDScrollView(size_hint=(1, None), height=max_scroll_height)
 - Slide-up/down animation
 - Integrated search field with filtered list
 - Used for race/species selection and other searchable lists
+
+**Zwei Modi:**
+
+| Modus | Verhalten | `on_confirm` bekommt |
+|---|---|---|
+| Einfachauswahl (Default) | Tippen auf einen Eintrag wählt aus und schließt sofort | den Namen (oder `None`) |
+| `multi_select=True` | Jeder Eintrag hat eine Checkbox (Per-Item-Debounce, Solution 4); der Titel zeigt die Anzahl; geschlossen wird erst über ✓ (bestätigen) bzw. ✕ (abbrechen) | die sortierte Liste der Namen |
+
+Die Mehrfachauswahl ist der Phase-1-Schritt der Lösch-Dialoge (siehe *Delete Dialogs mit
+Checkboxen*). `selected=` nimmt dort eine Liste bereits vorausgewählter Namen entgegen.
 
 ## Android 16 / targetSdk 36 (`buildozer.spec` + `build_fixes.py`)
 

--- a/test units/test_popup_basis.py
+++ b/test units/test_popup_basis.py
@@ -74,41 +74,57 @@ class TestDismissDialog(unittest.TestCase):
 
 
 class TestDeleteFlowPhase1(unittest.TestCase):
-    def _handler_mit_checkboxen(self, aktiv):
+    """Phase 1 bekommt die Auswahl als Namensliste vom SearchBottomSheet."""
+
+    def _handler(self):
         handler = _TestHandler(Mock())
-        handler._delete_checkboxes = {}
-        for name, ist_aktiv in aktiv.items():
-            cb = Mock()
-            cb.active = ist_aktiv
-            handler._delete_checkboxes[name] = cb
         handler._delete_popup = Mock()
         handler.show_error = Mock()
         handler._show_delete_confirmation_popup = Mock()
         return handler
 
     def test_keine_auswahl_zeigt_fehler(self):
-        handler = self._handler_mit_checkboxen({"Schwert": False, "Dolch": False})
+        handler = self._handler()
 
-        handler._on_delete_action_clicked()
+        handler._on_delete_action_clicked([])
 
         handler.show_error.assert_called_once()
         meldung = handler.show_error.call_args[0][0]
         self.assertIn("mindestens eine Waffe", meldung)
-        handler._delete_popup.dismiss.assert_not_called()
         handler._show_delete_confirmation_popup.assert_not_called()
 
     def test_auswahl_oeffnet_bestaetigung(self):
-        handler = self._handler_mit_checkboxen({"Schwert": True, "Dolch": False})
+        handler = self._handler()
 
-        handler._on_delete_action_clicked()
+        with patch('views.popup_basis.Clock') as mock_clock:
+            handler._on_delete_action_clicked(["Schwert"])
 
-        handler.show_error.assert_not_called()
-        handler._delete_popup.dismiss.assert_called_once()
-        self.assertEqual(handler._pending_delete_items, ["Schwert"])
+            handler.show_error.assert_not_called()
+            self.assertEqual(handler._pending_delete_items, ["Schwert"])
+            # Phase 2 erst im nächsten Frame (Sheet schließt gerade)
+            handler._show_delete_confirmation_popup.assert_not_called()
+            mock_clock.schedule_once.assert_called_once()
+            mock_clock.schedule_once.call_args[0][0](0)
+
         kwargs = handler._show_delete_confirmation_popup.call_args[1]
         self.assertEqual(kwargs['selected_items'], ["Schwert"])
         self.assertEqual(kwargs['item_type'], "Waffe")
         self.assertEqual(kwargs['on_confirm'], handler._confirm_delete_elemente)
+
+    def test_show_delete_dialog_oeffnet_bottomsheet(self):
+        """Phase 1 nutzt SearchBottomSheet (ModalView), nicht MDDialog."""
+        handler = _TestHandler(Mock())
+        sheet = Mock()
+        sheet_cls = Mock(return_value=sheet)
+
+        with patch.dict(sys.modules, {'views.ui_components': MagicMock(SearchBottomSheet=sheet_cls)}):
+            handler.show_delete_dialog()
+
+        sheet.open.assert_called_once()
+        kwargs = sheet_cls.call_args[1]
+        self.assertTrue(kwargs['multi_select'])
+        self.assertEqual(kwargs['items'], ["Dolch", "Schwert"])
+        self.assertEqual(kwargs['on_confirm'], handler._on_delete_action_clicked)
 
     def test_show_delete_dialog_ohne_elemente_zeigt_fehler(self):
         handler = _TestHandler(Mock())

--- a/views/popup_basis.py
+++ b/views/popup_basis.py
@@ -6,12 +6,13 @@ Ausrüstung, Talent, Handicap, Macht, Fertigkeit).
 Bündelt das in allen Handlern identische Gerüst:
 - Overlay-Beschaffung und Dialog-Schließen
 - Fehler-/Erfolgsmeldungen über den Dialog-Service
-- Two-Phase-Lösch-Flow: Auswahl-Popup mit Checkboxen + Suchfeld (Phase 1)
-  → separates Bestätigungs-Popup ohne Checkboxen (Phase 2)
+- Two-Phase-Lösch-Flow: Auswahl über das `SearchBottomSheet` mit Suchfeld
+  und Checkboxen (Phase 1) → separates Bestätigungs-Popup ohne Checkboxen
+  (Phase 2)
 
-Die Android-Workarounds (on_release + 500ms-Debounce für Checkboxen,
-separates Bestätigungs-Popup, Clock-verzögertes dismiss) sind unverändert
-aus den Einzeldateien übernommen — siehe docs/ANDROID_WORKAROUNDS.md.
+Die Android-Workarounds (SearchBottomSheet statt MDDialog für die Suchliste,
+on_release + 500ms-Debounce für Checkboxen, separates Bestätigungs-Popup,
+Clock-verzögertes dismiss) — siehe docs/ANDROID_WORKAROUNDS.md.
 Historisch existieren zwei Dismiss-Timing-Varianten für das Bestätigungs-
 Popup; die Basis liefert die gestaffelte Variante (Waffe/Rüstung/Schild/
 Ausrüstung), `SofortDismissMixin` die sofortige Variante (Talent/Handicap/
@@ -21,12 +22,14 @@ Element-spezifisch bleiben in den Subklassen: Hinzufügen/Bearbeiten/Speichern,
 das tatsächliche Löschen (`_confirm_delete_elemente`) und der View-Refresh.
 """
 
-import time
-
 from kivy.clock import Clock
 from kivy.logger import Logger
 from kivy.metrics import dp
 from kivymd.uix.boxlayout import MDBoxLayout
+
+from utils.platform_utils import is_mobile_layout
+
+_mobile = is_mobile_layout()
 
 
 class BasisDialogHandler:
@@ -112,110 +115,33 @@ class BasisDialogHandler:
     # Two-Phase-Lösch-Flow
     # ------------------------------------------------------------------
     def show_delete_dialog(self):
-        """Zeigt das Two-Phase Popup zum Löschen von Elementen (Phase 1)."""
-        from kivymd.uix.dialog import MDDialog, MDDialogHeadlineText, MDDialogContentContainer, MDDialogButtonContainer
-        from kivymd.uix.button import MDButton, MDButtonText
-        from kivymd.uix.list import MDList, MDListItem, MDListItemSupportingText, MDListItemTrailingCheckbox
-        from kivymd.uix.scrollview import MDScrollView
-        from kivymd.uix.textfield import MDTextField, MDTextFieldHintText
+        """Zeigt das Two-Phase Popup zum Löschen von Elementen (Phase 1).
 
+        Die Auswahl läuft über `SearchBottomSheet` (ModalView), NICHT über
+        einen `MDDialog`: Such-/Filterlisten in einem MDDialog scrollen auf
+        Android nicht (der Dialog stiehlt die Touch-Events), und der
+        Scrollbalken lag über den Checkboxen. Siehe
+        docs/ANDROID_WORKAROUNDS.md → SearchBottomSheet.
+        """
         elemente = self._get_loeschbare_elemente()
         if not elemente:
             self.show_error(f"Keine {self.element_name_plural} zum Löschen verfügbar.")
             return
 
-        self._delete_checkboxes = {}
-        self._delete_last_cb_times = {}
+        from views.ui_components import SearchBottomSheet
 
-        content = MDList(size_hint_y=None)
-        content.bind(minimum_height=content.setter('height'))
-
-        def create_checkbox(item_name):
-            item = MDListItem(size_hint_y=None, height=dp(48))
-            item.add_widget(MDListItemSupportingText(text=item_name))
-
-            checkbox = MDListItemTrailingCheckbox()
-            cb = checkbox
-
-            def on_release_checkbox(inst, cb=cb, name=item_name):
-                now = time.monotonic()
-                key = f"cb_{name}"
-                if key in self._delete_last_cb_times and (now - self._delete_last_cb_times[key]) < 0.5:
-                    return
-                self._delete_last_cb_times[key] = now
-
-            checkbox.bind(on_release=on_release_checkbox)
-            item.add_widget(checkbox)
-            content.add_widget(item)
-            self._delete_checkboxes[item_name] = checkbox
-
-        for element_name in sorted(elemente):
-            create_checkbox(element_name)
-
-        scroll_height = min(len(elemente) * dp(48), dp(250))
-        scroll = MDScrollView(
-            size_hint=(1, None),
-            height=scroll_height,
-            do_scroll_x=False,
-            do_scroll_y=True,
-        )
-        scroll.add_widget(content)
-
-        main_content = MDBoxLayout(
-            orientation="vertical",
-            spacing=dp(8),
-            size_hint_y=None,
-            padding=dp(16),
-            height=scroll_height + dp(80),
-        )
-
-        search_field = MDTextField(
-            mode="outlined",
-            size_hint_y=None,
-            height=dp(56),
-            hint_text="Suchen...",
-        )
-        search_field.add_widget(MDTextFieldHintText(text="Suchen..."))
-        main_content.add_widget(search_field)
-        main_content.add_widget(scroll)
-
-        def populate_list(search_text):
-            content.clear_widgets()
-            for element_name in sorted(elemente):
-                if search_text and search_text.lower() not in element_name.lower():
-                    continue
-                # Bestehende Checkbox wiederverwenden statt neue zu erstellen
-                if element_name in self._delete_checkboxes:
-                    item = MDListItem(size_hint_y=None, height=dp(48))
-                    item.add_widget(MDListItemSupportingText(text=element_name))
-                    cb_existing = self._delete_checkboxes[element_name]
-                    if cb_existing.parent:
-                        cb_existing.parent.remove_widget(cb_existing)
-                    item.add_widget(cb_existing)
-                    content.add_widget(item)
-                else:
-                    create_checkbox(element_name)
-
-        search_field.bind(text=lambda instance, value: populate_list(value))
-        populate_list("")
-
-        self._delete_popup = MDDialog(
-            MDDialogHeadlineText(text=f"{self.element_name} löschen"),
-            MDDialogContentContainer(main_content),
-            MDDialogButtonContainer(
-                MDButton(MDButtonText(text="Abbrechen"), style="text",
-                         on_release=lambda x: self._delete_popup.dismiss()),
-                MDButton(MDButtonText(text="Weiter"), style="filled",
-                         on_release=self._on_delete_action_clicked),
-            ),
-            size_hint=(0.85, None),
-            auto_dismiss=False,
+        self._delete_popup = SearchBottomSheet(
+            title=f"{self.element_name} löschen",
+            items=sorted(elemente),
+            multi_select=True,
+            on_confirm=self._on_delete_action_clicked,
+            search_hint=f"{self.element_name} suchen...",
         )
         self._delete_popup.open()
 
-    def _on_delete_action_clicked(self, *args):
-        """Phase 1: Sammelt ausgewählte Items und zeigt Bestätigungs-Popup."""
-        selected = [name for name, cb in self._delete_checkboxes.items() if cb.active]
+    def _on_delete_action_clicked(self, selected=None, *args):
+        """Phase 1: Übernimmt die Auswahl und zeigt das Bestätigungs-Popup."""
+        selected = list(selected) if selected else []
 
         if not selected:
             self.show_error(
@@ -224,11 +150,16 @@ class BasisDialogHandler:
             return
 
         self._pending_delete_items = selected
-        self._delete_popup.dismiss()
-        self._show_delete_confirmation_popup(
-            selected_items=selected,
-            item_type=self.element_name,
-            on_confirm=self._confirm_delete_elemente,
+        # Erst im nächsten Frame öffnen: das Auswahl-Sheet schließt sich
+        # gerade, ein sofort geöffneter Dialog kann auf Android in dessen
+        # Dismiss-Animation hängenbleiben.
+        Clock.schedule_once(
+            lambda dt: self._show_delete_confirmation_popup(
+                selected_items=selected,
+                item_type=self.element_name,
+                on_confirm=self._confirm_delete_elemente,
+            ),
+            0.1,
         )
 
     def _confirm_popup_callbacks(self, dismiss_fn, on_confirm):
@@ -258,25 +189,32 @@ class BasisDialogHandler:
         from kivymd.uix.button import MDButton, MDButtonText
 
         content = MDList(size_hint_y=None)
+        # Die feste Höhe gehört an den ScrollView, NICHT an sein Kind — sonst
+        # sind Einträge jenseits der Deckelung nicht erreichbar.
         content.bind(minimum_height=content.setter('height'))
+        if _mobile:
+            # Platz für den breiten Scrollbalken, sonst liegt er über dem Text
+            content.padding = [0, 0, dp(32), 0]
 
         for item_name in selected_items:
             list_item = MDListItem(size_hint_y=None, height=dp(48))
             list_item.add_widget(MDListItemSupportingText(text=item_name))
             content.add_widget(list_item)
 
-        scroll = MDScrollView(do_scroll_x=False, do_scroll_y=True)
-        scroll.add_widget(content)
-
         list_height = min(dp(48) * len(selected_items), dp(200))
-        content.size_hint_y = None
-        content.height = list_height
+        scroll = MDScrollView(
+            size_hint=(1, None),
+            height=list_height,
+            do_scroll_x=False,
+            do_scroll_y=True,
+        )
+        scroll.add_widget(content)
 
         main_content = MDBoxLayout(
             orientation="vertical",
             spacing=dp(8),
             size_hint_y=None,
-            height=dp(80) + list_height,
+            height=list_height + dp(32),
             padding=dp(16)
         )
         main_content.add_widget(scroll)

--- a/views/ui_components.py
+++ b/views/ui_components.py
@@ -3,6 +3,8 @@
 UI-Komponenten und Tab-Klassen extrahiert aus main.py
 """
 
+import time
+
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
 from kivy.uix.screenmanager import ScreenManager, SlideTransition
@@ -198,7 +200,13 @@ from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.label import MDLabel
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.textfield import MDTextField, MDTextFieldHintText
-from kivymd.uix.list import MDList, MDListItem, MDListItemHeadlineText, MDListItemLeadingIcon
+from kivymd.uix.list import (
+    MDList,
+    MDListItem,
+    MDListItemHeadlineText,
+    MDListItemLeadingIcon,
+    MDListItemTrailingCheckbox,
+)
 from kivymd.uix.scrollview import MDScrollView
 from kivy.uix.modalview import ModalView
 from kivy.uix.widget import Widget
@@ -243,11 +251,24 @@ class SearchBottomSheet(ModalView):
             search_hint="Volk suchen...",
         )
         sheet.open()
+
+    Mehrfachauswahl (`multi_select=True`): jeder Eintrag bekommt eine
+    Checkbox (mit Per-Item-Debounce, siehe docs/ANDROID_WORKAROUNDS.md
+    Solution 4), das Sheet schliesst erst beim Bestaetigen und
+    `on_confirm` erhaelt die Liste der gewaehlten Namen:
+
+        sheet = SearchBottomSheet(
+            title="Fertigkeit löschen",
+            items=["Fahren", "Fokus"],
+            multi_select=True,
+            on_confirm=lambda namen: print(namen),
+        )
     """
 
     def __init__(self, title="Auswählen", items=None, selected=None,
                  on_confirm=None, on_cancel=None, search_hint="Suchen...",
-                 allow_none=False, none_label="Keine Auswahl", **kwargs):
+                 allow_none=False, none_label="Keine Auswahl",
+                 multi_select=False, **kwargs):
         # ModalView-Einstellungen: transparenter Hintergrund, kein auto_dismiss-Bereich-Problem
         kwargs.setdefault('size_hint', (1, 1))
         kwargs.setdefault('background_color', (0, 0, 0, 0))
@@ -261,6 +282,13 @@ class SearchBottomSheet(ModalView):
         self._on_cancel = on_cancel
         self._allow_none = allow_none
         self._none_label = none_label
+        self._multi_select = multi_select
+        self._title = title
+        # Mehrfachauswahl: gewaehlte Namen + Per-Item-Debounce (Android)
+        self._selected_items = set()
+        if multi_select and selected:
+            self._selected_items = set(selected)
+        self._last_checkbox_times = {}
 
         # Scrim (halbtransparenter Hintergrund) - Klick schließt das Sheet
         scrim = Widget(size_hint=(1, 1))
@@ -316,14 +344,15 @@ class SearchBottomSheet(ModalView):
             on_release=lambda x: self._cancel(),
             pos_hint={'center_y': 0.5},
         ))
-        header.add_widget(MDLabel(
+        self._title_label = MDLabel(
             text=title,
             font_style="Title",
             role="medium",
             bold=True,
             size_hint_x=1,
             pos_hint={'center_y': 0.5},
-        ))
+        )
+        header.add_widget(self._title_label)
         confirm_btn = MDIconButton(
             icon="check",
             on_release=lambda x: self._confirm(),
@@ -400,6 +429,10 @@ class SearchBottomSheet(ModalView):
         self._items_list.clear_widgets()
         search_text = self._search_field.text.lower() if self._search_field.text else ""
 
+        if self._multi_select:
+            self._populate_multi_select(search_text)
+            return
+
         from kivymd.app import MDApp
         app = MDApp.get_running_app()
         theme = app.theme_cls if app else None
@@ -449,6 +482,46 @@ class SearchBottomSheet(ModalView):
             item.add_widget(headline)
             self._items_list.add_widget(item)
 
+    def _populate_multi_select(self, search_text):
+        """Befüllt die Liste mit Checkboxen (Mehrfachauswahl)."""
+        for name in self._items:
+            if search_text and search_text not in name.lower():
+                continue
+
+            item = MDListItem(size_hint_y=None, height=dp(48))
+            item.add_widget(MDListItemHeadlineText(text=name))
+
+            checkbox = MDListItemTrailingCheckbox(active=name in self._selected_items)
+            cb = checkbox  # Intermediate Variable gegen den Closure-Bug
+            checkbox.bind(
+                on_release=lambda x, cb=cb, n=name: self._on_checkbox_toggled(n, cb)
+            )
+            item.add_widget(checkbox)
+            self._items_list.add_widget(item)
+
+        self._update_title()
+
+    def _on_checkbox_toggled(self, name, checkbox):
+        """Übernimmt eine Checkbox-Änderung — mit Per-Item-Debounce (Android)."""
+        now = time.monotonic()
+        key = f"cb_{name}"
+        if key in self._last_checkbox_times and (now - self._last_checkbox_times[key]) < 0.5:
+            return  # Touch-Bounce für DIESEN Eintrag ignorieren
+        self._last_checkbox_times[key] = now
+
+        if checkbox.active:
+            self._selected_items.add(name)
+        else:
+            self._selected_items.discard(name)
+        self._update_title()
+
+    def _update_title(self):
+        """Zeigt die Anzahl der gewählten Einträge im Titel (Mehrfachauswahl)."""
+        if not self._multi_select or not self._title_label:
+            return
+        anzahl = len(self._selected_items)
+        self._title_label.text = f"{self._title} ({anzahl})" if anzahl else self._title
+
     def _filter_list(self, *args):
         """Filtert die Liste bei Texteingabe."""
         self._populate_list()
@@ -467,7 +540,10 @@ class SearchBottomSheet(ModalView):
     def _finish_confirm(self):
         self.dismiss()
         if self._on_confirm:
-            self._on_confirm(self._selected)
+            if self._multi_select:
+                self._on_confirm(sorted(self._selected_items))
+            else:
+                self._on_confirm(self._selected)
 
     def _cancel(self):
         """Bricht ab und schließt das Sheet."""

--- a/views/volk_dialog_handler.py
+++ b/views/volk_dialog_handler.py
@@ -7,8 +7,6 @@ volk_popup importiert (vermeidet Import-Zyklus, lädt dabei dessen KV-Datei).
 volk_popup re-exportiert VolkDialogHandler für bestehende Importe.
 """
 
-import time
-
 from kivy.app import App
 from kivy.clock import Clock
 from kivy.logger import Logger
@@ -16,9 +14,8 @@ from kivy.metrics import dp
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDButton, MDButtonText
 from kivymd.uix.dialog import MDDialog, MDDialogHeadlineText, MDDialogContentContainer, MDDialogButtonContainer
-from kivymd.uix.list import MDList, MDListItem, MDListItemSupportingText, MDListItemTrailingCheckbox
+from kivymd.uix.list import MDList, MDListItem, MDListItemSupportingText
 from kivymd.uix.scrollview import MDScrollView
-from kivymd.uix.textfield import MDTextField, MDTextFieldHintText
 
 from models.volk import Volk
 from utils.platform_utils import is_mobile_layout
@@ -105,119 +102,48 @@ class VolkDialogHandler:
             Logger.error(f"Fehler beim Erzwingen des Eigenschaften-Refresh: {e}")
 
     def show_delete_dialog(self):
-        """Zeigt das Two-Phase Popup zum Löschen von Völkern."""
-        import time
-        from kivymd.uix.list import MDListItemTrailingCheckbox
+        """Zeigt das Two-Phase Popup zum Löschen von Völkern (Phase 1).
 
+        Die Auswahl läuft über `SearchBottomSheet` (ModalView), NICHT über
+        einen `MDDialog`: Such-/Filterlisten in einem MDDialog scrollen auf
+        Android nicht (der Dialog stiehlt die Touch-Events), und der
+        Scrollbalken lag über den Checkboxen. Siehe
+        docs/ANDROID_WORKAROUNDS.md → SearchBottomSheet.
+        """
         voelker = self.get_all_voelker()
         if not voelker:
             self.show_error("Keine Abstammungen zum Löschen verfügbar.")
             return
 
-        self._volk_checkboxes = {}
-        self._volk_last_cb_times = {}
+        from views.ui_components import SearchBottomSheet
 
-        content = MDList(size_hint_y=None)
-        content.bind(minimum_height=content.setter('height'))
-
-        def create_checkbox(item_name):
-            item = MDListItem(size_hint_y=None, height=dp(48))
-            item.add_widget(MDListItemSupportingText(text=item_name))
-
-            checkbox = MDListItemTrailingCheckbox()
-            cb = checkbox
-
-            def on_release_checkbox(inst, cb=cb, name=item_name):
-                now = time.monotonic()
-                key = f"cb_{name}"
-                if key in self._volk_last_cb_times and (now - self._volk_last_cb_times[key]) < 0.5:
-                    return
-                self._volk_last_cb_times[key] = now
-
-            checkbox.bind(on_release=on_release_checkbox)
-            item.add_widget(checkbox)
-            content.add_widget(item)
-            self._volk_checkboxes[item_name] = checkbox
-
-        for volk_name in sorted(voelker):
-            create_checkbox(volk_name)
-
-        scroll_height = min(len(voelker) * dp(48), dp(250))
-        scroll = MDScrollView(
-            size_hint=(1, None),
-            height=scroll_height,
-            do_scroll_x=False,
-            do_scroll_y=True,
-            bar_width=dp(20) if _mobile else dp(15),
-            bar_margin=dp(8) if _mobile else dp(4),
-        )
-        if _mobile:
-            scroll.scroll_type = ['bars', 'content']
-        scroll.add_widget(content)
-
-        main_content = MDBoxLayout(
-            orientation="vertical",
-            spacing=dp(8),
-            size_hint_y=None,
-            padding=dp(16),
-            height=scroll_height + dp(80),
-        )
-
-        search_field = MDTextField(
-            mode="outlined",
-            size_hint_y=None,
-            height=dp(56),
-            hint_text="Suchen...",
-        )
-        search_field.add_widget(MDTextFieldHintText(text="Suchen..."))
-        main_content.add_widget(search_field)
-        main_content.add_widget(scroll)
-
-        def populate_list(search_text):
-            content.clear_widgets()
-            for volk_name in sorted(voelker):
-                if search_text and search_text.lower() not in volk_name.lower():
-                    continue
-                if volk_name in self._volk_checkboxes:
-                    item = MDListItem(size_hint_y=None, height=dp(48))
-                    item.add_widget(MDListItemSupportingText(text=volk_name))
-                    cb_existing = self._volk_checkboxes[volk_name]
-                    if cb_existing.parent:
-                        cb_existing.parent.remove_widget(cb_existing)
-                    item.add_widget(cb_existing)
-                    content.add_widget(item)
-                else:
-                    create_checkbox(volk_name)
-
-        search_field.bind(text=lambda instance, value: populate_list(value))
-        populate_list("")
-
-        self._delete_popup = MDDialog(
-            MDDialogHeadlineText(text="Abstammung löschen"),
-            MDDialogContentContainer(main_content),
-            MDDialogButtonContainer(
-                MDButton(MDButtonText(text="Abbrechen"), style="text",
-                         on_release=lambda x: self._delete_popup.dismiss()),
-                MDButton(MDButtonText(text="Weiter"), style="filled",
-                         on_release=self._on_delete_action_clicked),
-            ),
-            size_hint=(0.85, None),
-            auto_dismiss=False,
+        self._delete_popup = SearchBottomSheet(
+            title="Abstammung löschen",
+            items=sorted(voelker),
+            multi_select=True,
+            on_confirm=self._on_delete_action_clicked,
+            search_hint="Abstammung suchen...",
         )
         self._delete_popup.open()
 
-    def _on_delete_action_clicked(self, *args):
-        """Phase 1: Sammelt ausgewählte Items und zeigt Bestätigungs-Popup."""
-        selected = [name for name, cb in self._volk_checkboxes.items() if cb.active]
+    def _on_delete_action_clicked(self, selected=None, *args):
+        """Phase 1: Übernimmt die Auswahl und zeigt das Bestätigungs-Popup."""
+        selected = list(selected) if selected else []
 
         if not selected:
             self.show_error("Bitte wähle mindestens eine Abstammung zum Löschen aus.")
             return
 
         self._pending_delete_items = selected
-        self._delete_popup.dismiss()
-        self._show_delete_confirmation_popup(
-            selected_items=selected, item_type="Abstammung", on_confirm=self._confirm_delete_volk
+        # Erst im nächsten Frame öffnen: das Auswahl-Sheet schließt sich
+        # gerade, ein sofort geöffneter Dialog kann auf Android in dessen
+        # Dismiss-Animation hängenbleiben.
+        Clock.schedule_once(
+            lambda dt: self._show_delete_confirmation_popup(
+                selected_items=selected, item_type="Abstammung",
+                on_confirm=self._confirm_delete_volk,
+            ),
+            0.1,
         )
 
     def save_volk(self, *args):
@@ -372,25 +298,32 @@ class VolkDialogHandler:
         from kivy.metrics import dp
 
         content = MDList(size_hint_y=None)
+        # Die feste Höhe gehört an den ScrollView, NICHT an sein Kind — sonst
+        # sind Einträge jenseits der Deckelung nicht erreichbar.
         content.bind(minimum_height=content.setter('height'))
+        if _mobile:
+            # Platz für den breiten Scrollbalken, sonst liegt er über dem Text
+            content.padding = [0, 0, dp(32), 0]
 
         for item_name in selected_items:
             list_item = MDListItem(size_hint_y=None, height=dp(48))
             list_item.add_widget(MDListItemSupportingText(text=item_name))
             content.add_widget(list_item)
 
-        scroll = MDScrollView(do_scroll_x=False, do_scroll_y=True)
-        scroll.add_widget(content)
-
         list_height = min(dp(48) * len(selected_items), dp(200))
-        content.size_hint_y = None
-        content.height = list_height
+        scroll = MDScrollView(
+            size_hint=(1, None),
+            height=list_height,
+            do_scroll_x=False,
+            do_scroll_y=True,
+        )
+        scroll.add_widget(content)
 
         main_content = MDBoxLayout(
             orientation="vertical",
             spacing=dp(8),
             size_hint_y=None,
-            height=dp(80) + list_height,
+            height=list_height + dp(32),
             padding=dp(16)
         )
         main_content.add_widget(scroll)


### PR DESCRIPTION
Auf Android war die Auswahlliste im Lösch-Dialog nicht scrollbar und der
Scrollbalken lag über den Checkboxen.

- Phase 1 (Auswahl) läuft jetzt über SearchBottomSheet (ModalView) statt
  über einen MDDialog mit eingebettetem MDScrollView. MDDialog fängt auf
  Android die Touch-Events der Liste ab — genau der Grund, aus dem
  SearchBottomSheet existiert. Das Sheet bringt Suchfeld, korrektes
  Scrollverhalten und rechtes Listen-Padding für den breiten Balken mit.
- SearchBottomSheet bekommt dafür einen Mehrfachauswahl-Modus
  (multi_select=True): Checkboxen mit Per-Item-Debounce, Anzahl im Titel,
  on_confirm erhält die Namensliste.
- Phase 2 (Bestätigung) behält den MDDialog, aber die Höhen-Deckelung sitzt
  jetzt am ScrollView statt an der MDList — vorher waren ab ~5 gewählten
  Einträgen die restlichen weder sichtbar noch erreichbar. Zusätzlich
  rechtes Padding für den Scrollbalken.
- Der Bestätigungs-Dialog öffnet erst im nächsten Frame, damit er nicht in
  die Dismiss-Animation des Sheets läuft.
- Gleiche Umstellung für den dupliziert implementierten Volk-Lösch-Dialog.
- Doku (ANDROID_WORKAROUNDS.md, CLAUDE.md) und Tests nachgezogen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Frs75uEaeXgNFjJeKtfCQs